### PR TITLE
Reintroduce a flat vector store for quantized vectors in bulk load

### DIFF
--- a/et/src/bulk_load.rs
+++ b/et/src/bulk_load.rs
@@ -22,6 +22,10 @@ pub struct BulkLoadArgs {
     /// Similarity function to use for vector scoring.
     #[arg(short, long, value_enum)]
     similarity: VectorSimilarity,
+    /// If true, load all quantized vectors into a trivial memory store for bulk loading.
+    /// This can be significantly faster than reading these values from WiredTiger.
+    #[arg(long)]
+    memory_quantized_vectors: bool,
 
     /// Maximum number of edges for any vertex.
     #[arg(short, long, default_value = "64")]
@@ -85,7 +89,13 @@ pub fn bulk_load(
 
     let num_vectors = f32_vectors.len();
     let limit = args.limit.unwrap_or(num_vectors);
-    let mut builder = BulkLoadBuilder::new(connection, index, f32_vectors, limit);
+    let mut builder = BulkLoadBuilder::new(
+        connection,
+        index,
+        f32_vectors,
+        args.memory_quantized_vectors,
+        limit,
+    );
 
     {
         let progress = progress_bar(limit, "load nav vectors");

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -483,7 +483,7 @@ enum BulkLoadNavVectorStore<'a> {
     Memory(&'a DerefVectorStore<u8, memmap2::Mmap>),
 }
 
-impl<'a> NavVectorStore for BulkLoadNavVectorStore<'a> {
+impl NavVectorStore for BulkLoadNavVectorStore<'_> {
     fn get(&mut self, vertex_id: i64) -> Option<Result<Cow<'_, [u8]>>> {
         match self {
             Self::Cursor(c) => c.get(vertex_id),


### PR DESCRIPTION
As an option fill an anonymous mmap segment with quantized vector data and use that for lookups in bulk load.

This is substantially faster (2x) than doing wt lookups for the same data even when everything is in memory.
With this the bottleneck is our single-threaded graph application scheme.