### PR TITLE
Introduce `GraphVectorIndexReader` trait to bundle all index functionality

### DIFF
--- a/et/src/lookup.rs
+++ b/et/src/lookup.rs
@@ -2,8 +2,8 @@ use std::{io, sync::Arc};
 
 use clap::Args;
 use easy_tiger::{
-    graph::{Graph, GraphMetadata, GraphNode},
-    wt::{WiredTigerGraph, WiredTigerIndexParams},
+    graph::{Graph, GraphNode},
+    wt::{WiredTigerGraph, WiredTigerGraphVectorIndex},
 };
 use wt_mdb::Connection;
 
@@ -23,14 +23,13 @@ pub struct LookupArgs {
 
 pub fn lookup(
     connection: Arc<Connection>,
-    index_params: WiredTigerIndexParams,
-    metadata: GraphMetadata,
+    index: WiredTigerGraphVectorIndex,
     args: LookupArgs,
 ) -> io::Result<()> {
-    let mut session = connection.open_session().map_err(io::Error::from)?;
+    let mut session = connection.open_session()?;
     let mut graph = WiredTigerGraph::new(
-        metadata,
-        session.open_record_cursor(&index_params.graph_table_name)?,
+        *index.metadata(),
+        session.open_record_cursor(index.graph_table_name())?,
     );
     match graph.get(args.id) {
         None => {

--- a/et/src/main.rs
+++ b/et/src/main.rs
@@ -1,13 +1,10 @@
 mod lookup;
 mod search;
 
-use std::{
-    io::{self, ErrorKind},
-    num::NonZero,
-};
+use std::{io::ErrorKind, num::NonZero};
 
 use clap::{command, Parser, Subcommand};
-use easy_tiger::wt::{WiredTigerGraphVectorIndex, WiredTigerIndexParams};
+use easy_tiger::wt::WiredTigerGraphVectorIndex;
 use lookup::{lookup, LookupArgs};
 use search::{search, SearchArgs};
 use wt_mdb::{options::ConnectionOptionsBuilder, Connection};
@@ -50,11 +47,8 @@ fn main() -> std::io::Result<()> {
                 .cache_size_mb(cli.wiredtiger_cache_size_mb)
                 .into(),
         ),
-    )
-    .map_err(io::Error::from)?;
-    let index_params =
-        WiredTigerIndexParams::new(connection.clone(), &cli.wiredtiger_table_basename);
-    let index = WiredTigerGraphVectorIndex::from_db(index_params)?;
+    )?;
+    let index = WiredTigerGraphVectorIndex::from_db(&connection, &cli.wiredtiger_table_basename)?;
 
     match cli.command {
         Commands::Lookup(args) => lookup(connection, index, args),

--- a/et/src/main.rs
+++ b/et/src/main.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use clap::{command, Parser, Subcommand};
-use easy_tiger::wt::{read_graph_metadata, WiredTigerIndexParams};
+use easy_tiger::wt::{WiredTigerGraphVectorIndex, WiredTigerIndexParams};
 use lookup::{lookup, LookupArgs};
 use search::{search, SearchArgs};
 use wt_mdb::{options::ConnectionOptionsBuilder, Connection};
@@ -54,11 +54,11 @@ fn main() -> std::io::Result<()> {
     .map_err(io::Error::from)?;
     let index_params =
         WiredTigerIndexParams::new(connection.clone(), &cli.wiredtiger_table_basename);
-    let metadata = read_graph_metadata(connection.clone(), &index_params.graph_table_name)?;
+    let index = WiredTigerGraphVectorIndex::from_db(index_params)?;
 
     match cli.command {
-        Commands::Lookup(args) => lookup(connection, index_params, metadata, args),
-        Commands::Search(args) => search(connection, index_params, metadata, args),
+        Commands::Lookup(args) => lookup(connection, index, args),
+        Commands::Search(args) => search(connection, index, args),
         Commands::Add => Err(std::io::Error::from(ErrorKind::Unsupported)),
         Commands::Delete => Err(std::io::Error::from(ErrorKind::Unsupported)),
     }

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -18,7 +18,7 @@ use crate::{
     graph::{Graph, GraphMetadata, GraphNode, GraphVectorIndexReader},
     input::NumpyF32VectorStore,
     quantization::binary_quantize,
-    scoring::{DotProductScorer, F32VectorScorer, VectorScorer},
+    scoring::{DotProductScorer, F32VectorScorer},
     search::GraphSearcher,
     wt::{
         encode_graph_node, WiredTigerIndexParams, WiredTigerNavVectorStore, ENTRY_POINT_KEY,
@@ -330,15 +330,12 @@ where
     /// Prune `edges`, enforcing RNG properties with alpha parameter.
     ///
     /// Returns two slices: one containing the selected nodes and one containing the unselected nodes.
-    fn prune<'a, S>(
+    fn prune<'a>(
         &self,
         edges: &'a mut [Neighbor],
         graph: &mut BulkLoadBuilderGraph<'_, D>,
-        scorer: &S,
-    ) -> Result<(&'a [Neighbor], &'a [Neighbor])>
-    where
-        S: VectorScorer<Elem = f32>,
-    {
+        scorer: &dyn F32VectorScorer,
+    ) -> Result<(&'a [Neighbor], &'a [Neighbor])> {
         if edges.is_empty() {
             return Ok((&[], &[]));
         }

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -18,9 +18,7 @@ use crate::{
     graph::{Graph, GraphMetadata, GraphNode, GraphVectorIndexReader, NavVectorStore},
     input::NumpyF32VectorStore,
     quantization::binary_quantize,
-    scoring::{
-        DotProductScorer, F32VectorScorer, HammingScorer, QuantizedVectorScorer, VectorScorer,
-    },
+    scoring::{DotProductScorer, F32VectorScorer, HammingScorer, VectorScorer},
     search::GraphSearcher,
     wt::{
         encode_graph_node, WiredTigerIndexParams, WiredTigerNavVectorStore, ENTRY_POINT_KEY,
@@ -426,16 +424,12 @@ impl<'a, D> GraphVectorIndexReader for BulkLoadGraphVectorIndexReader<'a, D> {
     type Graph = BulkLoadBuilderGraph<'a, D>;
     type NavVectorStore = WiredTigerNavVectorStore;
 
-    fn scorer(&self) -> Box<dyn F32VectorScorer> {
-        Box::new(DotProductScorer)
+    fn metadata(&self) -> &GraphMetadata {
+        &self.0.metadata
     }
 
     fn graph(&mut self) -> Result<Self::Graph> {
         Ok(BulkLoadBuilderGraph(self.0))
-    }
-
-    fn nav_scorer(&self) -> Box<dyn QuantizedVectorScorer> {
-        Box::new(HammingScorer)
     }
 
     fn nav_vectors(&mut self) -> Result<Self::NavVectorStore> {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, num::NonZero};
 use serde::{Deserialize, Serialize};
 use wt_mdb::Result;
 
-use crate::scoring::{F32VectorScorer, QuantizedVectorScorer};
+use crate::scoring::{DotProductScorer, F32VectorScorer, HammingScorer, QuantizedVectorScorer};
 
 /// Parameters for a search over a Vamana graph.
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]
@@ -21,6 +21,19 @@ pub struct GraphMetadata {
     pub dimensions: NonZero<usize>,
     pub max_edges: NonZero<usize>,
     pub index_search_params: GraphSearchParams,
+}
+
+// TODO: properly parameterize scorer selection.
+impl GraphMetadata {
+    /// Return a scorer for high fidelity vectors in the index.
+    pub fn new_scorer(&self) -> Box<dyn F32VectorScorer> {
+        Box::new(DotProductScorer)
+    }
+
+    /// Return a scorer for quantized navigational vectors in the index.
+    pub fn new_nav_scorer(&self) -> Box<dyn QuantizedVectorScorer> {
+        Box::new(HammingScorer)
+    }
 }
 
 /// A node in the Vamana graph.
@@ -58,21 +71,15 @@ pub trait NavVectorStore {
 }
 
 /// `GraphVectorIndexReader` is used to generate objects for graph navigation.
-// XXX consider providing metadata here and having metadata manufacture scorer.
 pub trait GraphVectorIndexReader {
     type Graph: Graph;
     type NavVectorStore: NavVectorStore;
 
-    /// Return the scorer used for vectors returned by the graph.
-    ///
-    /// This is only used at the reranking step at the end.
-    fn scorer(&self) -> Box<dyn F32VectorScorer>;
+    /// Return metadata for this graph.
+    fn metadata(&self) -> &GraphMetadata;
 
     /// Return an object that can be used to navigate the graph.
     fn graph(&mut self) -> Result<Self::Graph>;
-
-    /// Return the scorer used for navigation vectors.
-    fn nav_scorer(&self) -> Box<dyn QuantizedVectorScorer>;
 
     /// Return an object that can be used to read navigational vectors.
     fn nav_vectors(&mut self) -> Result<Self::NavVectorStore>;

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -16,6 +16,7 @@ pub struct GraphSearchParams {
 }
 
 /// Metadata about graph shape and construction.
+// TODO: rename to GraphConfig.
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct GraphMetadata {
     pub dimensions: NonZero<usize>,

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -97,8 +97,8 @@ pub trait GraphVectorIndex {
     fn scorer(&self) -> Box<dyn F32VectorScorer>;
 
     /// Return an object that can be used to navigate the graph.
-    fn graph(&self) -> Result<Self::Graph>;
+    fn graph(&mut self) -> Result<Self::Graph>;
 
     /// Return an object that can be used to score navigational vectors.
-    fn nav_vectors(&self) -> Result<Self::NavVectorStore>;
+    fn nav_vectors(&mut self) -> Result<Self::NavVectorStore>;
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -23,7 +23,6 @@ pub struct GraphMetadata {
     pub index_search_params: GraphSearchParams,
 }
 
-// TODO: properly parameterize scorer selection.
 impl GraphMetadata {
     /// Return a scorer for high fidelity vectors in the index.
     pub fn new_scorer(&self) -> Box<dyn F32VectorScorer> {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -58,6 +58,7 @@ pub trait NavVectorStore {
 }
 
 /// `GraphVectorIndexReader` is used to generate objects for graph navigation.
+// XXX consider providing metadata here and having metadata manufacture scorer.
 pub trait GraphVectorIndexReader {
     type Graph: Graph;
     type NavVectorStore: NavVectorStore;

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, num::NonZero};
 
 use serde::{Deserialize, Serialize};
-use wt_mdb::{Result, Session};
+use wt_mdb::Result;
 
 use crate::scoring::{F32VectorScorer, QuantizedVectorScorer};
 
@@ -94,12 +94,11 @@ pub trait GraphVectorIndex {
     /// Return the scorer used for vectors returned by the graph.
     ///
     /// This is only used at the reranking step at the end.
-    fn scorer(&self) -> &dyn F32VectorScorer;
+    fn scorer(&self) -> Box<dyn F32VectorScorer>;
 
     /// Return an object that can be used to navigate the graph.
-    // XXX might run into lifetime trouble session -> recordcursor.
-    fn graph(&self, session: &Session) -> Result<Graph>;
+    fn graph(&self) -> Result<Self::Graph>;
 
     /// Return an object that can be used to score navigational vectors.
-    fn nav_vector(&self, session: &Session) -> Result<NavVectorScorer<N>>;
+    fn nav_vectors(&self) -> Result<Self::NavVectorStore>;
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -57,37 +57,8 @@ pub trait NavVectorStore {
     fn get(&mut self, node: i64) -> Option<Result<Cow<'_, [u8]>>>;
 }
 
-pub struct NavVectorScorer<S> {
-    store: S,
-    query: Vec<u8>,
-    scorer: Box<dyn QuantizedVectorScorer>,
-}
-
-impl<S> NavVectorScorer<S>
-where
-    S: NavVectorStore,
-{
-    pub fn new<Q: Into<Vec<u8>>>(
-        store: S,
-        query: Q,
-        scorer: Box<dyn QuantizedVectorScorer>,
-    ) -> Self {
-        Self {
-            store,
-            query: query.into(),
-            scorer,
-        }
-    }
-
-    pub fn score(&mut self, vertex: i64) -> Option<Result<f64>> {
-        self.store
-            .get(vertex)
-            .map(|r| r.map(|v| self.scorer.score(&self.query, v.as_ref())))
-    }
-}
-
-/// `GraphVectorIndex` is used to generate objects for graph navigation.
-pub trait GraphVectorIndex {
+/// `GraphVectorIndexReader` is used to generate objects for graph navigation.
+pub trait GraphVectorIndexReader {
     type Graph: Graph;
     type NavVectorStore: NavVectorStore;
 
@@ -99,6 +70,9 @@ pub trait GraphVectorIndex {
     /// Return an object that can be used to navigate the graph.
     fn graph(&mut self) -> Result<Self::Graph>;
 
-    /// Return an object that can be used to score navigational vectors.
+    /// Return the scorer used for navigation vectors.
+    fn nav_scorer(&self) -> Box<dyn QuantizedVectorScorer>;
+
+    /// Return an object that can be used to read navigational vectors.
     fn nav_vectors(&mut self) -> Result<Self::NavVectorStore>;
 }

--- a/src/scoring.rs
+++ b/src/scoring.rs
@@ -1,11 +1,12 @@
 use simsimd::{BinarySimilarity, SpatialSimilarity};
 
 /// Trait type for a vector scorer.
+// XXX remove this entirely.
 pub trait VectorScorer {
     type Elem;
 
     /// Score vectors `a` and `b` against one another. Returns a score
-    /// where higher values are better matches.
+    /// where larger values are better matches.
     ///
     /// Input vectors must be the same length or this function may panic.
     fn score(&self, a: &[Self::Elem], b: &[Self::Elem]) -> f64;
@@ -13,6 +14,35 @@ pub trait VectorScorer {
     /// Normalize a vector for use with this scoring function.
     /// By default, does nothing.
     fn normalize(&self, _vector: &mut [Self::Elem]) {}
+}
+
+/// Scorer for `f32` vectors.
+///
+/// This trait is object-safe; it may be instantiated at runtime based on
+/// data that appears in a file or other backing store.
+pub trait F32VectorScorer {
+    /// Score vectors `a` and `b` against one another. Returns a score
+    /// where larger values are better matches.
+    ///
+    /// Input vectors must be the same length or this function may panic.
+    fn score(&self, a: &[f32], b: &[f32]) -> f64;
+
+    /// Normalize a vector for use with this scoring function.
+    /// By default, does nothing.
+    fn normalize(&self, _vector: &mut [f32]) {}
+}
+
+/// Scorer for quantized vectors.
+///
+/// This trait is object-safe; it may be instantiated at runtime based on
+/// data that appears in a file or other backing store.
+pub trait QuantizedVectorScorer {
+    /// Score the `query` vector against the `doc` vector. Returns a score
+    /// where larger values are better matches.
+    ///
+    /// This function is not required to be commutative and may panic if
+    /// one of the inputs is misshapen.
+    fn score(&self, query: &[u8], doc: &[u8]) -> f64;
 }
 
 /// Computes a score based on l2 distance.
@@ -23,6 +53,12 @@ impl VectorScorer for EuclideanScorer {
     type Elem = f32;
 
     fn score(&self, a: &[Self::Elem], b: &[Self::Elem]) -> f64 {
+        1f64 / (1f64 + SpatialSimilarity::l2sq(a, b).unwrap())
+    }
+}
+
+impl F32VectorScorer for EuclideanScorer {
+    fn score(&self, a: &[f32], b: &[f32]) -> f64 {
         1f64 / (1f64 + SpatialSimilarity::l2sq(a, b).unwrap())
     }
 }
@@ -47,6 +83,20 @@ impl VectorScorer for DotProductScorer {
     }
 }
 
+impl F32VectorScorer for DotProductScorer {
+    fn score(&self, a: &[f32], b: &[f32]) -> f64 {
+        // Assuming values are normalized, this will produce a score in [0,1]
+        (1f64 + SpatialSimilarity::dot(a, b).unwrap()) / 2f64
+    }
+
+    fn normalize(&self, vector: &mut [f32]) {
+        let norm = SpatialSimilarity::dot(vector, vector).unwrap().sqrt() as f32;
+        for d in vector.iter_mut() {
+            *d /= norm;
+        }
+    }
+}
+
 /// Computes a score from two bitmaps using hamming distance.
 #[derive(Debug, Copy, Clone)]
 pub struct HammingScorer;
@@ -55,6 +105,13 @@ impl VectorScorer for HammingScorer {
     type Elem = u8;
 
     fn score(&self, a: &[Self::Elem], b: &[Self::Elem]) -> f64 {
+        let dim = (a.len() * 8) as f64;
+        (dim - BinarySimilarity::hamming(a, b).unwrap()) / dim
+    }
+}
+
+impl QuantizedVectorScorer for HammingScorer {
+    fn score(&self, a: &[u8], b: &[u8]) -> f64 {
         let dim = (a.len() * 8) as f64;
         (dim - BinarySimilarity::hamming(a, b).unwrap()) / dim
     }

--- a/src/search.rs
+++ b/src/search.rs
@@ -244,11 +244,7 @@ impl<'a> VisitCandidateGuard<'a> {
 mod test {
     use std::num::NonZero;
 
-    use crate::{
-        scoring::DotProductScorer,
-        test::{TestGraphVectorIndex, TestGraphVectorIndexReader},
-        Neighbor,
-    };
+    use crate::{scoring::DotProductScorer, test::TestGraphVectorIndex, Neighbor};
 
     use super::{GraphSearchParams, GraphSearcher};
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -7,7 +7,7 @@ use crate::{
         Graph, GraphMetadata, GraphNode, GraphSearchParams, GraphVectorIndexReader, NavVectorStore,
     },
     quantization::binary_quantize,
-    scoring::VectorScorer,
+    scoring::F32VectorScorer,
     Neighbor,
 };
 
@@ -27,7 +27,7 @@ pub struct TestGraphVectorIndex {
 impl TestGraphVectorIndex {
     pub fn new<S, T, V>(max_edges: NonZero<usize>, scorer: S, iter: T) -> Self
     where
-        S: VectorScorer<Elem = f32>,
+        S: F32VectorScorer,
         T: IntoIterator<Item = V>,
         V: Into<Vec<f32>>,
     {
@@ -73,7 +73,7 @@ impl TestGraphVectorIndex {
         scorer: &S,
     ) -> Vec<i64>
     where
-        S: VectorScorer<Elem = f32>,
+        S: F32VectorScorer,
     {
         let q = &graph[index].vector;
         let mut scored = graph

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,9 +1,11 @@
-use std::{borrow::Cow, num::NonZero, rc::Rc};
+use std::{borrow::Cow, num::NonZero, usize};
 
 use wt_mdb::Result;
 
 use crate::{
-    graph::{Graph, GraphNode, NavVectorStore},
+    graph::{
+        Graph, GraphMetadata, GraphNode, GraphSearchParams, GraphVectorIndexReader, NavVectorStore,
+    },
     quantization::binary_quantize,
     scoring::VectorScorer,
     Neighbor,
@@ -16,10 +18,13 @@ struct TestVector {
     edges: Vec<i64>,
 }
 
-#[derive(Clone, Debug)]
-pub struct TestVectorData(Rc<Vec<TestVector>>);
+#[derive(Debug)]
+pub struct TestGraphVectorIndex {
+    data: Vec<TestVector>,
+    metadata: GraphMetadata,
+}
 
-impl TestVectorData {
+impl TestGraphVectorIndex {
     pub fn new<S, T, V>(max_edges: NonZero<usize>, scorer: S, iter: T) -> Self
     where
         S: VectorScorer<Elem = f32>,
@@ -43,7 +48,22 @@ impl TestVectorData {
         for i in 0..rep.len() {
             rep[i].edges = Self::compute_edges(&rep, i, max_edges, &scorer);
         }
-        TestVectorData(Rc::new(rep))
+        let metadata = GraphMetadata {
+            dimensions: NonZero::new(rep.first().map(|v| v.vector.len()).unwrap_or(1)).unwrap(),
+            max_edges: max_edges,
+            index_search_params: GraphSearchParams {
+                beam_width: NonZero::new(usize::MAX).unwrap(),
+                num_rerank: usize::MAX,
+            },
+        };
+        Self {
+            data: rep,
+            metadata,
+        }
+    }
+
+    pub fn reader(&self) -> TestGraphVectorIndexReader {
+        TestGraphVectorIndexReader(self)
     }
 
     fn compute_edges<S>(
@@ -94,19 +114,33 @@ impl TestVectorData {
 }
 
 #[derive(Debug)]
-pub struct TestGraph(TestVectorData);
+pub struct TestGraphVectorIndexReader<'a>(&'a TestGraphVectorIndex);
 
-impl From<TestVectorData> for TestGraph {
-    fn from(value: TestVectorData) -> Self {
-        TestGraph(value.clone())
+impl<'a> GraphVectorIndexReader for TestGraphVectorIndexReader<'a> {
+    type Graph = TestGraph<'a>;
+    type NavVectorStore = TestNavVectorStore<'a>;
+
+    fn metadata(&self) -> &GraphMetadata {
+        &self.0.metadata
+    }
+
+    fn graph(&mut self) -> Result<Self::Graph> {
+        Ok(TestGraph(self.0))
+    }
+
+    fn nav_vectors(&mut self) -> Result<Self::NavVectorStore> {
+        Ok(TestNavVectorStore(self.0))
     }
 }
 
-impl Graph for TestGraph {
-    type Node<'c> = TestGraphNode<'c>;
+#[derive(Debug)]
+pub struct TestGraph<'a>(&'a TestGraphVectorIndex);
+
+impl<'a> Graph for TestGraph<'a> {
+    type Node<'c> = TestGraphNode<'c> where Self: 'c;
 
     fn entry_point(&mut self) -> Option<i64> {
-        if self.0 .0.is_empty() {
+        if self.0.data.is_empty() {
             None
         } else {
             Some(0)
@@ -114,10 +148,10 @@ impl Graph for TestGraph {
     }
 
     fn get(&mut self, node: i64) -> Option<Result<Self::Node<'_>>> {
-        if node < 0 || node as usize >= self.0 .0.len() {
+        if node < 0 || node as usize >= self.0.data.len() {
             None
         } else {
-            Some(Ok(TestGraphNode(&self.0 .0[node as usize])))
+            Some(Ok(TestGraphNode(&self.0.data[node as usize])))
         }
     }
 }
@@ -137,20 +171,14 @@ impl<'a> GraphNode for TestGraphNode<'a> {
 }
 
 #[derive(Debug)]
-pub struct TestNavVectorStore(TestVectorData);
+pub struct TestNavVectorStore<'a>(&'a TestGraphVectorIndex);
 
-impl From<TestVectorData> for TestNavVectorStore {
-    fn from(value: TestVectorData) -> Self {
-        TestNavVectorStore(value)
-    }
-}
-
-impl NavVectorStore for TestNavVectorStore {
+impl<'a> NavVectorStore for TestNavVectorStore<'a> {
     fn get(&mut self, node: i64) -> Option<Result<Cow<'_, [u8]>>> {
-        if node < 0 || node as usize >= self.0 .0.len() {
+        if node < 0 || node as usize >= self.0.data.len() {
             None
         } else {
-            Some(Ok(Cow::from(&self.0 .0[node as usize].nav_vector)))
+            Some(Ok(Cow::from(&self.0.data[node as usize].nav_vector)))
         }
     }
 }

--- a/src/wt.rs
+++ b/src/wt.rs
@@ -2,10 +2,7 @@ use std::{borrow::Cow, io, num::NonZero, sync::Arc};
 
 use wt_mdb::{Connection, Error, RecordCursor, RecordView, Result, Session, WiredTigerError};
 
-use crate::{
-    graph::{Graph, GraphMetadata, GraphNode, GraphVectorIndexReader, NavVectorStore},
-    scoring::{DotProductScorer, F32VectorScorer, HammingScorer},
-};
+use crate::graph::{Graph, GraphMetadata, GraphNode, GraphVectorIndexReader, NavVectorStore};
 
 // TODO: drop WiredTiger from most of these names, it feels redundant and verbose.
 
@@ -223,8 +220,8 @@ impl GraphVectorIndexReader for WiredTigerGraphVectorIndexReader {
     type Graph = WiredTigerGraph;
     type NavVectorStore = WiredTigerNavVectorStore;
 
-    fn scorer(&self) -> Box<dyn F32VectorScorer> {
-        Box::new(DotProductScorer)
+    fn metadata(&self) -> &GraphMetadata {
+        &self.index.metadata
     }
 
     fn graph(&mut self) -> Result<Self::Graph> {
@@ -233,10 +230,6 @@ impl GraphVectorIndexReader for WiredTigerGraphVectorIndexReader {
             self.session
                 .open_record_cursor(&self.index.index_params.graph_table_name)?,
         ))
-    }
-
-    fn nav_scorer(&self) -> Box<dyn crate::scoring::QuantizedVectorScorer> {
-        Box::new(HammingScorer)
     }
 
     fn nav_vectors(&mut self) -> Result<Self::NavVectorStore> {

--- a/src/wt.rs
+++ b/src/wt.rs
@@ -192,6 +192,13 @@ impl WiredTigerGraphVectorIndex {
         })
     }
 
+    pub fn from_parts(index_params: WiredTigerIndexParams, metadata: GraphMetadata) -> Self {
+        Self {
+            index_params,
+            metadata,
+        }
+    }
+
     /// Return `GraphMetadata` for this index.
     pub fn metadata(&self) -> &GraphMetadata {
         &self.metadata

--- a/src/wt.rs
+++ b/src/wt.rs
@@ -2,7 +2,10 @@ use std::{borrow::Cow, io, num::NonZero, sync::Arc};
 
 use wt_mdb::{Connection, Error, RecordCursor, RecordView, Result, WiredTigerError};
 
-use crate::graph::{Graph, GraphMetadata, GraphNode, NavVectorStore};
+use crate::{
+    graph::{Graph, GraphMetadata, GraphNode, NavVectorStore},
+    scoring::QuantizedVectorScorer,
+};
 
 /// Key in the graph table containing the entry point.
 pub const ENTRY_POINT_KEY: i64 = -1;

--- a/src/wt.rs
+++ b/src/wt.rs
@@ -183,7 +183,7 @@ pub struct WiredTigerGraphVectorIndex {
 impl WiredTigerGraphVectorIndex {
     /// Create a new `WiredTigerGraphVectorIndex` from `index_params`, caching immutable
     /// graph metadata.
-    pub fn new(index_params: WiredTigerIndexParams) -> io::Result<Self> {
+    pub fn from_db(index_params: WiredTigerIndexParams) -> io::Result<Self> {
         let mut session = index_params.connection.open_session()?;
         let mut cursor = session.open_record_cursor(&index_params.graph_table_name)?;
         let metadata_json = unsafe { cursor.seek_exact_unsafe(METADATA_KEY) }

--- a/src/wt.rs
+++ b/src/wt.rs
@@ -169,25 +169,21 @@ pub fn read_graph_metadata(
     serde_json::from_slice(metadata_json.value()).map_err(|e| e.into())
 }
 
-// XXX this doesn't compile and it's not obvious why unconstrained lifetime wtf.
 pub struct WiredTigerGraphVectorIndex {
     index_params: WiredTigerIndexParams,
     metadata: GraphMetadata,
     session: Session,
 }
 
-impl<'a> GraphVectorIndex for WiredTigerGraphVectorIndex
-where
-    Self: 'a,
-{
-    type Graph = WiredTigerGraph<'a>;
-    type NavVectorStore = WiredTigerNavVectorStore<'a>;
+impl GraphVectorIndex for WiredTigerGraphVectorIndex {
+    type Graph = WiredTigerGraph;
+    type NavVectorStore = WiredTigerNavVectorStore;
 
     fn scorer(&self) -> Box<dyn F32VectorScorer> {
         Box::new(DotProductScorer)
     }
 
-    fn graph(&self) -> Result<Self::Graph> {
+    fn graph(&mut self) -> Result<Self::Graph> {
         Ok(WiredTigerGraph::new(
             self.metadata,
             self.session
@@ -195,7 +191,7 @@ where
         ))
     }
 
-    fn nav_vectors(&self) -> Result<Self::NavVectorStore> {
+    fn nav_vectors(&mut self) -> Result<Self::NavVectorStore> {
         Ok(WiredTigerNavVectorStore::new(
             self.session
                 .open_record_cursor(&self.index_params.nav_table_name)?,


### PR DESCRIPTION
This allows us to pass a single object to `GraphSearcher.search()` that generates all the objects we need for
a search, which will allow us to introduce a search mode that parallelizes IO on the graph table.

Refactor the scorer code so that the traits are object-safe and inject this into the search as `Box<dyn [Scorer]>`
so that we can embed the similarity functions in the table itself and create the right objects at runtime.