### PR TITLE
Switch `wt_sys` build to use the CMake crate

### DIFF
--- a/wt_sys/Cargo.toml
+++ b/wt_sys/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 
 [build-dependencies]
 bindgen = "0.70.1"
+cmake = "0.1.51"


### PR DESCRIPTION
This is mostly simpler than manually invoking cmake directly via `Command`.

Read the `PROFILE` environment variable that is set for build scripts to enable or disable
the `HAVE_DIAGNOSTIC` flag. When diagnostics are on there are frequent calls to `cthread_yield()`
on macos which is very bad for performance.