### PR TITLE
Remove lifetime from `RecordCursor`

### DIFF
--- a/bulk_load/src/main.rs
+++ b/bulk_load/src/main.rs
@@ -90,7 +90,7 @@ fn main() -> io::Result<()> {
 
     let wt_params = WiredTigerIndexParams::new(connection.clone(), &args.wiredtiger_table_basename);
     if args.drop_tables {
-        let session = connection.open_session().map_err(io::Error::from)?;
+        let mut session = connection.open_session().map_err(io::Error::from)?;
         session
             .drop_record_table(
                 &wt_params.graph_table_name,

--- a/et/src/lookup.rs
+++ b/et/src/lookup.rs
@@ -27,7 +27,7 @@ pub fn lookup(
     metadata: GraphMetadata,
     args: LookupArgs,
 ) -> io::Result<()> {
-    let session = connection.open_session().map_err(io::Error::from)?;
+    let mut session = connection.open_session().map_err(io::Error::from)?;
     let mut graph = WiredTigerGraph::new(
         metadata,
         session.open_record_cursor(&index_params.graph_table_name)?,

--- a/et/src/search.rs
+++ b/et/src/search.rs
@@ -49,7 +49,7 @@ pub fn search(
         args.limit.unwrap_or(query_vectors.len()),
     );
 
-    let session = connection.open_session()?;
+    let mut session = connection.open_session()?;
     let mut graph = WiredTigerGraph::new(
         metadata,
         session.open_record_cursor(&index_params.graph_table_name)?,

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -98,7 +98,7 @@ where
     where
         P: Fn(),
     {
-        let session = self.wt_params.connection.open_session()?;
+        let mut session = self.wt_params.connection.open_session()?;
         let mut sum = vec![0.0; self.metadata.dimensions.get()];
         session.bulk_load(
             &self.wt_params.nav_table_name,
@@ -153,7 +153,7 @@ where
                 // objects to be Send + Sync, but Session is only Send and wrapping it in a Mutex does not
                 // work because any RecordCursor objects returned have to be destroyed before the Mutex is
                 // released.
-                let session = self.wt_params.connection.open_session()?;
+                let mut session = self.wt_params.connection.open_session()?;
                 let mut nav = WiredTigerNavVectorStore::new(
                     session
                         .open_record_cursor(&self.wt_params.nav_table_name)
@@ -239,7 +239,7 @@ where
                     .to_vec(),
             ),
         ];
-        let session = self.wt_params.connection.open_session()?;
+        let mut session = self.wt_params.connection.open_session()?;
         session.bulk_load(
             &self.wt_params.graph_table_name,
             None,

--- a/src/wt.rs
+++ b/src/wt.rs
@@ -30,18 +30,18 @@ impl WiredTigerIndexParams {
     }
 }
 
-/// Implementation of NavVectorStore that reads from a WiredTiger `RecordCursor``.
-pub struct WiredTigerNavVectorStore<'a> {
-    cursor: RecordCursor<'a>,
+/// Implementation of NavVectorStore that reads from a WiredTiger `RecordCursor`.
+pub struct WiredTigerNavVectorStore {
+    cursor: RecordCursor,
 }
 
-impl<'a> WiredTigerNavVectorStore<'a> {
-    pub fn new(cursor: RecordCursor<'a>) -> Self {
+impl WiredTigerNavVectorStore {
+    pub fn new(cursor: RecordCursor) -> Self {
         Self { cursor }
     }
 }
 
-impl<'a> NavVectorStore for WiredTigerNavVectorStore<'a> {
+impl NavVectorStore for WiredTigerNavVectorStore {
     fn get(&mut self, node: i64) -> Option<Result<Cow<'_, [u8]>>> {
         Some(unsafe { self.cursor.seek_exact_unsafe(node)? }.map(RecordView::into_inner_value))
     }
@@ -123,18 +123,18 @@ impl<'a> Iterator for WiredTigerEdgeIterator<'a> {
 }
 
 /// Implementation of `Graph` that reads from a WiredTiger `RecordCursor`.
-pub struct WiredTigerGraph<'a> {
+pub struct WiredTigerGraph {
     metadata: GraphMetadata,
-    cursor: RecordCursor<'a>,
+    cursor: RecordCursor,
 }
 
-impl<'a> WiredTigerGraph<'a> {
-    pub fn new(metadata: GraphMetadata, cursor: RecordCursor<'a>) -> Self {
+impl WiredTigerGraph {
+    pub fn new(metadata: GraphMetadata, cursor: RecordCursor) -> Self {
         Self { metadata, cursor }
     }
 }
 
-impl<'a> Graph for WiredTigerGraph<'a> {
+impl Graph for WiredTigerGraph {
     type Node<'c> = WiredTigerGraphNode<'c> where Self: 'c;
 
     fn entry_point(&mut self) -> Option<i64> {

--- a/src/wt.rs
+++ b/src/wt.rs
@@ -159,7 +159,7 @@ pub fn read_graph_metadata(
     connection: Arc<Connection>,
     graph_table_name: &str,
 ) -> io::Result<GraphMetadata> {
-    let session = connection.open_session()?;
+    let mut session = connection.open_session()?;
     let mut cursor = session.open_record_cursor(graph_table_name)?;
     let metadata_json = unsafe { cursor.seek_exact_unsafe(METADATA_KEY) }
         .unwrap_or(Err(Error::WiredTiger(WiredTigerError::NotFound)))?;

--- a/wt_mdb/src/connection.rs
+++ b/wt_mdb/src/connection.rs
@@ -84,7 +84,7 @@ impl Connection {
 
     /// Create a new `Session`. These can be used to obtain cursors to read and write data
     /// as well as manage transaction.
-    pub fn open_session(self: &Arc<Self>) -> Result<Session> {
+    pub fn open_session(self: &Arc<Self>) -> Result<Arc<Session>> {
         let mut sessionp: *mut WT_SESSION = ptr::null_mut();
         let result: i32;
         unsafe {
@@ -95,7 +95,7 @@ impl Connection {
                 &mut sessionp,
             );
         }
-        wrap_ptr_create(result, sessionp).map(|session| Session::new(session, self))
+        wrap_ptr_create(result, sessionp).map(|session| Arc::new(Session::new(session, self)))
     }
 
     /// Close this database connection.

--- a/wt_mdb/src/lib.rs
+++ b/wt_mdb/src/lib.rs
@@ -160,7 +160,7 @@ mod test {
     fn insert_and_iterate() {
         let tmpdir = tempfile::tempdir().unwrap();
         let conn = Connection::open(tmpdir.path().to_str().unwrap(), conn_options()).unwrap();
-        let session = conn.open_session().unwrap();
+        let mut session = conn.open_session().unwrap();
         session.create_record_table("test", None).unwrap();
         let mut cursor = session.open_record_cursor("test").unwrap();
         assert_eq!(cursor.set(&RecordView::new(11, b"bar")), Ok(()));
@@ -174,7 +174,7 @@ mod test {
     fn insert_and_search() {
         let tmpdir = tempfile::tempdir().unwrap();
         let conn = Connection::open(tmpdir.path().to_str().unwrap(), conn_options()).unwrap();
-        let session = conn.open_session().unwrap();
+        let mut session = conn.open_session().unwrap();
         session.create_record_table("test", None).unwrap();
         let mut cursor = session.open_record_cursor("test").unwrap();
         let value: &[u8] = b"bar";
@@ -188,7 +188,7 @@ mod test {
     fn insert_and_remove() {
         let tmpdir = tempfile::tempdir().unwrap();
         let conn = Connection::open(tmpdir.path().to_str().unwrap(), conn_options()).unwrap();
-        let session = conn.open_session().unwrap();
+        let mut session = conn.open_session().unwrap();
         session.create_record_table("test", None).unwrap();
         let mut cursor = session.open_record_cursor("test").unwrap();
         assert_eq!(cursor.set(&RecordView::new(11, b"bar")), Ok(()));
@@ -206,7 +206,7 @@ mod test {
     fn largest_key() {
         let tmpdir = tempfile::tempdir().unwrap();
         let conn = Connection::open(tmpdir.path().to_str().unwrap(), conn_options()).unwrap();
-        let session = conn.open_session().unwrap();
+        let mut session = conn.open_session().unwrap();
         session.create_record_table("test", None).unwrap();
         let mut cursor = session.open_record_cursor("test").unwrap();
         assert_eq!(cursor.largest_key(), None);
@@ -220,9 +220,9 @@ mod test {
     fn transaction_commit() {
         let tmpdir = tempfile::tempdir().unwrap();
         let conn = Connection::open(tmpdir.path().to_str().unwrap(), conn_options()).unwrap();
-        let session = conn.open_session().unwrap();
+        let mut session = conn.open_session().unwrap();
         session.create_record_table("test", None).unwrap();
-        let read_session = conn.open_session().unwrap();
+        let mut read_session = conn.open_session().unwrap();
         let mut read_cursor = read_session.open_record_cursor("test").unwrap();
 
         let mut cursor = session.open_record_cursor("test").unwrap();
@@ -239,7 +239,7 @@ mod test {
     fn transaction_rollback() {
         let tmpdir = tempfile::tempdir().unwrap();
         let conn = Connection::open(tmpdir.path().to_str().unwrap(), conn_options()).unwrap();
-        let session = conn.open_session().unwrap();
+        let mut session = conn.open_session().unwrap();
         session.create_record_table("test", None).unwrap();
 
         let mut cursor = session.open_record_cursor("test").unwrap();
@@ -254,7 +254,7 @@ mod test {
     fn bulk_load() {
         let tmpdir = tempfile::tempdir().unwrap();
         let conn = Connection::open(tmpdir.path().to_str().unwrap(), conn_options()).unwrap();
-        let session = conn.open_session().unwrap();
+        let mut session = conn.open_session().unwrap();
 
         // Create Vec<Record>, bulk_load() into session, compare cursors.
         let records = vec![
@@ -277,7 +277,7 @@ mod test {
     fn bulk_load_existing_table() {
         let tmpdir = tempfile::tempdir().unwrap();
         let conn = Connection::open(tmpdir.path().to_str().unwrap(), conn_options()).unwrap();
-        let session = conn.open_session().unwrap();
+        let mut session = conn.open_session().unwrap();
 
         // Bulk load will happily load into an empty table, so to get it to fail we insert a record.
         assert_eq!(session.create_record_table("test", None), Ok(()));
@@ -293,7 +293,7 @@ mod test {
     fn bulk_load_out_of_order() {
         let tmpdir = tempfile::tempdir().unwrap();
         let conn = Connection::open(tmpdir.path().to_str().unwrap(), conn_options()).unwrap();
-        let session = conn.open_session().unwrap();
+        let mut session = conn.open_session().unwrap();
 
         assert_eq!(
             session.bulk_load(

--- a/wt_mdb/src/session.rs
+++ b/wt_mdb/src/session.rs
@@ -216,12 +216,12 @@ impl Session {
     }
 
     /// Open a record cursor over the named table.
-    pub fn open_record_cursor(&self, table_name: &str) -> Result<RecordCursor> {
+    pub fn open_record_cursor(self: &Arc<Self>, table_name: &str) -> Result<RecordCursor> {
         self.open_record_cursor_with_options(table_name, None)
     }
 
     fn open_record_cursor_with_options(
-        &self,
+        self: &Arc<Self>,
         table_name: &str,
         options: Option<&CStr>,
     ) -> Result<RecordCursor> {
@@ -311,7 +311,7 @@ impl Session {
     /// Bulk load requires that `table_name` not exist or be empty and that `iter` yields records in
     /// order by `key()`.
     pub fn bulk_load<'a, I>(
-        &self,
+        self: &Arc<Self>,
         table_name: &str,
         options: Option<CreateOptions>,
         iter: I,

--- a/wt_mdb/src/session.rs
+++ b/wt_mdb/src/session.rs
@@ -182,6 +182,9 @@ impl Drop for InnerSession {
 // XXX FIXME members should not be public
 // XXX PhantomData<Cell<()>> should force this to be !Sync. Not sure if this matters
 // since all non-trivial methods are mut.
+// XXX alternatives: make methods &self, use Arc<Mutex<InnerSession>>, eat locking for
+// every single method call. Then RecordCursor would be able to manufacture a Session
+// if desired and it would be safe to use.
 pub struct Session(pub(crate) Arc<InnerSession>);
 
 impl Session {

--- a/wt_mdb/src/session.rs
+++ b/wt_mdb/src/session.rs
@@ -156,7 +156,6 @@ impl From<RollbackTransactionOptionsBuilder> for RollbackTransactionOptions {
 ///
 /// Mark this as Send+Sync so it can used from an Arc, but we mark the parent Session
 /// as !Sync so that it cannot be used directly from multiple threads.
-// XXX move Record to a separate module and move RecordCursor in here.
 pub(crate) struct InnerSession {
     ptr: NonNull<WT_SESSION>,
     conn: Arc<Connection>,
@@ -179,17 +178,10 @@ impl Drop for InnerSession {
 ///
 /// Sessions are used to create cursors to view and mutate data and manage
 /// transaction state.
-// XXX FIXME members should not be public
-// XXX PhantomData<Cell<()>> should force this to be !Sync. Not sure if this matters
-// since all non-trivial methods are mut.
-// XXX alternatives: make methods &self, use Arc<Mutex<InnerSession>>, eat locking for
-// every single method call. Then RecordCursor would be able to manufacture a Session
-// if desired and it would be safe to use.
-pub struct Session(pub(crate) Arc<InnerSession>);
+pub struct Session(Arc<InnerSession>);
 
 impl Session {
     pub(crate) fn new(session: NonNull<WT_SESSION>, connection: &Arc<Connection>) -> Self {
-        // XXX new problem dropped: Arc<InnerSession> is not Send either.
         Self(Arc::new(InnerSession {
             ptr: session,
             conn: connection.clone(),

--- a/wt_mdb/src/session.rs
+++ b/wt_mdb/src/session.rs
@@ -154,8 +154,11 @@ impl From<RollbackTransactionOptionsBuilder> for RollbackTransactionOptions {
 
 /// Inner state of a `Session`.
 ///
-/// Mark this as Send+Sync so it can used from an Arc, but we mark the parent Session
-/// as !Sync so that it cannot be used directly from multiple threads.
+/// Mark this as Send+Sync so it can use meaningfully from an Arc.
+/// *Safety*
+/// - Session has an Arc<InnerCursor> but only access it through mut methods, ensuring that
+///   we will not have concurrent access.
+/// - RecordCursor has an Arc<InnerCursor> reference but does not use it.
 pub(crate) struct InnerSession {
     ptr: NonNull<WT_SESSION>,
     conn: Arc<Connection>,


### PR DESCRIPTION
`RecordCursor` lifetimes make it more difficult to build other templated abstractions.

In order to make this work we have a reference counted internal session that is distinct from `Session`.
Each `RecordCursor` takes a reference to the inner session to ensure that the underlying `WT_SESSION`
remains alive so long as there are any open cursors. We need to use `Arc` to support sending `Session`
across threads, which also means that the inner session must be `Send + Sync` which also causes
`Session` to be `Send + Sync`. Make most `Session` methods `&mut` which will prevent use from
multiple threads anyway.

One caveat to this approach is that it is no longer possible to access the `Session` from a `RecordCursor`
since that could be unsound. If this is important we could refactor the representation so that thread-safe
`Session` access is possible via internal `Mutex`.

Remove most public `close()` functions because I'm pretty sure they will leak memory if an error occurs.