### PR TITLE
Add call to restrict `RecordCursor` bounds

### DIFF
--- a/wt_mdb/src/connection.rs
+++ b/wt_mdb/src/connection.rs
@@ -1,6 +1,8 @@
 use crate::{
-    options::ConfigurationString, options::ConnectionOptions, session::Session, wrap_ptr_create,
-    Result,
+    make_result,
+    options::{ConfigurationString, ConnectionOptions},
+    session::Session,
+    wt_call, Error, Result,
 };
 use std::{
     ffi::CString,
@@ -21,32 +23,38 @@ impl Connection {
     pub fn open(filename: &str, options: Option<ConnectionOptions>) -> Result<Arc<Self>> {
         let mut connp: *mut WT_CONNECTION = ptr::null_mut();
         let dbpath = CString::new(filename).unwrap();
-        let result: i32;
-        unsafe {
-            result = wiredtiger_open(
-                dbpath.as_ptr(),
-                ptr::null_mut(),
-                options.unwrap_or_default().as_config_ptr(),
-                &mut connp,
-            );
-        };
-        wrap_ptr_create(result, connp).map(|conn| Arc::new(Connection(conn)))
+        make_result(
+            unsafe {
+                wiredtiger_open(
+                    dbpath.as_ptr(),
+                    ptr::null_mut(),
+                    options.unwrap_or_default().as_config_ptr(),
+                    &mut connp,
+                )
+            },
+            (),
+        )?;
+        NonNull::new(connp)
+            .ok_or(Error::generic_error())
+            .map(|conn| Arc::new(Connection(conn)))
     }
 
     /// Create a new `Session`. These can be used to obtain cursors to read and write data
     /// as well as manage transaction.
     pub fn open_session(self: &Arc<Self>) -> Result<Session> {
         let mut sessionp: *mut WT_SESSION = ptr::null_mut();
-        let result: i32;
         unsafe {
-            result = (self.0.as_ref().open_session.unwrap())(
-                self.0.as_ptr(),
-                ptr::null_mut(),
-                ptr::null(),
-                &mut sessionp,
-            );
-        }
-        wrap_ptr_create(result, sessionp).map(|session| Session::new(session, self))
+            wt_call!(
+                self.0,
+                open_session,
+                std::ptr::null_mut(),
+                std::ptr::null(),
+                &mut sessionp
+            )
+        }?;
+        NonNull::new(sessionp)
+            .ok_or(Error::generic_error())
+            .map(|session| Session::new(session, self))
     }
 }
 
@@ -57,6 +65,6 @@ impl Drop for Connection {
     fn drop(&mut self) {
         // TODO: log something when an error occurs here.
         // This would be unexpected as the connection can't be dropped until all cursors and sessions have also been dropped.
-        unsafe { self.0.as_ref().close.unwrap()(self.0.as_ptr(), std::ptr::null()) };
+        let _ = unsafe { wt_call!(self.0, close, std::ptr::null()) };
     }
 }

--- a/wt_mdb/src/lib.rs
+++ b/wt_mdb/src/lib.rs
@@ -180,6 +180,14 @@ fn make_result<T>(code: i32, value: T) -> Result<T> {
         .unwrap_or(Ok(value))
 }
 
+fn map_not_found<T>(r: Result<T>) -> Option<Result<T>> {
+    if r.as_ref().is_err_and(|e| *e == Error::not_found_error()) {
+        None
+    } else {
+        Some(r)
+    }
+}
+
 const EOPNOTSUPP: i32 = 95;
 
 /// Call a `$func` on the `NonNull` WiredTiger object `$ptr` optionally with some `$args`.

--- a/wt_mdb/src/lib.rs
+++ b/wt_mdb/src/lib.rs
@@ -16,7 +16,6 @@ use std::borrow::Cow;
 use std::ffi::CStr;
 use std::io::ErrorKind;
 use std::num::NonZero;
-use std::ptr::NonNull;
 
 /// WiredTiger specific error codes.
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
@@ -179,11 +178,6 @@ fn make_result<T>(code: i32, value: T) -> Result<T> {
     NonZero::<i32>::new(code)
         .map(|c| Err(Error::from(c)))
         .unwrap_or(Ok(value))
-}
-
-fn wrap_ptr_create<T>(code: i32, ptr: *mut T) -> Result<NonNull<T>> {
-    let p = make_result(code, ptr)?;
-    NonNull::new(p).ok_or(Error::generic_error())
 }
 
 const EOPNOTSUPP: i32 = 95;

--- a/wt_mdb/src/lib.rs
+++ b/wt_mdb/src/lib.rs
@@ -207,7 +207,7 @@ macro_rules! wt_call {
     };
 }
 
-pub(crate) use wt_call;
+use wt_call;
 
 #[cfg(test)]
 mod test {

--- a/wt_mdb/src/session/mod.rs
+++ b/wt_mdb/src/session/mod.rs
@@ -5,7 +5,7 @@ use std::{
     cell::RefCell,
     ffi::{CStr, CString},
     ops::Deref,
-    ptr::{self, NonNull},
+    ptr::NonNull,
     sync::Arc,
 };
 
@@ -119,8 +119,9 @@ impl Session {
         table_name: &str,
         options: Option<&CStr>,
     ) -> Result<RecordCursor> {
+        // XXX heavy overlap with stats cursor
         let uri = TableUri::from(table_name);
-        let mut cursorp: *mut WT_CURSOR = ptr::null_mut();
+        let mut cursorp: *mut WT_CURSOR = std::ptr::null_mut();
         unsafe {
             wt_call!(
                 self.ptr,

--- a/wt_mdb/src/session/mod.rs
+++ b/wt_mdb/src/session/mod.rs
@@ -155,7 +155,8 @@ impl Session {
     }
 
     /// Return a `RecordCursor` to the cache for future re-use.
-    fn return_record_cursor(&self, cursor: RecordCursor) {
+    fn return_record_cursor(&self, mut cursor: RecordCursor) {
+        let _ = cursor.reset();
         self.cached_cursors.borrow_mut().push(cursor.into_inner())
     }
 
@@ -184,7 +185,10 @@ impl Session {
                     self.ptr.as_ptr(),
                     uri.as_ptr(),
                     ptr::null_mut(),
-                    options.as_ref().map(|o| o.as_ptr()).unwrap_or(std::ptr::null()),
+                    options
+                        .as_ref()
+                        .map(|o| o.as_ptr())
+                        .unwrap_or(std::ptr::null()),
                     &mut cursorp,
                 ),
                 cursorp,

--- a/wt_mdb/src/session/record_cursor.rs
+++ b/wt_mdb/src/session/record_cursor.rs
@@ -164,7 +164,26 @@ impl<'a> RecordCursor<'a> {
             },
             (),
         )?;
-        todo!()
+        let end_config_str = match bounds.end_bound() {
+            Bound::Included(key) => {
+                unsafe { self.inner.ptr.as_ref().set_key.unwrap()(self.inner.ptr.as_ptr(), *key) };
+                c"bound=upper,action=set"
+            }
+            Bound::Excluded(key) => {
+                unsafe { self.inner.ptr.as_ref().set_key.unwrap()(self.inner.ptr.as_ptr(), *key) };
+                c"bound=upper,action=set,inclusive=false"
+            }
+            Bound::Unbounded => c"bound=upper,action=clear",
+        };
+        make_result(
+            unsafe {
+                self.inner.ptr.as_ref().bound.unwrap()(
+                    self.inner.ptr.as_ptr(),
+                    end_config_str.as_ptr(),
+                )
+            },
+            (),
+        )
     }
 
     /// Reset the cursor to an unpositioned state.

--- a/wt_mdb/src/session/record_cursor.rs
+++ b/wt_mdb/src/session/record_cursor.rs
@@ -5,7 +5,7 @@ use std::{
     ptr::NonNull,
 };
 
-use crate::{map_not_found, wt_call, Error, Record, RecordView, Result};
+use crate::{map_not_found, wt_call, Record, RecordView, Result};
 use wt_sys::{WT_CURSOR, WT_ITEM};
 
 use super::{Session, TableUri};

--- a/wt_mdb/src/session/stat_cursor.rs
+++ b/wt_mdb/src/session/stat_cursor.rs
@@ -19,8 +19,7 @@ impl<'a> StatCursor<'a> {
     pub fn seek_exact(&mut self, wt_stat: u32) -> Option<Result<i64>> {
         map_not_found(
             unsafe {
-                wt_call!(nocode self.ptr, set_key, wt_stat)
-                    .and_then(|()| wt_call!(self.ptr, search))
+                wt_call!(void self.ptr, set_key, wt_stat).and_then(|()| wt_call!(self.ptr, search))
             }
             .and_then(|()| self.read_stat().map(|(_, v)| v)),
         )

--- a/wt_mdb/src/session/stat_cursor.rs
+++ b/wt_mdb/src/session/stat_cursor.rs
@@ -1,11 +1,10 @@
 use std::{
     ffi::{c_char, CStr},
-    num::NonZero,
     ptr::NonNull,
 };
 
-use crate::{make_result, Error, Result};
-use wt_sys::{WT_CURSOR, WT_NOTFOUND};
+use crate::{wt_call, Error, Result};
+use wt_sys::WT_CURSOR;
 
 use super::Session;
 
@@ -18,13 +17,13 @@ pub struct StatCursor<'a> {
 impl<'a> StatCursor<'a> {
     /// Seek to specific WT_STAT_.* and return the associated value if any.
     pub fn seek_exact(&mut self, wt_stat: u32) -> Option<Result<i64>> {
-        unsafe {
-            self.ptr.as_ref().set_key.unwrap()(self.ptr.as_ptr(), wt_stat);
-            match NonZero::new(self.ptr.as_ref().search.unwrap()(self.ptr.as_ptr())) {
-                None => Some(self.read_stat().map(|(_, v)| v)),
-                Some(code) if code.get() == WT_NOTFOUND => None,
-                Some(code) => Some(Err(Error::from(code))),
-            }
+        let result = unsafe {
+            wt_call!(nocode self.ptr, set_key, wt_stat).and_then(|()| wt_call!(self.ptr, search))
+        };
+        match result {
+            Ok(()) => Some(self.read_stat().map(|(_, v)| v)),
+            Err(e) if e == Error::not_found_error() => None,
+            Err(e) => Some(Err(e)),
         }
     }
 
@@ -36,14 +35,12 @@ impl<'a> StatCursor<'a> {
             let mut desc_ptr: *mut c_char = std::ptr::null_mut();
             let mut pvalue_ptr: *mut c_char = std::ptr::null_mut();
             let mut value = 0i64;
-            make_result(
-                self.ptr.as_ref().get_value.unwrap()(
-                    self.ptr.as_ptr(),
-                    &mut desc_ptr,
-                    &mut pvalue_ptr,
-                    &mut value,
-                ),
-                (),
+            wt_call!(
+                self.ptr,
+                get_value,
+                &mut desc_ptr,
+                &mut pvalue_ptr,
+                &mut value
             )?;
             (CStr::from_ptr::<'a>(desc_ptr), value)
         };
@@ -60,12 +57,11 @@ impl<'a> Iterator for StatCursor<'a> {
     type Item = Result<(String, i64)>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        unsafe {
-            match NonZero::new(self.ptr.as_ref().next.unwrap()(self.ptr.as_ptr())) {
-                None => Some(self.read_stat()),
-                Some(code) if code.get() == WT_NOTFOUND => None,
-                Some(code) => Some(Err(Error::from(code))),
-            }
+        let result = unsafe { wt_call!(self.ptr, next) };
+        match result {
+            Ok(()) => Some(self.read_stat()),
+            Err(e) if e == Error::not_found_error() => None,
+            Err(e) => Some(Err(e)),
         }
     }
 }
@@ -73,6 +69,6 @@ impl<'a> Iterator for StatCursor<'a> {
 impl<'a> Drop for StatCursor<'a> {
     fn drop(&mut self) {
         // TODO: print something if this returns an error.
-        unsafe { self.ptr.as_ref().close.unwrap()(self.ptr.as_ptr()) };
+        let _ = unsafe { wt_call!(self.ptr, close) };
     }
 }

--- a/wt_mdb/src/session/stat_cursor.rs
+++ b/wt_mdb/src/session/stat_cursor.rs
@@ -17,10 +17,9 @@ pub struct StatCursor<'a> {
 impl<'a> StatCursor<'a> {
     /// Seek to specific WT_STAT_.* and return the associated value if any.
     pub fn seek_exact(&mut self, wt_stat: u32) -> Option<Result<i64>> {
-        let result = unsafe {
+        match unsafe {
             wt_call!(nocode self.ptr, set_key, wt_stat).and_then(|()| wt_call!(self.ptr, search))
-        };
-        match result {
+        } {
             Ok(()) => Some(self.read_stat().map(|(_, v)| v)),
             Err(e) if e == Error::not_found_error() => None,
             Err(e) => Some(Err(e)),
@@ -57,8 +56,7 @@ impl<'a> Iterator for StatCursor<'a> {
     type Item = Result<(String, i64)>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let result = unsafe { wt_call!(self.ptr, next) };
-        match result {
+        match unsafe { wt_call!(self.ptr, next) } {
             Ok(()) => Some(self.read_stat()),
             Err(e) if e == Error::not_found_error() => None,
             Err(e) => Some(Err(e)),


### PR DESCRIPTION
`set_bounds` accepts a `RangeBound` to restrict positioning. This can be useful if we want to iterate over a subset
of the input table -- we can set bounds and then use the cursor as an `Iterator`.

Add a `wt_call!` macro to try to make programming in `wt_mdb` more pleasant.