### PR TITLE
Add search to `et` tool

### DIFF
--- a/et/src/lookup.rs
+++ b/et/src/lookup.rs
@@ -1,19 +1,14 @@
-use std::{io, num::NonZero, sync::Arc};
+use std::{io, sync::Arc};
 
 use clap::Args;
 use easy_tiger::{
-    graph::{Graph, GraphMetadata, GraphNode, GraphSearchParams},
+    graph::{Graph, GraphMetadata, GraphNode},
     wt::{WiredTigerGraph, WiredTigerIndexParams},
 };
 use wt_mdb::Connection;
 
 #[derive(Args)]
 pub struct LookupArgs {
-    /// Number of vector dimensions for index and query vectors.
-    // TODO: this should appear in the table, derive it from that!
-    #[arg(short, long)]
-    dimensions: NonZero<usize>,
-
     /// Id of the vertex to lookup.
     #[arg(short, long)]
     id: i64,
@@ -29,19 +24,10 @@ pub struct LookupArgs {
 pub fn lookup(
     connection: Arc<Connection>,
     index_params: WiredTigerIndexParams,
+    metadata: GraphMetadata,
     args: LookupArgs,
 ) -> io::Result<()> {
     let session = connection.open_session().map_err(io::Error::from)?;
-    // TODO: this should be read from the graph table.
-    let metadata = GraphMetadata {
-        dimensions: args.dimensions,
-        max_edges: NonZero::new(1).unwrap(), // unused here.
-        index_search_params: GraphSearchParams {
-            //unused here.
-            beam_width: NonZero::new(1).unwrap(),
-            num_rerank: 0,
-        },
-    };
     let mut graph = WiredTigerGraph::new(
         metadata,
         session.open_record_cursor(&index_params.graph_table_name)?,

--- a/et/src/main.rs
+++ b/et/src/main.rs
@@ -1,4 +1,5 @@
 <<<<<<< HEAD
+<<<<<<< HEAD
 mod lookup;
 
 use std::{
@@ -10,9 +11,14 @@ use clap::{command, Parser, Subcommand};
 use easy_tiger::wt::WiredTigerIndexParams;
 use lookup::{lookup, LookupArgs};
 use wt_mdb::{Connection, ConnectionOptionsBuilder};
+=======
+mod search;
+
+>>>>>>> 959108b (search command)
 use std::io::ErrorKind;
 
 use clap::{command, Parser, Subcommand};
+use search::{search, SearchArgs};
 
 #[derive(Parser)]
 #[command(version, about = "EasyTiger vector indexing tool", long_about = None)]
@@ -36,7 +42,7 @@ enum Commands {
     /// Lookup the contents of a single vertex.
     Lookup(LookupArgs),
     /// Search for a list of vectors and time the operation.
-    Search,
+    Search(SearchArgs),
     /// Add a list of vectors to the index.
     Add,
     /// Delete vectors by key range.
@@ -59,7 +65,7 @@ fn main() -> std::io::Result<()> {
 
     match cli.command {
         Commands::Lookup(args) => lookup(connection, index_params, args),
-        Commands::Search => Err(std::io::Error::from(ErrorKind::Unsupported)),
+        Commands::Search(args) => search(args),
         Commands::Add => Err(std::io::Error::from(ErrorKind::Unsupported)),
         Commands::Delete => Err(std::io::Error::from(ErrorKind::Unsupported)),
     }

--- a/et/src/main.rs
+++ b/et/src/main.rs
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 mod lookup;
 
 use std::{
@@ -9,6 +10,9 @@ use clap::{command, Parser, Subcommand};
 use easy_tiger::wt::WiredTigerIndexParams;
 use lookup::{lookup, LookupArgs};
 use wt_mdb::{Connection, ConnectionOptionsBuilder};
+use std::io::ErrorKind;
+
+use clap::{command, Parser, Subcommand};
 
 #[derive(Parser)]
 #[command(version, about = "EasyTiger vector indexing tool", long_about = None)]
@@ -31,6 +35,12 @@ struct Cli {
 enum Commands {
     /// Lookup the contents of a single vertex.
     Lookup(LookupArgs),
+    /// Search for a list of vectors and time the operation.
+    Search,
+    /// Add a list of vectors to the index.
+    Add,
+    /// Delete vectors by key range.
+    Delete,
 }
 
 fn main() -> std::io::Result<()> {
@@ -49,5 +59,8 @@ fn main() -> std::io::Result<()> {
 
     match cli.command {
         Commands::Lookup(args) => lookup(connection, index_params, args),
+        Commands::Search => Err(std::io::Error::from(ErrorKind::Unsupported)),
+        Commands::Add => Err(std::io::Error::from(ErrorKind::Unsupported)),
+        Commands::Delete => Err(std::io::Error::from(ErrorKind::Unsupported)),
     }
 }

--- a/et/src/main.rs
+++ b/et/src/main.rs
@@ -1,24 +1,16 @@
-<<<<<<< HEAD
-<<<<<<< HEAD
 mod lookup;
+mod search;
 
 use std::{
-    io::{self},
+    io::{self, ErrorKind},
     num::NonZero,
 };
 
 use clap::{command, Parser, Subcommand};
 use easy_tiger::wt::WiredTigerIndexParams;
 use lookup::{lookup, LookupArgs};
-use wt_mdb::{Connection, ConnectionOptionsBuilder};
-=======
-mod search;
-
->>>>>>> 959108b (search command)
-use std::io::ErrorKind;
-
-use clap::{command, Parser, Subcommand};
 use search::{search, SearchArgs};
+use wt_mdb::{Connection, ConnectionOptionsBuilder};
 
 #[derive(Parser)]
 #[command(version, about = "EasyTiger vector indexing tool", long_about = None)]
@@ -65,7 +57,7 @@ fn main() -> std::io::Result<()> {
 
     match cli.command {
         Commands::Lookup(args) => lookup(connection, index_params, args),
-        Commands::Search(args) => search(args),
+        Commands::Search(args) => search(connection, index_params, args),
         Commands::Add => Err(std::io::Error::from(ErrorKind::Unsupported)),
         Commands::Delete => Err(std::io::Error::from(ErrorKind::Unsupported)),
     }

--- a/et/src/main.rs
+++ b/et/src/main.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use clap::{command, Parser, Subcommand};
-use easy_tiger::wt::WiredTigerIndexParams;
+use easy_tiger::wt::{read_graph_metadata, WiredTigerIndexParams};
 use lookup::{lookup, LookupArgs};
 use search::{search, SearchArgs};
 use wt_mdb::{Connection, ConnectionOptionsBuilder};
@@ -54,10 +54,11 @@ fn main() -> std::io::Result<()> {
     .map_err(io::Error::from)?;
     let index_params =
         WiredTigerIndexParams::new(connection.clone(), &cli.wiredtiger_table_basename);
+    let metadata = read_graph_metadata(connection.clone(), &index_params.graph_table_name)?;
 
     match cli.command {
-        Commands::Lookup(args) => lookup(connection, index_params, args),
-        Commands::Search(args) => search(connection, index_params, args),
+        Commands::Lookup(args) => lookup(connection, index_params, metadata, args),
+        Commands::Search(args) => search(connection, index_params, metadata, args),
         Commands::Add => Err(std::io::Error::from(ErrorKind::Unsupported)),
         Commands::Delete => Err(std::io::Error::from(ErrorKind::Unsupported)),
     }

--- a/et/src/search.rs
+++ b/et/src/search.rs
@@ -1,0 +1,118 @@
+use std::{
+    fs::File,
+    io::{self},
+    num::NonZero,
+    path::PathBuf,
+};
+
+use clap::Args;
+use easy_tiger::{
+    scoring::{DotProductScorer, HammingScorer},
+    search::{GraphSearchParams, GraphSearcher},
+    wt::{GraphMetadata, WiredTigerGraph, WiredTigerIndexParams, WiredTigerNavVectorStore},
+};
+use indicatif::{ProgressBar, ProgressStyle};
+use wt_mdb::{Connection, ConnectionOptionsBuilder};
+
+#[derive(Args)]
+pub struct SearchArgs {
+    /// Path to the WiredTiger database.
+    #[arg(long)]
+    wiredtiger_db_path: String,
+    /// Size of the WiredTiger disk cache, in MB.
+    #[arg(long, default_value = "1024")]
+    wiredtiger_cache_size_mb: NonZero<usize>,
+    /// WiredTiger table basename use to locate the graph.
+    #[arg(long)]
+    wiredtiger_table_basename: String,
+    /// Number of vector dimensions for index and query vectors.
+    // TODO: this should appear in the table, derive it from that!
+    #[arg(short, long)]
+    dimensions: NonZero<usize>,
+
+    /// Path to numpy formatted little-endian float vectors.
+    #[arg(short, long)]
+    query_vectors: PathBuf,
+    /// Number candidates in the search list.
+    candidates: NonZero<usize>,
+    /// Number of results to re-rank at the end of each search.
+    /// If unset, use the same figure as candidates.
+    rerank_budget: Option<usize>,
+    /// Maximum number of queries to run. If unset, run all queries in the vector file.
+    #[arg(short, long)]
+    limit: Option<usize>,
+    // TODO: recall statistics
+}
+
+pub fn search(args: SearchArgs) -> io::Result<()> {
+    let query_vectors = easy_tiger::input::NumpyF32VectorStore::new(
+        unsafe { memmap2::Mmap::map(&File::open(args.query_vectors)?)? },
+        args.dimensions,
+    );
+    let limit = std::cmp::min(
+        query_vectors.len(),
+        args.limit.unwrap_or(query_vectors.len()),
+    );
+
+    // This leaves much to be desired.
+    let connection = Connection::open(
+        &args.wiredtiger_db_path,
+        Some(
+            ConnectionOptionsBuilder::default()
+                .cache_size_mb(args.wiredtiger_cache_size_mb)
+                .into(),
+        ),
+    )
+    .map_err(io::Error::from)?;
+    let index_params =
+        WiredTigerIndexParams::new(connection.clone(), &args.wiredtiger_table_basename);
+    // TODO: this should be read from the graph table.
+    let metadata = GraphMetadata {
+        dimensions: args.dimensions,
+        max_edges: NonZero::new(1).unwrap(), // unused here.
+        index_search_params: GraphSearchParams {
+            //unused here.
+            beam_width: NonZero::new(1).unwrap(),
+            num_rerank: 0,
+        },
+    };
+    let session = connection.open_session().map_err(io::Error::from)?;
+    let mut graph = WiredTigerGraph::new(
+        metadata,
+        session.open_record_cursor(&index_params.graph_table_name)?,
+    );
+    let mut nav_vectors =
+        WiredTigerNavVectorStore::new(session.open_record_cursor(&index_params.nav_table_name)?);
+    let mut searcher = GraphSearcher::new(GraphSearchParams {
+        beam_width: args.candidates,
+        num_rerank: args.rerank_budget.unwrap_or_else(|| args.candidates.get()),
+    });
+
+    let progress = ProgressBar::new(limit as u64)
+        .with_style(
+            ProgressStyle::default_bar()
+                .template("{wide_bar} {pos}/{len} ETA: {eta_precise} Elapsed: {elapsed_precise}")
+                .unwrap(),
+        )
+        .with_finish(indicatif::ProgressFinish::AndLeave);
+    for q in query_vectors.iter().take(limit) {
+        let results = searcher.search(
+            q,
+            &mut graph,
+            &DotProductScorer,
+            &mut nav_vectors,
+            &HammingScorer,
+        )?;
+        assert_ne!(results.len(), 0);
+        progress.inc(1);
+    }
+    progress.finish_using_style();
+
+    println!(
+        "queries {} avg duration {:.3} ms",
+        limit,
+        progress.elapsed().div_f32(limit as f32).as_micros() as f64 / 1_000f64
+    );
+
+    Ok(())
+}

--- a/et/src/search.rs
+++ b/et/src/search.rs
@@ -79,9 +79,9 @@ pub fn search(
         )?;
         assert_ne!(results.len(), 0);
         progress.inc(1);
-        progress.finish_using_style();
+        session.rollback_transaction(None)?;
     }
-    session.rollback_transaction(None)?;
+    progress.finish_using_style();
 
     println!(
         "queries {} avg duration {:.3} ms",

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -284,6 +284,15 @@ where
             nav_vectors,
             &HammingScorer,
         )?;
+        // XXX figure out how this is happening
+        // XXX it always happens for vertex 0 with limit <1k, probably because I'm searching for the ep.
+        // XXX introduce a search for indexing that skip this the named point entirely
+        // XXX introduce entry point selection.
+        let original_len = candidates.len();
+        candidates.retain(|n| index != n.node() as usize);
+        if candidates.len() != original_len {
+            eprintln!("Found self link for vertex {}", index);
+        }
 
         let pruned_len = self
             .prune(&mut candidates, &mut graph, &DotProductScorer)?
@@ -350,10 +359,13 @@ where
         edges: &'a mut [Neighbor],
         graph: &mut BulkLoadBuilderGraph<'_, D>,
         scorer: &S,
-    ) -> Result<(&'a mut [Neighbor], &'a mut [Neighbor])>
+    ) -> Result<(&'a [Neighbor], &'a [Neighbor])>
     where
         S: VectorScorer<Elem = f32>,
     {
+        if edges.is_empty() {
+            return Ok((&[], &[]));
+        }
         edges.sort();
         // TODO: replace with a fixed length bitset
         let mut selected = BTreeSet::new();
@@ -401,7 +413,7 @@ where
             edges.swap(i, *j);
         }
 
-        Ok(edges.split_at_mut(selected.len()))
+        Ok(edges.split_at(selected.len()))
     }
 }
 

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -284,16 +284,6 @@ where
             nav_vectors,
             &HammingScorer,
         )?;
-        // XXX figure out how this is happening
-        // XXX it always happens for vertex 0 with limit <1k, probably because I'm searching for the ep.
-        // XXX introduce a search for indexing that skip this the named point entirely
-        // XXX introduce entry point selection.
-        let original_len = candidates.len();
-        candidates.retain(|n| index != n.node() as usize);
-        if candidates.len() != original_len {
-            eprintln!("Found self link for vertex {}", index);
-        }
-
         let pruned_len = self
             .prune(&mut candidates, &mut graph, &DotProductScorer)?
             .0

--- a/src/wt.rs
+++ b/src/wt.rs
@@ -70,7 +70,7 @@ impl<'a> WiredTigerGraphNode<'a> {
             // Try to align it and if that fails, copy the data.
             let (prefix, vector, _) = unsafe { self.data.as_ref().align_to::<f32>() };
             if prefix.is_empty() {
-                return Some(vector);
+                return Some(&vector[..self.dimensions.get()]);
             }
         }
         None


### PR DESCRIPTION
Reads an input set of numpy vectors and runs them one at a time through a graph search.
* Encode graph metadata and entry point in the graph table so we can read it back later.
* Fix a bug in WiredTigerGraphNode that would return erroneously sized vectors if the value memory was aligned.

Initial run with a 2GB cache yields 16ms/search which is not terribly competitive on overall latency but likely
better than lucene in a small container. 75% of the profile is in `WiredTigerGraph.get() -> pread()` which is
not unexpected and could certainly be improved.