### PR TITLE
Implement Vamana search algorithm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 memmap2 = { version = "0.9.5", features = ["stable_deref_trait"] }
+simsimd = "6.0.1"
 stable_deref_trait = "1.2.0"
 wt_mdb = { path = "./wt_mdb" }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -25,13 +25,13 @@ pub trait Graph {
     fn entry_point(&self) -> Option<i64>;
 
     /// Get the contents of a single node.
-    // XXX this design is weird to allow this to be cursor backed.
+    // NB: self is mutable to allow reading from a WT cursor.
     fn get(&mut self, node: i64) -> Option<Result<Self::Node<'_>>>;
 }
 
 /// Vector store for vectors used to navigate the graph.
 pub trait NavVectorStore {
     /// Get the navigation vector for a single node.
-    // XXX this design is weird to allow this to be cursor backed.
+    // NB: self is mutable to allow reading from a WT cursor.
     fn get(&mut self, node: i64) -> Option<Result<Cow<'_, [u8]>>>;
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,0 +1,34 @@
+use std::borrow::Cow;
+
+use wt_mdb::Result;
+
+/// A node in the Vamana graph.
+pub trait GraphNode {
+    type EdgeIterator<'a>: Iterator<Item = i64>
+    where
+        Self: 'a;
+
+    /// Access the raw float vector.
+    fn vector(&self) -> Cow<'_, [f32]>;
+
+    /// Access the edges of the graph. These may be returned in an arbitrary order.
+    fn edges(&self) -> Self::EdgeIterator<'_>;
+}
+
+/// A Vamana graph.
+pub trait Graph {
+    type Node<'c>: GraphNode
+    where
+        Self: 'c;
+
+    /// Get the contents of a single node.
+    // XXX this design is weird to allow this to be cursor backed.
+    fn get(&mut self, node: i64) -> Option<Result<Self::Node<'_>>>;
+}
+
+/// Vector store for vectors used to navigate the graph.
+pub trait NavVectorStore {
+    /// Get the navigation vector for a single node.
+    // XXX this design is weird to allow this to be cursor backed.
+    fn get(&mut self, node: i64) -> Option<Result<Cow<'_, [u8]>>>;
+}

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -21,6 +21,9 @@ pub trait Graph {
     where
         Self: 'c;
 
+    /// Return the graph entry point, or None if the graph is empty.
+    fn entry_point(&self) -> Option<i64>;
+
     /// Get the contents of a single node.
     // XXX this design is weird to allow this to be cursor backed.
     fn get(&mut self, node: i64) -> Option<Result<Self::Node<'_>>>;

--- a/src/input.rs
+++ b/src/input.rs
@@ -48,6 +48,11 @@ impl<D> NumpyF32VectorStore<D> {
         self.vectors.len() / self.dimensions.get()
     }
 
+    /// Return true if this store is empty.
+    pub fn is_empty(&self) -> bool {
+        self.vectors.is_empty()
+    }
+
     /// Return an iterator over all the vectors in the store.
     pub fn iter(&self) -> impl Iterator<Item = &[f32]> {
         self.vectors.chunks(self.dimensions.get())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,59 @@
+use std::cmp::Ordering;
+
 mod graph;
 pub mod input;
 pub mod quantization;
+
+/// `Neighbor` is a node and a distance relative to some other node.
+///
+/// During a search distance might be relative to the query vector.
+/// In a graph index, distance might be relative to another node in the index.
+///
+/// When sorted, a slice of nodes is ordered first by distance, then by node, both in increasing
+/// order.
+#[derive(Debug, Copy, Clone)]
+pub struct Neighbor {
+    node: i64,
+    dist: f64,
+}
+
+impl Neighbor {
+    pub fn new(node: i64, distance: f64) -> Self {
+        Self {
+            node,
+            dist: distance,
+        }
+    }
+
+    pub fn node(&self) -> i64 {
+        self.node
+    }
+
+    pub fn distance(&self) -> f64 {
+        self.dist
+    }
+}
+
+impl PartialEq for Neighbor {
+    fn eq(&self, other: &Self) -> bool {
+        self.node == other.node && self.dist.total_cmp(&other.dist) == Ordering::Equal
+    }
+}
+
+impl Eq for Neighbor {}
+
+impl PartialOrd for Neighbor {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Neighbor {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match self.dist.total_cmp(&other.dist) {
+            Ordering::Equal => self.node.cmp(&other.node),
+            Ordering::Less => Ordering::Less,
+            Ordering::Greater => Ordering::Greater,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ use std::cmp::Ordering;
 mod graph;
 pub mod input;
 pub mod quantization;
+mod scoring;
 pub mod search;
 #[cfg(test)]
 mod test;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@ mod graph;
 pub mod input;
 pub mod quantization;
 pub mod search;
+#[cfg(test)]
+mod test;
 
 /// `Neighbor` is a node and a distance relative to some other node.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,37 +10,34 @@ mod test;
 
 /// `Neighbor` is a node and a distance relative to some other node.
 ///
-/// During a search distance might be relative to the query vector.
-/// In a graph index, distance might be relative to another node in the index.
+/// During a search score might be relative to the query vector.
+/// In a graph index, score might be relative to another node in the index.
 ///
-/// When sorted, a slice of nodes is ordered first by distance, then by node, both in increasing
-/// order.
+/// When compared `Neighbor`s are ordered first in descending order by score,
+/// then in ascending order by node.
 #[derive(Debug, Copy, Clone)]
 pub struct Neighbor {
     node: i64,
-    dist: f64,
+    score: f64,
 }
 
 impl Neighbor {
-    pub fn new(node: i64, distance: f64) -> Self {
-        Self {
-            node,
-            dist: distance,
-        }
+    pub fn new(node: i64, score: f64) -> Self {
+        Self { node, score }
     }
 
     pub fn node(&self) -> i64 {
         self.node
     }
 
-    pub fn distance(&self) -> f64 {
-        self.dist
+    pub fn score(&self) -> f64 {
+        self.score
     }
 }
 
 impl PartialEq for Neighbor {
     fn eq(&self, other: &Self) -> bool {
-        self.node == other.node && self.dist.total_cmp(&other.dist) == Ordering::Equal
+        self.node == other.node && self.score.total_cmp(&other.score) == Ordering::Equal
     }
 }
 
@@ -54,10 +51,10 @@ impl PartialOrd for Neighbor {
 
 impl Ord for Neighbor {
     fn cmp(&self, other: &Self) -> Ordering {
-        match self.dist.total_cmp(&other.dist) {
+        let c = self.score.total_cmp(&other.score).reverse();
+        match c {
             Ordering::Equal => self.node.cmp(&other.node),
-            Ordering::Less => Ordering::Less,
-            Ordering::Greater => Ordering::Greater,
+            _ => c,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,3 @@
+mod graph;
 pub mod input;
 pub mod quantization;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ use std::cmp::Ordering;
 mod graph;
 pub mod input;
 pub mod quantization;
+pub mod search;
 
 /// `Neighbor` is a node and a distance relative to some other node.
 ///

--- a/src/scoring.rs
+++ b/src/scoring.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use simsimd::{BinarySimilarity, SpatialSimilarity};
 
 /// Trait type for a vector scorer.

--- a/src/scoring.rs
+++ b/src/scoring.rs
@@ -13,14 +13,8 @@ pub trait VectorScorer {
     fn score(a: &[Self::Elem], b: &[Self::Elem]) -> f64;
 
     /// Normalize a vector for use with this scoring function.
-    /// By default, returns a reference to the input vector.
-    fn normalize<'a>(vector: &'a [Self::Elem]) -> Cow<'a, [Self::Elem]>
-    where
-        Self::Elem: Clone,
-        [Self::Elem]: ToOwned,
-    {
-        vector.into()
-    }
+    /// By default, does nothing.
+    fn normalize(_vector: &mut [Self::Elem]) {}
 }
 
 /// Computes a score based on l2 distance.
@@ -47,9 +41,11 @@ impl VectorScorer for DotProductScorer {
         (1f64 + SpatialSimilarity::dot(a, b).unwrap()) / 2f64
     }
 
-    fn normalize<'a>(vector: &'a [Self::Elem]) -> Cow<'a, [Self::Elem]> {
+    fn normalize(vector: &mut [Self::Elem]) {
         let norm = SpatialSimilarity::dot(vector, vector).unwrap().sqrt() as f32;
-        vector.iter().map(|d| *d / norm).collect::<Vec<_>>().into()
+        for d in vector.iter_mut() {
+            *d /= norm;
+        }
     }
 }
 

--- a/src/scoring.rs
+++ b/src/scoring.rs
@@ -8,11 +8,11 @@ pub trait VectorScorer {
     /// where higher values are better matches.
     ///
     /// Input vectors must be the same length or this function may panic.
-    fn score(a: &[Self::Elem], b: &[Self::Elem]) -> f64;
+    fn score(&self, a: &[Self::Elem], b: &[Self::Elem]) -> f64;
 
     /// Normalize a vector for use with this scoring function.
     /// By default, does nothing.
-    fn normalize(_vector: &mut [Self::Elem]) {}
+    fn normalize(&self, _vector: &mut [Self::Elem]) {}
 }
 
 /// Computes a score based on l2 distance.
@@ -22,7 +22,7 @@ pub struct EuclideanScorer;
 impl VectorScorer for EuclideanScorer {
     type Elem = f32;
 
-    fn score(a: &[Self::Elem], b: &[Self::Elem]) -> f64 {
+    fn score(&self, a: &[Self::Elem], b: &[Self::Elem]) -> f64 {
         1f64 / (1f64 + SpatialSimilarity::l2sq(a, b).unwrap())
     }
 }
@@ -34,12 +34,12 @@ pub struct DotProductScorer;
 impl VectorScorer for DotProductScorer {
     type Elem = f32;
 
-    fn score(a: &[Self::Elem], b: &[Self::Elem]) -> f64 {
+    fn score(&self, a: &[Self::Elem], b: &[Self::Elem]) -> f64 {
         // Assuming values are normalized, this will produce a score in [0,1]
         (1f64 + SpatialSimilarity::dot(a, b).unwrap()) / 2f64
     }
 
-    fn normalize(vector: &mut [Self::Elem]) {
+    fn normalize(&self, vector: &mut [Self::Elem]) {
         let norm = SpatialSimilarity::dot(vector, vector).unwrap().sqrt() as f32;
         for d in vector.iter_mut() {
             *d /= norm;
@@ -54,7 +54,7 @@ pub struct HammingScorer;
 impl VectorScorer for HammingScorer {
     type Elem = u8;
 
-    fn score(a: &[Self::Elem], b: &[Self::Elem]) -> f64 {
+    fn score(&self, a: &[Self::Elem], b: &[Self::Elem]) -> f64 {
         let dim = (a.len() * 8) as f64;
         (dim - BinarySimilarity::hamming(a, b).unwrap()) / dim
     }

--- a/src/scoring.rs
+++ b/src/scoring.rs
@@ -1,0 +1,67 @@
+use std::borrow::Cow;
+
+use simsimd::{BinarySimilarity, SpatialSimilarity};
+
+/// Trait type for a vector scorer.
+pub trait VectorScorer {
+    type Elem;
+
+    /// Score vectors `a` and `b` against one another. Returns a score
+    /// where higher values are better matches.
+    ///
+    /// Input vectors must be the same length or this function may panic.
+    fn score(a: &[Self::Elem], b: &[Self::Elem]) -> f64;
+
+    /// Normalize a vector for use with this scoring function.
+    /// By default, returns a reference to the input vector.
+    fn normalize<'a>(vector: &'a [Self::Elem]) -> Cow<'a, [Self::Elem]>
+    where
+        Self::Elem: Clone,
+        [Self::Elem]: ToOwned,
+    {
+        vector.into()
+    }
+}
+
+/// Computes a score based on l2 distance.
+#[derive(Debug, Copy, Clone)]
+pub struct EuclideanScorer;
+
+impl VectorScorer for EuclideanScorer {
+    type Elem = f32;
+
+    fn score(a: &[Self::Elem], b: &[Self::Elem]) -> f64 {
+        1f64 / (1f64 + SpatialSimilarity::l2sq(a, b).unwrap())
+    }
+}
+
+/// Computes a score based on the dot product.
+#[derive(Debug, Copy, Clone)]
+pub struct DotProductScorer;
+
+impl VectorScorer for DotProductScorer {
+    type Elem = f32;
+
+    fn score(a: &[Self::Elem], b: &[Self::Elem]) -> f64 {
+        // Assuming values are normalized, this will produce a score in [0,1]
+        (1f64 + SpatialSimilarity::dot(a, b).unwrap()) / 2f64
+    }
+
+    fn normalize<'a>(vector: &'a [Self::Elem]) -> Cow<'a, [Self::Elem]> {
+        let norm = SpatialSimilarity::dot(vector, vector).unwrap().sqrt() as f32;
+        vector.iter().map(|d| *d / norm).collect::<Vec<_>>().into()
+    }
+}
+
+/// Computes a score from two bitmaps using hamming distance.
+#[derive(Debug, Copy, Clone)]
+pub struct HammingScorer;
+
+impl VectorScorer for HammingScorer {
+    type Elem = u8;
+
+    fn score(a: &[Self::Elem], b: &[Self::Elem]) -> f64 {
+        let dim = (a.len() * 8) as f64;
+        (dim - BinarySimilarity::hamming(a, b).unwrap()) / dim
+    }
+}

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,0 +1,159 @@
+use std::num::NonZero;
+
+use crate::{
+    graph::{Graph, NavVectorStore},
+    Neighbor,
+};
+
+/// Parameters for a search over a Vamana graph.
+pub struct GraphSearchParams {
+    /// Width of the graph search beam -- the number of candidates considered.
+    /// We will return this many results.
+    pub beam_width: NonZero<usize>,
+    /// Number of results to re-rank using the vectors in the graph.
+    pub num_rerank: usize,
+}
+
+/// Helper to search a Vamana graph.
+pub struct GraphSearcher {
+    candidates: CandidateList,
+    params: GraphSearchParams,
+}
+
+impl GraphSearcher {
+    pub fn new(params: GraphSearchParams) -> Self {
+        Self {
+            candidates: CandidateList::new(params.beam_width.get()),
+            params,
+        }
+    }
+
+    pub fn params(&self) -> &GraphSearchParams {
+        &self.params
+    }
+
+    // XXX this search is explicitly single threaded, we'd need a _generator_ of graphs and vector stores
+    // to search multi-threaded. Some other internals would also need to change like the queue would need
+    // to be protected.
+    pub fn search<G, N>(&mut self, graph: &mut G, nav: &mut N) -> Vec<Neighbor>
+    where
+        G: Graph,
+        N: NavVectorStore,
+    {
+        todo!()
+    }
+}
+
+/// A candidate in the search list. Once visited, the candidate becomes a result.
+#[derive(Debug)]
+struct Candidate {
+    neighbor: Neighbor,
+    // If set, we've visited this neighbor.
+    vector: Option<Vec<f32>>,
+}
+
+impl From<Neighbor> for Candidate {
+    fn from(neighbor: Neighbor) -> Self {
+        Candidate {
+            neighbor,
+            vector: None,
+        }
+    }
+}
+
+/// An ordered set of `Candidate` as a sort of priority queue.
+///
+/// Results are ordered by `Neighbor` value and the set is capped to a fixed capacity. Callers may
+/// iterate over unvisited candidates, a core part of the Vamana search algorithm.
+struct CandidateList {
+    candidates: Vec<Candidate>,
+    next_unvisited: usize,
+}
+
+impl CandidateList {
+    /// Create a new candidate list with the given capacity. The list will never be longer
+    /// than this capacity.
+    fn new(capacity: usize) -> Self {
+        Self {
+            candidates: Vec::with_capacity(capacity),
+            next_unvisited: 0,
+        }
+    }
+
+    fn add_unvisited(&mut self, neighbor: Neighbor) {
+        // If the queue is full and the candidate is not competitive then drop it.
+        if self.candidates.len() >= self.candidates.capacity()
+            && neighbor >= self.candidates.last().unwrap().neighbor
+        {
+            return;
+        }
+
+        if let Some(insert_idx) = self
+            .candidates
+            .binary_search_by_key(&neighbor, |c| c.neighbor)
+            .err()
+        {
+            if self.candidates.len() >= self.candidates.capacity() {
+                self.candidates.pop();
+            }
+            self.candidates.insert(insert_idx, neighbor.into());
+            self.next_unvisited = std::cmp::min(self.next_unvisited, insert_idx);
+        }
+    }
+
+    /// Return the next unvisited neighbor, or None if all neighbors have been visited.
+    fn next_unvisited(&mut self) -> Option<VisitCandidateGuard<'_>> {
+        if self.next_unvisited < self.candidates.len() {
+            Some(VisitCandidateGuard::new(self))
+        } else {
+            None
+        }
+    }
+
+    fn clear(&mut self) {
+        self.candidates.clear();
+        self.next_unvisited = 0;
+    }
+}
+
+impl Extend<Neighbor> for CandidateList {
+    fn extend<T: IntoIterator<Item = Neighbor>>(&mut self, iter: T) {
+        for n in iter {
+            self.add_unvisited(n);
+        }
+    }
+}
+
+struct VisitCandidateGuard<'a> {
+    list: &'a mut CandidateList,
+    index: usize,
+}
+
+impl<'a> VisitCandidateGuard<'a> {
+    fn new(list: &'a mut CandidateList) -> Self {
+        let index = list.next_unvisited;
+        Self { list, index }
+    }
+
+    /// The current neighbor we are visiting.
+    fn neighbor(&self) -> Neighbor {
+        self.list.candidates[self.index].neighbor
+    }
+
+    /// Mark this candidate as visited and update the full fidelity vector in the candidate list.
+    fn visit(&mut self, vector: impl Into<Vec<f32>>) {
+        self.list.candidates[self.index].vector = Some(vector.into());
+        self.list.next_unvisited = self
+            .list
+            .candidates
+            .iter()
+            .enumerate()
+            .skip(self.index + 1)
+            .find_map(|(i, c)| if c.vector.is_some() { None } else { Some(i) })
+            .unwrap_or(self.list.candidates.len());
+    }
+}
+
+// XXX when I get the next unvisited node I want to update it with a vector
+// I can't represent the iteration as an iterator because it would need a reference and i wouldn't
+// be able to insert new items while I have the iterator outstanding.

--- a/src/search.rs
+++ b/src/search.rs
@@ -33,10 +33,16 @@ impl GraphSearcher {
         &self.params
     }
 
+    // XXX when searching as part of insertion, I probably want the raw vectors returned as well
+    // -- I can use them for RNG pruning.
+
+    // XXX I probably want to attach the scorer, quantization function, and quantization scorer to be
+    // a property of the graph object somehow.
+
     // NB: graph and nav have to be mutable, which means that we can only use one thread internally for
     // searching. A freelist or generator would be necessary to do a multi-threaded search that pops
     // multiple candidates at once. This would also require significant changes to CandidateList.
-    // XXX need an error handling aware signature and
+    // XXX need an Result return value err handling.
     pub fn search<G, N>(&mut self, query: &[f32], graph: &mut G, nav: &mut N) -> Vec<Neighbor>
     where
         G: Graph,
@@ -59,7 +65,7 @@ impl GraphSearcher {
                 .get(best_candidate.neighbor().node())
                 .unwrap()
                 .unwrap();
-            // If we aren't reranking we don't need to read the
+            // If we aren't reranking we don't need to copy the actual vector.
             best_candidate.visit(if self.params.num_rerank > 0 {
                 node.vector().into()
             } else {
@@ -93,6 +99,7 @@ impl GraphSearcher {
         results
     }
 
+    // XXX this doesn't work, we need to normalize the distance into a score (i think?)
     fn score(q: &[f32], d: &[f32]) -> f64 {
         simsimd::SpatialSimilarity::dot(q, d).unwrap()
     }

--- a/src/search.rs
+++ b/src/search.rs
@@ -22,7 +22,11 @@ pub struct GraphSearcher {
     params: GraphSearchParams,
 }
 
+// TODO: search_for_indexing() that includes the vectors in the results. These could easily be
+// used for edge pruning.
+// TODO: consider attaching relevant scorers and quantization function to the Graph.
 impl GraphSearcher {
+    /// Create a new, reusable graph searcher.
     pub fn new(params: GraphSearchParams) -> Self {
         Self {
             candidates: CandidateList::new(params.beam_width.get()),
@@ -30,16 +34,16 @@ impl GraphSearcher {
         }
     }
 
+    /// Return the search params.
     pub fn params(&self) -> &GraphSearchParams {
         &self.params
     }
 
-    // XXX when searching as part of insertion, I probably want the raw vectors returned as well
-    // -- I can use them for RNG pruning.
-
-    // XXX I probably want to attach the scorer, quantization function, and quantization scorer to be
-    // a property of the graph object somehow.
-
+    /// Search for `query` in the given `graph`. `nav` and `nav_scorer` are used to score candidates
+    /// as we traverse the graph, `scorer` may be used to re-rank results if configured for this
+    /// searcher.
+    ///
+    /// Returns an approximate list of neighbors with the highest scores.
     // NB: graph and nav have to be mutable, which means that we can only use one thread internally for
     // searching. A freelist or generator would be necessary to do a multi-threaded search that pops
     // multiple candidates at once. This would also require significant changes to CandidateList.

--- a/src/test.rs
+++ b/src/test.rs
@@ -13,7 +13,7 @@ pub struct TestGraph {
 }
 
 impl TestGraph {
-    fn new<T, V>(max_edges: NonZero<usize>, iter: T) -> Self
+    pub fn new<T, V>(max_edges: NonZero<usize>, iter: T) -> Self
     where
         T: IntoIterator<Item = V>,
         V: Into<Vec<f32>>,
@@ -33,9 +33,9 @@ impl TestGraph {
         TestGraph { rep }
     }
 
-    fn search(&self, index: usize) -> Vec<i64> {
+    fn compute_edges(&self, index: usize, max_edges: NonZero<usize>) -> Vec<i64> {
         let q = &self.rep[index].vector;
-        let neighbors = self
+        let mut scored = self
             .rep
             .iter()
             .enumerate()
@@ -50,6 +50,15 @@ impl TestGraph {
                 }
             })
             .collect::<Vec<_>>();
+        scored.sort();
+        if (scored.is_empty()) {
+            return vec![];
+        }
+
+        let mut edges = Vec::with_capacity(std::cmp::min(scored.len(), max_edges.get()));
+        edges.push(scored[0]);
+        // score against all previous vectors in the list
+        for (i, n) in scored.iter().enumerate().skip(1) {}
         todo!()
     }
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,0 +1,55 @@
+use std::num::NonZero;
+
+use crate::{quantization::binary_quantize, Neighbor};
+
+struct TestVector {
+    vector: Vec<f32>,
+    nav_vector: Vec<u8>,
+    edges: Vec<i64>,
+}
+
+pub struct TestGraph {
+    rep: Vec<TestVector>,
+}
+
+impl TestGraph {
+    fn new<T, V>(max_edges: NonZero<usize>, iter: T) -> Self
+    where
+        T: IntoIterator<Item = V>,
+        V: Into<Vec<f32>>,
+    {
+        let rep = iter
+            .into_iter()
+            .map(|x| {
+                let v = x.into();
+                let b = binary_quantize(&v);
+                TestVector {
+                    vector: v,
+                    nav_vector: b,
+                    edges: Vec::new(),
+                }
+            })
+            .collect();
+        TestGraph { rep }
+    }
+
+    fn search(&self, index: usize) -> Vec<i64> {
+        let q = &self.rep[index].vector;
+        let neighbors = self
+            .rep
+            .iter()
+            .enumerate()
+            .filter_map(|(i, n)| {
+                if i != index {
+                    Some(Neighbor::new(
+                        i as i64,
+                        simsimd::SpatialSimilarity::dot(q, &n.vector).unwrap(),
+                    ))
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+        todo!()
+    }
+}

--- a/wt_mdb/src/record_cursor.rs
+++ b/wt_mdb/src/record_cursor.rs
@@ -74,7 +74,7 @@ impl<'a> RecordCursor<'a> {
     }
 
     /// Set the contents of `record` in the collection.
-    pub fn set<'b>(&mut self, record: &RecordView<'b>) -> Result<()> {
+    pub fn set(&mut self, record: &RecordView<'_>) -> Result<()> {
         // safety: the memory passed to set_{key,value} need only be valid until a modifying
         // call like insert().
         unsafe {


### PR DESCRIPTION
Add abstractions for a DiskANN Graph and navigational vector store as well as scoring.

Implement Vamana graph search in terms of these primitives. This is a required step before
building bulk graph indexing as generating the candidate edge list on node insertion starts
with a search of the partially built graph.