### PR TITLE
Attach RecordCursor lifetime to underlying Session

### DIFF
--- a/et/src/lookup.rs
+++ b/et/src/lookup.rs
@@ -2,7 +2,7 @@ use std::{io, sync::Arc};
 
 use clap::Args;
 use easy_tiger::{
-    graph::{Graph, GraphNode},
+    graph::{Graph, GraphVertex},
     wt::{WiredTigerGraph, WiredTigerGraphVectorIndex},
 };
 use wt_mdb::Connection;

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -405,18 +405,18 @@ impl<'a, D> BulkLoadGraphVectorIndexReader<'a, D> {
 }
 
 impl<'a, D> GraphVectorIndexReader for BulkLoadGraphVectorIndexReader<'a, D> {
-    type Graph = BulkLoadBuilderGraph<'a, D>;
-    type NavVectorStore = WiredTigerNavVectorStore;
+    type Graph<'b> = BulkLoadBuilderGraph<'b, D> where Self: 'b;
+    type NavVectorStore<'b> = WiredTigerNavVectorStore<'b> where Self: 'b;
 
     fn metadata(&self) -> &GraphMetadata {
         self.0.index.metadata()
     }
 
-    fn graph(&mut self) -> Result<Self::Graph> {
+    fn graph(&self) -> Result<Self::Graph<'_>> {
         Ok(BulkLoadBuilderGraph(self.0))
     }
 
-    fn nav_vectors(&mut self) -> Result<Self::NavVectorStore> {
+    fn nav_vectors(&self) -> Result<Self::NavVectorStore<'_>> {
         Ok(WiredTigerNavVectorStore::new(
             self.1.open_record_cursor(self.0.index.nav_table_name())?,
         ))

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -36,40 +36,6 @@ impl GraphMetadata {
     }
 }
 
-/// A node in the Vamana graph.
-pub trait GraphNode {
-    type EdgeIterator<'a>: Iterator<Item = i64>
-    where
-        Self: 'a;
-
-    /// Access the raw float vector.
-    fn vector(&self) -> Cow<'_, [f32]>;
-
-    /// Access the edges of the graph. These may be returned in an arbitrary order.
-    fn edges(&self) -> Self::EdgeIterator<'_>;
-}
-
-/// A Vamana graph.
-pub trait Graph {
-    type Node<'c>: GraphNode
-    where
-        Self: 'c;
-
-    /// Return the graph entry point, or None if the graph is empty.
-    fn entry_point(&mut self) -> Option<i64>;
-
-    /// Get the contents of a single node.
-    // NB: self is mutable to allow reading from a WT cursor.
-    fn get(&mut self, node: i64) -> Option<Result<Self::Node<'_>>>;
-}
-
-/// Vector store for vectors used to navigate the graph.
-pub trait NavVectorStore {
-    /// Get the navigation vector for a single node.
-    // NB: self is mutable to allow reading from a WT cursor.
-    fn get(&mut self, node: i64) -> Option<Result<Cow<'_, [u8]>>>;
-}
-
 /// `GraphVectorIndexReader` is used to generate objects for graph navigation.
 pub trait GraphVectorIndexReader {
     type Graph<'a>: Graph + 'a
@@ -87,4 +53,37 @@ pub trait GraphVectorIndexReader {
 
     /// Return an object that can be used to read navigational vectors.
     fn nav_vectors(&self) -> Result<Self::NavVectorStore<'_>>;
+}
+
+/// A Vamana graph.
+pub trait Graph {
+    type Vertex<'c>: GraphVertex
+    where
+        Self: 'c;
+
+    /// Return the graph entry point, or None if the graph is empty.
+    fn entry_point(&mut self) -> Option<Result<i64>>;
+
+    /// Get the contents of a single vertex.
+    // NB: self is mutable to allow reading from a WT cursor.
+    fn get(&mut self, vertex_id: i64) -> Option<Result<Self::Vertex<'_>>>;
+}
+
+/// A node in the Vamana graph.
+pub trait GraphVertex {
+    type EdgeIterator<'a>: Iterator<Item = i64>
+    where
+        Self: 'a;
+
+    /// Access the raw float vector.
+    fn vector(&self) -> Cow<'_, [f32]>;
+
+    /// Access the edges of the graph. These may be returned in an arbitrary order.
+    fn edges(&self) -> Self::EdgeIterator<'_>;
+}
+
+/// Vector store for vectors used to navigate the graph.
+pub trait NavVectorStore {
+    /// Get the navigation vector for a single vertex.
+    fn get(&mut self, vertex_id: i64) -> Option<Result<Cow<'_, [u8]>>>;
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -72,15 +72,19 @@ pub trait NavVectorStore {
 
 /// `GraphVectorIndexReader` is used to generate objects for graph navigation.
 pub trait GraphVectorIndexReader {
-    type Graph: Graph;
-    type NavVectorStore: NavVectorStore;
+    type Graph<'a>: Graph + 'a
+    where
+        Self: 'a;
+    type NavVectorStore<'a>: NavVectorStore + 'a
+    where
+        Self: 'a;
 
     /// Return metadata for this graph.
     fn metadata(&self) -> &GraphMetadata;
 
     /// Return an object that can be used to navigate the graph.
-    fn graph(&mut self) -> Result<Self::Graph>;
+    fn graph(&self) -> Result<Self::Graph<'_>>;
 
     /// Return an object that can be used to read navigational vectors.
-    fn nav_vectors(&mut self) -> Result<Self::NavVectorStore>;
+    fn nav_vectors(&self) -> Result<Self::NavVectorStore<'_>>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,20 +16,20 @@ pub mod wt;
 /// In a graph index, score might be relative to another node in the index.
 ///
 /// When compared `Neighbor`s are ordered first in descending order by score,
-/// then in ascending order by node.
+/// then in ascending order by vertex id.
 #[derive(Debug, Copy, Clone)]
 pub struct Neighbor {
-    node: i64,
+    vertex: i64,
     score: f64,
 }
 
 impl Neighbor {
-    pub fn new(node: i64, score: f64) -> Self {
-        Self { node, score }
+    pub fn new(vertex: i64, score: f64) -> Self {
+        Self { vertex, score }
     }
 
-    pub fn node(&self) -> i64 {
-        self.node
+    pub fn vertex(&self) -> i64 {
+        self.vertex
     }
 
     pub fn score(&self) -> f64 {
@@ -39,7 +39,7 @@ impl Neighbor {
 
 impl PartialEq for Neighbor {
     fn eq(&self, other: &Self) -> bool {
-        self.node == other.node && self.score.total_cmp(&other.score).is_eq()
+        self.vertex == other.vertex && self.score.total_cmp(&other.score).is_eq()
     }
 }
 
@@ -55,7 +55,7 @@ impl Ord for Neighbor {
     fn cmp(&self, other: &Self) -> Ordering {
         let c = self.score.total_cmp(&other.score).reverse();
         match c {
-            Ordering::Equal => self.node.cmp(&other.node),
+            Ordering::Equal => self.vertex.cmp(&other.vertex),
             _ => c,
         }
     }

--- a/src/search.rs
+++ b/src/search.rs
@@ -92,7 +92,7 @@ impl GraphSearcher {
 
         while let Some(mut best_candidate) = self.candidates.next_unvisited() {
             let node = graph
-                .get(best_candidate.neighbor().node())
+                .get(best_candidate.neighbor().vertex())
                 .unwrap_or_else(|| Err(Error::WiredTiger(WiredTigerError::NotFound)))?;
             // If we aren't reranking we don't need to copy the actual vector.
             best_candidate.visit(if self.params.num_rerank > 0 {
@@ -122,7 +122,7 @@ impl GraphSearcher {
                 .take(self.params.num_rerank)
                 .map(|c| {
                     Neighbor::new(
-                        c.neighbor.node(),
+                        c.neighbor.vertex(),
                         scorer.score(query, c.vector.as_ref().expect("node visited")),
                     )
                 })

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use crate::{
-    graph::{Graph, GraphNode, GraphSearchParams, GraphVectorIndexReader, NavVectorStore},
+    graph::{Graph, GraphSearchParams, GraphVectorIndexReader, GraphVertex, NavVectorStore},
     quantization::binary_quantize,
     Neighbor,
 };
@@ -74,7 +74,8 @@ impl GraphSearcher {
         let mut graph = reader.graph()?;
         let mut nav = reader.nav_vectors()?;
         let nav_scorer = reader.metadata().new_nav_scorer();
-        let nav_query = if let Some(entry_point) = graph.entry_point() {
+        let nav_query = if let Some(epr) = graph.entry_point() {
+            let entry_point = epr?;
             let nav_query = binary_quantize(query);
             let entry_vector = nav
                 .get(entry_point)

--- a/src/test.rs
+++ b/src/test.rs
@@ -102,15 +102,15 @@ impl TestGraphVectorIndex {
                 break;
             }
 
-            let q = &graph[n.node() as usize].vector;
+            let q = &graph[n.vertex() as usize].vector;
             if !selected
                 .iter()
-                .any(|p| scorer.score(q, &graph[p.node() as usize].vector) > n.score())
+                .any(|p| scorer.score(q, &graph[p.vertex() as usize].vector) > n.score())
             {
                 selected.push(*n);
             }
         }
-        selected.into_iter().map(|n| n.node()).collect()
+        selected.into_iter().map(|n| n.vertex()).collect()
     }
 }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -4,7 +4,8 @@ use wt_mdb::Result;
 
 use crate::{
     graph::{
-        Graph, GraphMetadata, GraphNode, GraphSearchParams, GraphVectorIndexReader, NavVectorStore,
+        Graph, GraphMetadata, GraphSearchParams, GraphVectorIndexReader, GraphVertex,
+        NavVectorStore,
     },
     quantization::binary_quantize,
     scoring::F32VectorScorer,
@@ -137,28 +138,28 @@ impl<'a> GraphVectorIndexReader for TestGraphVectorIndexReader<'a> {
 pub struct TestGraph<'a>(&'a TestGraphVectorIndex);
 
 impl<'a> Graph for TestGraph<'a> {
-    type Node<'c> = TestGraphNode<'c> where Self: 'c;
+    type Vertex<'c> = TestGraphVertex<'c> where Self: 'c;
 
-    fn entry_point(&mut self) -> Option<i64> {
+    fn entry_point(&mut self) -> Option<Result<i64>> {
         if self.0.data.is_empty() {
             None
         } else {
-            Some(0)
+            Some(Ok(0))
         }
     }
 
-    fn get(&mut self, node: i64) -> Option<Result<Self::Node<'_>>> {
-        if node < 0 || node as usize >= self.0.data.len() {
+    fn get(&mut self, vertex_id: i64) -> Option<Result<Self::Vertex<'_>>> {
+        if vertex_id < 0 || vertex_id as usize >= self.0.data.len() {
             None
         } else {
-            Some(Ok(TestGraphNode(&self.0.data[node as usize])))
+            Some(Ok(TestGraphVertex(&self.0.data[vertex_id as usize])))
         }
     }
 }
 
-pub struct TestGraphNode<'a>(&'a TestVector);
+pub struct TestGraphVertex<'a>(&'a TestVector);
 
-impl<'a> GraphNode for TestGraphNode<'a> {
+impl<'a> GraphVertex for TestGraphVertex<'a> {
     type EdgeIterator<'c> = std::iter::Copied<std::slice::Iter<'c, i64>> where Self: 'c;
 
     fn vector(&self) -> Cow<'_, [f32]> {
@@ -174,11 +175,11 @@ impl<'a> GraphNode for TestGraphNode<'a> {
 pub struct TestNavVectorStore<'a>(&'a TestGraphVectorIndex);
 
 impl<'a> NavVectorStore for TestNavVectorStore<'a> {
-    fn get(&mut self, node: i64) -> Option<Result<Cow<'_, [u8]>>> {
-        if node < 0 || node as usize >= self.0.data.len() {
+    fn get(&mut self, vertex_id: i64) -> Option<Result<Cow<'_, [u8]>>> {
+        if vertex_id < 0 || vertex_id as usize >= self.0.data.len() {
             None
         } else {
-            Some(Ok(Cow::from(&self.0.data[node as usize].nav_vector)))
+            Some(Ok(Cow::from(&self.0.data[vertex_id as usize].nav_vector)))
         }
     }
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -117,18 +117,18 @@ impl TestGraphVectorIndex {
 pub struct TestGraphVectorIndexReader<'a>(&'a TestGraphVectorIndex);
 
 impl<'a> GraphVectorIndexReader for TestGraphVectorIndexReader<'a> {
-    type Graph = TestGraph<'a>;
-    type NavVectorStore = TestNavVectorStore<'a>;
+    type Graph<'b> = TestGraph<'b> where Self: 'b;
+    type NavVectorStore<'b> = TestNavVectorStore<'b> where Self: 'b;
 
     fn metadata(&self) -> &GraphMetadata {
         &self.0.metadata
     }
 
-    fn graph(&mut self) -> Result<Self::Graph> {
+    fn graph(&self) -> Result<Self::Graph<'_>> {
         Ok(TestGraph(self.0))
     }
 
-    fn nav_vectors(&mut self) -> Result<Self::NavVectorStore> {
+    fn nav_vectors(&self) -> Result<Self::NavVectorStore<'_>> {
         Ok(TestNavVectorStore(self.0))
     }
 }

--- a/src/wt.rs
+++ b/src/wt.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, io, num::NonZero, sync::Arc};
 
 use wt_mdb::{Connection, Error, RecordCursor, RecordView, Result, Session, WiredTigerError};
 
-use crate::graph::{Graph, GraphMetadata, GraphNode, GraphVectorIndexReader, NavVectorStore};
+use crate::graph::{Graph, GraphMetadata, GraphVectorIndexReader, GraphVertex, NavVectorStore};
 
 // TODO: drop WiredTiger from most of these names, it feels redundant and verbose.
 
@@ -23,18 +23,18 @@ impl<'a> WiredTigerNavVectorStore<'a> {
 }
 
 impl<'a> NavVectorStore for WiredTigerNavVectorStore<'a> {
-    fn get(&mut self, node: i64) -> Option<Result<Cow<'_, [u8]>>> {
-        Some(unsafe { self.cursor.seek_exact_unsafe(node)? }.map(RecordView::into_inner_value))
+    fn get(&mut self, vertex_id: i64) -> Option<Result<Cow<'_, [u8]>>> {
+        Some(unsafe { self.cursor.seek_exact_unsafe(vertex_id)? }.map(RecordView::into_inner_value))
     }
 }
 
-/// Implementation of GraphNode that reads from an encoded value in a WiredTiger record table.
-pub struct WiredTigerGraphNode<'a> {
+/// Implementation of GraphVertex that reads from an encoded value in a WiredTiger record table.
+pub struct WiredTigerGraphVertex<'a> {
     dimensions: NonZero<usize>,
     data: Cow<'a, [u8]>,
 }
 
-impl<'a> WiredTigerGraphNode<'a> {
+impl<'a> WiredTigerGraphVertex<'a> {
     pub fn new(metadata: &GraphMetadata, data: Cow<'a, [u8]>) -> Self {
         Self {
             dimensions: metadata.dimensions,
@@ -58,7 +58,7 @@ impl<'a> WiredTigerGraphNode<'a> {
     }
 }
 
-impl<'a> GraphNode for WiredTigerGraphNode<'a> {
+impl<'a> GraphVertex for WiredTigerGraphVertex<'a> {
     type EdgeIterator<'c> = WiredTigerEdgeIterator<'c> where Self: 'c;
 
     fn vector(&self) -> Cow<'_, [f32]> {
@@ -116,21 +116,17 @@ impl<'a> WiredTigerGraph<'a> {
 }
 
 impl<'a> Graph for WiredTigerGraph<'a> {
-    type Node<'c> = WiredTigerGraphNode<'c> where Self: 'c;
+    type Vertex<'c> = WiredTigerGraphVertex<'c> where Self: 'c;
 
-    fn entry_point(&mut self) -> Option<i64> {
-        // TODO: handle errors better here. This probably requires changing the trait signature.
+    fn entry_point(&mut self) -> Option<Result<i64>> {
         let result = unsafe { self.cursor.seek_exact_unsafe(ENTRY_POINT_KEY)? };
-        Some(
-            result
-                .map(|r| i64::from_le_bytes(r.value().try_into().unwrap()))
-                .unwrap_or(0),
-        )
+        Some(result.map(|r| i64::from_le_bytes(r.value().try_into().unwrap())))
     }
 
-    fn get(&mut self, node: i64) -> Option<Result<Self::Node<'_>>> {
-        let r = unsafe { self.cursor.seek_exact_unsafe(node)? }.map(RecordView::into_inner_value);
-        Some(r.map(|r| WiredTigerGraphNode::new(&self.metadata, r)))
+    fn get(&mut self, vertex_id: i64) -> Option<Result<Self::Vertex<'_>>> {
+        let r =
+            unsafe { self.cursor.seek_exact_unsafe(vertex_id)? }.map(RecordView::into_inner_value);
+        Some(r.map(|r| WiredTigerGraphVertex::new(&self.metadata, r)))
     }
 }
 

--- a/wt_mdb/src/session.rs
+++ b/wt_mdb/src/session.rs
@@ -270,15 +270,6 @@ impl Drop for InnerCursor {
     }
 }
 
-impl Default for InnerCursor {
-    fn default() -> Self {
-        Self {
-            ptr: NonNull::dangling(),
-            uri: TableUri::default(),
-        }
-    }
-}
-
 /// A `RecordCursor` facilities viewing and mutating data in a WiredTiger table where
 /// the table is `i64` keyed and byte-string valued.
 pub struct RecordCursor<'a> {

--- a/wt_mdb/src/session.rs
+++ b/wt_mdb/src/session.rs
@@ -5,7 +5,6 @@ use std::{
     num::NonZero,
     ops::{Deref, DerefMut},
     ptr::{self, NonNull},
-    rc::Rc,
     slice,
     sync::Arc,
 };
@@ -21,28 +20,6 @@ use crate::{
     },
     wrap_ptr_create, Error, Record, RecordView, Result,
 };
-
-/// Inner state of a `Session`.
-///
-/// Mark this as Send+Sync so it can use meaningfully from an Arc.
-/// *Safety*
-/// - Session has an Arc<InnerCursor> but only access it through mut methods, ensuring that
-///   we will not have concurrent access.
-/// - RecordCursor has an Arc<InnerCursor> reference but does not use it.
-struct InnerSession {
-    ptr: NonNull<WT_SESSION>,
-    conn: Arc<Connection>,
-}
-
-/// Close the underlying WiredTiger session.
-impl Drop for InnerSession {
-    fn drop(&mut self) {
-        // TODO: print something if this returns an error.
-        // I would not expect this to happen as we have structure things to guarantee that
-        // `InnerSession` is only dropped when all cursors are closed.
-        unsafe { self.ptr.as_ref().close.unwrap()(self.ptr.as_ptr(), std::ptr::null()) };
-    }
-}
 
 /// URI of a WT table encoded as a CString.
 #[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -68,89 +45,27 @@ impl From<&str> for TableUri {
     }
 }
 
-/// Inner representation of a cursor.
-///
-/// This inner representation is used by RecordCursor but also may be cached by Session.
-struct InnerCursor {
-    ptr: NonNull<WT_CURSOR>,
-    uri: TableUri,
-}
-
-impl Drop for InnerCursor {
-    fn drop(&mut self) {
-        // TODO: log this.
-        let _ = unsafe { self.ptr.as_ref().close.unwrap()(self.ptr.as_ptr()) };
-    }
-}
-
-impl Default for InnerCursor {
-    fn default() -> Self {
-        Self {
-            ptr: NonNull::dangling(),
-            uri: TableUri::default(),
-        }
-    }
-}
-
-pub struct RecordCursorGuard<'a> {
-    session: &'a Session,
-    // On drop we will take the value and return it to session.
-    cursor: ManuallyDrop<RecordCursor>,
-}
-
-impl<'a> RecordCursorGuard<'a> {
-    fn new(session: &'a Session, cursor: RecordCursor) -> Self {
-        Self {
-            session,
-            cursor: ManuallyDrop::new(cursor),
-        }
-    }
-}
-
-impl<'a> Deref for RecordCursorGuard<'a> {
-    type Target = RecordCursor;
-
-    fn deref(&self) -> &Self::Target {
-        &self.cursor
-    }
-}
-
-impl<'a> DerefMut for RecordCursorGuard<'a> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.cursor
-    }
-}
-
-impl<'a> Drop for RecordCursorGuard<'a> {
-    fn drop(&mut self) {
-        // Safety: we never intend to allow RecordCursorGuard to drop the value.
-        self.session
-            .return_record_cursor(unsafe { ManuallyDrop::take(&mut self.cursor) });
-    }
-}
-
 /// A WiredTiger session.
 ///
 /// Sessions are used to create cursors to view and mutate data and manage transaction state.
 pub struct Session {
-    inner: Rc<InnerSession>,
+    ptr: NonNull<WT_SESSION>,
+    connection: Arc<Connection>,
     cached_cursors: RefCell<Vec<InnerCursor>>,
 }
 
 impl Session {
     pub(crate) fn new(session: NonNull<WT_SESSION>, connection: &Arc<Connection>) -> Self {
         Self {
-            inner: Rc::new(InnerSession {
-                ptr: session,
-                conn: connection.clone(),
-            }),
+            ptr: session,
+            connection: connection.clone(),
             cached_cursors: RefCell::new(vec![]),
         }
     }
 
     /// Return the `Connection` this session belongs to.
     pub fn connection(&self) -> &Arc<Connection> {
-        &self.inner.conn
+        &self.connection
     }
 
     /// Create a new record table.
@@ -162,8 +77,8 @@ impl Session {
         let uri = TableUri::from(table_name);
         unsafe {
             make_result(
-                (self.inner.ptr.as_ref().create.unwrap())(
-                    self.inner.ptr.as_ptr(),
+                (self.ptr.as_ref().create.unwrap())(
+                    self.ptr.as_ptr(),
                     uri.as_ptr(),
                     config.unwrap_or_default().as_config_ptr(),
                 ),
@@ -180,8 +95,8 @@ impl Session {
         let uri = TableUri::from(table_name);
         unsafe {
             make_result(
-                self.inner.ptr.as_ref().drop.unwrap()(
-                    self.inner.ptr.as_ptr(),
+                self.ptr.as_ref().drop.unwrap()(
+                    self.ptr.as_ptr(),
                     uri.as_ptr(),
                     config.unwrap_or_default().as_config_ptr(),
                 ),
@@ -204,8 +119,8 @@ impl Session {
         let mut cursorp: *mut WT_CURSOR = ptr::null_mut();
         let result: i32;
         unsafe {
-            result = (self.inner.ptr.as_ref().open_cursor.unwrap())(
-                self.inner.ptr.as_ptr(),
+            result = (self.ptr.as_ref().open_cursor.unwrap())(
+                self.ptr.as_ptr(),
                 uri.0.as_ptr(),
                 ptr::null_mut(),
                 options.map(|s| s.as_ptr()).unwrap_or(std::ptr::null()),
@@ -213,12 +128,10 @@ impl Session {
             );
         }
         wrap_ptr_create(result, cursorp)
-            .map(|ptr| RecordCursor::new(InnerCursor { ptr, uri }, self.inner.clone()))
+            .map(|ptr| RecordCursor::new(InnerCursor { ptr, uri }, self))
     }
 
     /// Get a cached cursor or create a new cursor over `table_name`.
-    // TODO: return a Guard the automatically returns the cursor. We cannot do this yet as the guard would need
-    // a reference, which would prevent us from calling any mutable Session methods (nearly all of them).
     pub fn get_record_cursor(&self, table_name: &str) -> Result<RecordCursorGuard<'_>> {
         let mut cursor_cache = self.cached_cursors.borrow_mut();
         cursor_cache
@@ -226,20 +139,15 @@ impl Session {
             .position(|c| c.uri.table_name().to_bytes() == table_name.as_bytes())
             .map(|i| {
                 let inner = cursor_cache.remove(i);
-                Ok(RecordCursor::new(inner, self.inner.clone()))
+                Ok(RecordCursor::new(inner, self))
             })
             .unwrap_or_else(|| self.open_record_cursor(table_name))
             .map(|c| RecordCursorGuard::new(self, c))
     }
 
     /// Return a `RecordCursor` to the cache for future re-use.
-    // XXX remove me
     pub fn return_record_cursor(&self, cursor: RecordCursor) {
-        self.return_record_cursor_internal(cursor.into_inner());
-    }
-
-    fn return_record_cursor_internal(&self, cursor: InnerCursor) {
-        self.cached_cursors.borrow_mut().push(cursor)
+        self.cached_cursors.borrow_mut().push(cursor.into_inner())
     }
 
     /// Remove all cached cursors.
@@ -258,8 +166,8 @@ impl Session {
     pub fn begin_transaction(&self, options: Option<&BeginTransactionOptions>) -> Result<()> {
         unsafe {
             make_result(
-                self.inner.ptr.as_ref().begin_transaction.unwrap()(
-                    self.inner.ptr.as_ptr(),
+                self.ptr.as_ref().begin_transaction.unwrap()(
+                    self.ptr.as_ptr(),
                     options.as_config_ptr(),
                 ),
                 (),
@@ -277,8 +185,8 @@ impl Session {
     pub fn commit_transaction(&self, options: Option<&CommitTransactionOptions>) -> Result<()> {
         unsafe {
             make_result(
-                self.inner.ptr.as_ref().commit_transaction.unwrap()(
-                    self.inner.ptr.as_ptr(),
+                self.ptr.as_ref().commit_transaction.unwrap()(
+                    self.ptr.as_ptr(),
                     options.as_config_ptr(),
                 ),
                 (),
@@ -295,8 +203,8 @@ impl Session {
     pub fn rollback_transaction(&self, options: Option<&RollbackTransactionOptions>) -> Result<()> {
         unsafe {
             make_result(
-                self.inner.ptr.as_ref().rollback_transaction.unwrap()(
-                    self.inner.ptr.as_ptr(),
+                self.ptr.as_ref().rollback_transaction.unwrap()(
+                    self.ptr.as_ptr(),
                     options.as_config_ptr(),
                 ),
                 (),
@@ -327,39 +235,57 @@ impl Session {
 
     /// Reset this session, which also resets any outstanding cursors.
     pub fn reset(&self) -> Result<()> {
-        unsafe {
-            make_result(
-                self.inner.ptr.as_ref().reset.unwrap()(self.inner.ptr.as_ptr()),
-                (),
-            )
-        }
+        unsafe { make_result(self.ptr.as_ref().reset.unwrap()(self.ptr.as_ptr()), ()) }
     }
 }
 
 impl Drop for Session {
     fn drop(&mut self) {
+        // Empty the cursor cache otherwise closing the session may fail.
         self.clear_cursor_cache();
+        // TODO: print something if this returns an error.
+        unsafe { self.ptr.as_ref().close.unwrap()(self.ptr.as_ptr(), std::ptr::null()) };
+    }
+}
+
+/// Inner representation of a cursor.
+///
+/// This inner representation is used by RecordCursor but also may be cached by Session.
+struct InnerCursor {
+    ptr: NonNull<WT_CURSOR>,
+    uri: TableUri,
+}
+
+impl Drop for InnerCursor {
+    fn drop(&mut self) {
+        // TODO: log this.
+        let _ = unsafe { self.ptr.as_ref().close.unwrap()(self.ptr.as_ptr()) };
+    }
+}
+
+impl Default for InnerCursor {
+    fn default() -> Self {
+        Self {
+            ptr: NonNull::dangling(),
+            uri: TableUri::default(),
+        }
     }
 }
 
 /// A `RecordCursor` facilities viewing and mutating data in a WiredTiger table where
 /// the table is `i64` keyed and byte-string valued.
-pub struct RecordCursor {
+pub struct RecordCursor<'a> {
     inner: InnerCursor,
-    // Ref the InnerSession, *DO NOT USE*.
-    //
-    // We maintain this reference to ensure that the underlying WT_SESSION outlives this cursor.
-    //
-    // TODO: switch to maintaining a lifetime.
-    _session: Rc<InnerSession>,
+    session: &'a Session,
 }
 
-impl RecordCursor {
-    fn new(inner: InnerCursor, session: Rc<InnerSession>) -> Self {
-        Self {
-            inner,
-            _session: session,
-        }
+impl<'a> RecordCursor<'a> {
+    fn new(inner: InnerCursor, session: &'a Session) -> Self {
+        Self { inner, session }
+    }
+
+    pub fn session(&self) -> &Session {
+        self.session
     }
 
     /// Returns the name of the table.
@@ -521,7 +447,7 @@ impl RecordCursor {
     }
 }
 
-impl Iterator for RecordCursor {
+impl<'a> Iterator for RecordCursor<'a> {
     type Item = Result<Record>;
 
     /// Advance and return the next record.
@@ -529,5 +455,42 @@ impl Iterator for RecordCursor {
     /// If this cursor is unpositioned, returns to the start of the collection.
     fn next(&mut self) -> Option<Self::Item> {
         unsafe { self.next_unsafe() }.map(|r| r.map(RecordView::to_owned))
+    }
+}
+
+pub struct RecordCursorGuard<'a> {
+    session: &'a Session,
+    // On drop we will take the value and return it to session.
+    cursor: ManuallyDrop<RecordCursor<'a>>,
+}
+
+impl<'a> RecordCursorGuard<'a> {
+    fn new(session: &'a Session, cursor: RecordCursor<'a>) -> Self {
+        Self {
+            session,
+            cursor: ManuallyDrop::new(cursor),
+        }
+    }
+}
+
+impl<'a> Deref for RecordCursorGuard<'a> {
+    type Target = RecordCursor<'a>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.cursor
+    }
+}
+
+impl<'a> DerefMut for RecordCursorGuard<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.cursor
+    }
+}
+
+impl<'a> Drop for RecordCursorGuard<'a> {
+    fn drop(&mut self) {
+        // Safety: we never intend to allow RecordCursorGuard to drop the value.
+        self.session
+            .return_record_cursor(unsafe { ManuallyDrop::take(&mut self.cursor) });
     }
 }


### PR DESCRIPTION
This is part 2 of 3 to implement intra-query in graph search.

Mark `Session` as `Send` -- in practice this can only be used if there are no outstanding cursors, although this
is less of an impediment given the new cursor caching mechanisms.

Fix various graph related traits to accept lifetimes, which is the reason that `RecordCursor` lifetimes were removed
in the first place.

Rename uses of 'node' to 'vertex' to minimize confusion as node is heavily overloaded.

Part 3 will provide a separate trait for concurrent lookups, a WT implementation of that trait, and a concurrent
search implementation.