### PR TITLE
Upgrade to WiredTiger 11.3.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: WiredTiger submodule init
-      run: git submodule init -- wt_sys/wiredtiger
+      run: git submodule update --init --recursive
     - name: Build
       run: cargo build --workspace
     - name: Run tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: WiredTiger submodule init
+      run: git submodule init -- wt_sys/wiredtiger
     - name: Build
       run: cargo build --workspace
     - name: Run tests

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "wt_sys/wiredtiger"]
+	path = wt_sys/wiredtiger
+	url = https://github.com/wiredtiger/wiredtiger.git
+	branch = develop

--- a/wt_sys/build.rs
+++ b/wt_sys/build.rs
@@ -14,7 +14,7 @@ fn build_wt() -> PathBuf {
         .define("HAVE_DIAGNOSTIC", if have_diagnostic { "1" } else { "0" })
         .define("ENABLE_PYTHON", "0")
         // CMake crate is not doing this correctly for whatever reason.
-        .build_arg(format!("-j{}", jobs))
+        //.build_arg(format!("-j{}", jobs))
         .build();
     PathBuf::from_iter([build_path, PathBuf::from("build")])
 }

--- a/wt_sys/build.rs
+++ b/wt_sys/build.rs
@@ -3,15 +3,18 @@ use std::path::PathBuf;
 
 fn build_wt() -> PathBuf {
     let have_diagnostic = env::var("PROFILE").unwrap() == "debug";
+    let jobs = std::cmp::max(
+        env::var("NUM_JOBS")
+            .map(|v| str::parse::<i32>(&v).unwrap())
+            .unwrap_or(4),
+        4,
+    );
     let build_path = cmake::Config::new("wiredtiger")
         .define("ENABLE_STATIC", "1")
         .define("HAVE_DIAGNOSTIC", if have_diagnostic { "1" } else { "0" })
         .define("ENABLE_PYTHON", "0")
         // CMake crate is not doing this correctly for whatever reason.
-        .build_arg(format!(
-            "-j{}",
-            env::var("NUM_JOBS").unwrap_or("1".to_string())
-        ))
+        .build_arg(format!("-j{}", jobs))
         .build();
     PathBuf::from_iter([build_path, PathBuf::from("build")])
 }

--- a/wt_sys/build.rs
+++ b/wt_sys/build.rs
@@ -1,55 +1,26 @@
 use std::env;
-use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::path::PathBuf;
 
-const GITHUB_WT_TAGS_URI: &str = "https://github.com/wiredtiger/wiredtiger/archive/refs/tags";
-const WT_VERSION: &str = "11.2.0";
-
-fn download_source() -> PathBuf {
-    let uri = format!("{GITHUB_WT_TAGS_URI}/{WT_VERSION}.tar.gz");
-    let out_dir = env::var("OUT_DIR").unwrap();
-    Command::new("wget")
-        .arg(uri)
-        .arg("-P")
-        .arg(out_dir.clone())
-        .output()
-        .expect("Failed to download source");
-    PathBuf::from_iter([out_dir, format!("{WT_VERSION}.tar.gz")])
-}
-
-fn extract_source(tar_path: &Path) -> PathBuf {
-    let mut src_path = tar_path.to_path_buf();
-    src_path.pop();
-    Command::new("tar")
-        .arg("-xvf")
-        .arg(tar_path)
-        .arg("-C")
-        .arg(&src_path)
-        .output()
-        .expect("Failed to extract source");
-    src_path.push(format!("wiredtiger-{WT_VERSION}"));
-    src_path
-}
-
-fn build_wt(src_path: &Path) -> PathBuf {
+fn build_wt() -> PathBuf {
     let have_diagnostic = env::var("PROFILE").unwrap() == "debug";
-    let build_path = cmake::Config::new(src_path)
+    let build_path = cmake::Config::new("wiredtiger")
         .define("ENABLE_STATIC", "1")
         .define("HAVE_DIAGNOSTIC", if have_diagnostic { "1" } else { "0" })
-        // Overidde C_FLAGS and CXX_FLAGS to keep cmake from passing both --target and -mmacosx-version-min
-        .define("CMAKE_C_FLAGS", "")
-        .define("CMAKE_CXX_FLAGS", "")
-        .no_build_target(false)
+        .define("ENABLE_PYTHON", "0")
+        // CMake crate is not doing this correctly for whatever reason.
+        .build_arg(format!(
+            "-j{}",
+            env::var("NUM_JOBS").unwrap_or("1".to_string())
+        ))
         .build();
     PathBuf::from_iter([build_path, PathBuf::from("build")])
 }
 
 fn main() {
-    let tar_path = download_source();
-    let src_path = extract_source(&tar_path);
-    let build_path = build_wt(&src_path);
+    let build_path = build_wt();
 
     println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=wiredtiger");
 
     // Tell cargo to look for shared libraries in the specified directory
     println!("cargo:rustc-link-search={}", build_path.display());

--- a/wt_sys/build.rs
+++ b/wt_sys/build.rs
@@ -3,18 +3,13 @@ use std::path::PathBuf;
 
 fn build_wt() -> PathBuf {
     let have_diagnostic = env::var("PROFILE").unwrap() == "debug";
-    let jobs = std::cmp::max(
-        env::var("NUM_JOBS")
-            .map(|v| str::parse::<i32>(&v).unwrap())
-            .unwrap_or(4),
-        4,
-    );
+    let jobs = env::var("NUM_JOBS").unwrap_or("1".to_string());
     let build_path = cmake::Config::new("wiredtiger")
         .define("ENABLE_STATIC", "1")
         .define("HAVE_DIAGNOSTIC", if have_diagnostic { "1" } else { "0" })
         .define("ENABLE_PYTHON", "0")
         // CMake crate is not doing this correctly for whatever reason.
-        //.build_arg(format!("-j{}", jobs))
+        .build_arg(format!("-j{}", jobs))
         .build();
     PathBuf::from_iter([build_path, PathBuf::from("build")])
 }


### PR DESCRIPTION
In addition to the upgrade:
* Make WiredTiger a submodule. The source code appears just once instead of being downloaded into each output directory.
* Stop overriding cflags. On macos if the installed toolchains are ahead of the os version you may need to set `MACOSX_DEPLOYMENT_TARGET="${current_version}"`
* Set `-j` on the cmake build. The cmake crate is not inferring this correctly and setting it from environment variables reduces build times 200s+ => 15s.
* Rerun if the wt directory changed in the source tree. This should only happen on upgrades or trying another branch.