### PR TITLE
Switch bulk load back to wt nav vector store

### DIFF
--- a/et/src/bulk_load.rs
+++ b/et/src/bulk_load.rs
@@ -88,10 +88,6 @@ pub fn bulk_load(
     let mut builder = BulkLoadBuilder::new(connection, index, f32_vectors, limit);
 
     {
-        let progress = progress_bar(limit, "quantize nav vectors");
-        builder.quantize_nav_vectors(|| progress.inc(1))?;
-    }
-    {
         let progress = progress_bar(limit, "load nav vectors");
         builder.load_nav_vectors(|| progress.inc(1))?;
     }
@@ -105,7 +101,7 @@ pub fn bulk_load(
     }
     let stats = {
         let progress = progress_bar(limit, "load graph");
-        builder.load_graph(|| progress.inc(1))?;
+        builder.load_graph(|| progress.inc(1))?
     };
     println!("{:?}", stats);
 

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -373,7 +373,7 @@ where
 
     fn nav_vectors(&self) -> Result<Self::NavVectorStore<'_>> {
         Ok(CursorNavVectorStore::new(
-            self.1.get_record_cursor(&self.0.index.nav_table_name())?,
+            self.1.get_record_cursor(self.0.index.nav_table_name())?,
         ))
     }
 }


### PR DESCRIPTION
On MacOS this seems to corrupt the nav vectors and derived scores, which is bad for recall.