### PR TITLE
Implement CRUD operations in the `et` tool

### DIFF
--- a/et/src/bulk_load.rs
+++ b/et/src/bulk_load.rs
@@ -11,6 +11,8 @@ use easy_tiger::{
 use indicatif::{ProgressBar, ProgressFinish, ProgressStyle};
 use wt_mdb::{options::DropOptionsBuilder, Connection};
 
+use crate::drop_index;
+
 #[derive(Args)]
 pub struct BulkLoadArgs {
     /// Path to the input vectors to bulk ingest.
@@ -74,18 +76,10 @@ pub fn bulk_load(
                 .unwrap_or_else(|| args.edge_candidates.get()),
         },
     };
-    let index = TableGraphVectorIndex::from_init(config, index_name)?;
     if args.drop_tables {
-        let session = connection.open_session()?;
-        session.drop_record_table(
-            index.graph_table_name(),
-            Some(DropOptionsBuilder::default().set_force().into()),
-        )?;
-        session.drop_record_table(
-            index.nav_table_name(),
-            Some(DropOptionsBuilder::default().set_force().into()),
-        )?;
+        drop_index(connection.clone(), index_name)?;
     }
+    let index = TableGraphVectorIndex::from_init(config, index_name)?;
 
     let num_vectors = f32_vectors.len();
     let limit = args.limit.unwrap_or(num_vectors);

--- a/et/src/bulk_load.rs
+++ b/et/src/bulk_load.rs
@@ -9,7 +9,7 @@ use easy_tiger::{
     wt::TableGraphVectorIndex,
 };
 use indicatif::{ProgressBar, ProgressFinish, ProgressStyle};
-use wt_mdb::{options::DropOptionsBuilder, Connection};
+use wt_mdb::Connection;
 
 use crate::drop_index;
 

--- a/et/src/delete.rs
+++ b/et/src/delete.rs
@@ -1,0 +1,75 @@
+use std::{io, ops::Range, str::FromStr, sync::Arc};
+
+use clap::Args;
+use easy_tiger::wt::TableGraphVectorIndex;
+use wt_mdb::{Connection, RecordCursor};
+
+#[derive(Debug, Clone)]
+struct KeyRange(Range<i64>);
+
+impl FromStr for KeyRange {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let parts = s.split("-").collect::<Vec<_>>();
+        if parts.len() != 2 {
+            return Err("must have exactly two parts");
+        }
+        let start = parts[0]
+            .parse::<i64>()
+            .map_err(|_| "failed to parse start key")?;
+        if start < 0 {
+            return Err("start must be >= 0");
+        }
+        let end = parts[1]
+            .parse::<i64>()
+            .map_err(|_| "failed to parse end key")?;
+        Ok(Self(start..end))
+    }
+}
+
+#[derive(Args)]
+pub struct DeleteArgs {
+    /// First key to delete from the index.
+    #[arg(long)]
+    keys: KeyRange,
+}
+
+fn delete_all(
+    id_cursor: RecordCursor<'_>,
+    mut graph_cursor: RecordCursor<'_>,
+    mut nav_cursor: RecordCursor<'_>,
+) -> wt_mdb::Result<()> {
+    for record in id_cursor {
+        let key = record?.key();
+        graph_cursor.remove(key)?;
+        nav_cursor.remove(key)?;
+    }
+    Ok(())
+}
+
+pub fn delete(connection: Arc<Connection>, index_name: &str, args: DeleteArgs) -> io::Result<()> {
+    let index = Arc::new(TableGraphVectorIndex::from_db(&connection, index_name)?);
+    let session = connection.open_session()?;
+    session.begin_transaction(None)?;
+
+    // Use the nav table to find the ids in range to delete. This is probably cheaper than iterating over the graph table.
+    let mut id_cursor = session.open_record_cursor(index.nav_table_name())?;
+    id_cursor.set_bounds(args.keys.0.clone())?;
+    match delete_all(
+        id_cursor,
+        session.open_record_cursor(index.graph_table_name())?,
+        session.open_record_cursor(index.nav_table_name())?,
+    ) {
+        Ok(_) => {
+            println!("Deleted {:?}", args.keys.0);
+            session.commit_transaction(None)?;
+        }
+        Err(e) => {
+            println!("Delete failed {}", e);
+            session.rollback_transaction(None)?;
+        }
+    }
+
+    Ok(())
+}

--- a/et/src/delete.rs
+++ b/et/src/delete.rs
@@ -2,7 +2,10 @@ use std::{io, ops::Range, str::FromStr, sync::Arc};
 
 use clap::Args;
 use easy_tiger::wt::TableGraphVectorIndex;
+use indicatif::ProgressIterator;
 use wt_mdb::{Connection, RecordCursor};
+
+use crate::ui::progress_spinner;
 
 #[derive(Debug, Clone)]
 struct KeyRange(Range<i64>);
@@ -40,7 +43,7 @@ fn delete_all(
     mut graph_cursor: RecordCursor<'_>,
     mut nav_cursor: RecordCursor<'_>,
 ) -> wt_mdb::Result<()> {
-    for record in id_cursor {
+    for record in id_cursor.progress_with(progress_spinner()) {
         let key = record?.key();
         graph_cursor.remove(key)?;
         nav_cursor.remove(key)?;

--- a/et/src/drop_index.rs
+++ b/et/src/drop_index.rs
@@ -4,15 +4,12 @@ use easy_tiger::wt::TableGraphVectorIndex;
 use wt_mdb::{options::DropOptionsBuilder, Connection};
 
 pub fn drop_index(connection: Arc<Connection>, index_name: &str) -> io::Result<()> {
-    let index = TableGraphVectorIndex::from_db(&connection, index_name)?;
     let session = connection.open_session()?;
-    session.drop_record_table(
-        index.graph_table_name(),
-        Some(DropOptionsBuilder::default().set_force().into()),
-    )?;
-    session.drop_record_table(
-        index.nav_table_name(),
-        Some(DropOptionsBuilder::default().set_force().into()),
-    )?;
+    for table_name in TableGraphVectorIndex::generate_table_names(index_name) {
+        session.drop_record_table(
+            &table_name,
+            Some(DropOptionsBuilder::default().set_force().into()),
+        )?;
+    }
     Ok(())
 }

--- a/et/src/init_index.rs
+++ b/et/src/init_index.rs
@@ -1,0 +1,75 @@
+use std::{io, num::NonZero, sync::Arc};
+
+use clap::Args;
+use easy_tiger::{
+    graph::{GraphConfig, GraphSearchParams},
+    scoring::VectorSimilarity,
+    wt::TableGraphVectorIndex,
+};
+use wt_mdb::Connection;
+
+use crate::drop_index::drop_index;
+
+#[derive(Args)]
+pub struct InitIndexArgs {
+    /// Number of dimensions in input vectors.
+    #[arg(short, long)]
+    dimensions: NonZero<usize>,
+    /// Similarity function to use for vector scoring.
+    #[arg(short, long, value_enum)]
+    similarity: VectorSimilarity,
+
+    /// Maximum number of edges for any vertex.
+    #[arg(long, default_value = "64")]
+    max_edges: NonZero<usize>,
+    /// Number of edges to search for when indexing a vertex.
+    ///
+    /// Larger values make indexing more expensive but may also produce a larger, more
+    /// saturated graph that has higher recall.
+    #[arg(long, default_value = "256")]
+    edge_candidates: NonZero<usize>,
+    /// Number of edge candidates to rerank. Defaults to edge_candidates.
+    ///
+    /// When > 0 re-rank candidate edges using the highest fidelity vectors available.
+    /// The candidate list is then truncated to this size, so this may effectively reduce
+    /// the value of edge_candidates.
+    #[arg(long)]
+    rerank_edges: Option<usize>,
+
+    /// If true, drop the named index if it exists and re-initialize.
+    ///
+    /// If false and the index already exists this command will fail.
+    #[arg(long)]
+    drop_if_exists: bool,
+}
+
+pub fn init_index(
+    connection: Arc<Connection>,
+    args: InitIndexArgs,
+    index_name: &str,
+) -> io::Result<()> {
+    if args.drop_if_exists {
+        drop_index(connection.clone(), index_name)?;
+    } else if !TableGraphVectorIndex::from_db(&connection, index_name)
+        .is_err_and(|e| e.kind() == io::ErrorKind::NotFound)
+    {
+        println!("Index {} already exists!", index_name);
+        return Ok(());
+    }
+
+    TableGraphVectorIndex::init_index(
+        &connection,
+        None,
+        GraphConfig {
+            dimensions: args.dimensions,
+            similarity: args.similarity,
+            max_edges: args.max_edges,
+            index_search_params: GraphSearchParams {
+                beam_width: args.edge_candidates,
+                num_rerank: args.rerank_edges.unwrap_or(args.edge_candidates.get()),
+            },
+        },
+        index_name,
+    )
+    .map(|_| ())
+}

--- a/et/src/init_index.rs
+++ b/et/src/init_index.rs
@@ -45,8 +45,8 @@ pub struct InitIndexArgs {
 
 pub fn init_index(
     connection: Arc<Connection>,
-    args: InitIndexArgs,
     index_name: &str,
+    args: InitIndexArgs,
 ) -> io::Result<()> {
     if args.drop_if_exists {
         drop_index(connection.clone(), index_name)?;

--- a/et/src/insert.rs
+++ b/et/src/insert.rs
@@ -6,6 +6,7 @@ use easy_tiger::{
     input::{DerefVectorStore, VectorStore},
     wt::TableGraphVectorIndex,
 };
+use indicatif::ProgressIterator;
 use wt_mdb::{Connection, Result};
 
 use crate::ui::progress_bar;
@@ -31,7 +32,7 @@ fn insert_all<'a>(
     let mut keys: Vec<Range<i64>> = vec![];
     // I could probably write this as a fold but it seems annoying.
     let progress = progress_bar(vectors.len(), None);
-    for vector in vectors {
+    for vector in vectors.progress_with(progress) {
         let key = mutator.insert(vector)?;
         if let Some(r) = keys.last_mut() {
             if r.end == key {
@@ -42,7 +43,6 @@ fn insert_all<'a>(
         } else {
             keys.push(key..(key + 1))
         }
-        progress.inc(1);
     }
     Ok(keys)
 }

--- a/et/src/insert.rs
+++ b/et/src/insert.rs
@@ -8,6 +8,8 @@ use easy_tiger::{
 };
 use wt_mdb::{Connection, Result};
 
+use crate::ui::progress_bar;
+
 #[derive(Args)]
 pub struct InsertArgs {
     /// Path to the numpy formatted vectors to insert.
@@ -24,10 +26,11 @@ pub struct InsertArgs {
 
 fn insert_all<'a>(
     mutator: &mut IndexMutator,
-    vectors: impl Iterator<Item = &'a [f32]>,
+    vectors: impl Iterator<Item = &'a [f32]> + ExactSizeIterator,
 ) -> Result<Vec<Range<i64>>> {
     let mut keys: Vec<Range<i64>> = vec![];
     // I could probably write this as a fold but it seems annoying.
+    let progress = progress_bar(vectors.len(), None);
     for vector in vectors {
         let key = mutator.insert(vector)?;
         if let Some(r) = keys.last_mut() {
@@ -39,6 +42,7 @@ fn insert_all<'a>(
         } else {
             keys.push(key..(key + 1))
         }
+        progress.inc(1);
     }
     Ok(keys)
 }

--- a/et/src/insert.rs
+++ b/et/src/insert.rs
@@ -1,0 +1,74 @@
+use std::{fs::File, io, num::NonZero, ops::Range, path::PathBuf, sync::Arc, usize};
+
+use clap::Args;
+use easy_tiger::{
+    crud::IndexMutator,
+    input::{DerefVectorStore, VectorStore},
+    wt::TableGraphVectorIndex,
+};
+use wt_mdb::{Connection, Result};
+
+#[derive(Args)]
+pub struct InsertArgs {
+    /// Path to the numpy formatted vectors to insert.
+    #[arg(short, long)]
+    vectors: PathBuf,
+    /// Index of the first vector to insert.
+    #[arg(long)]
+    offset: usize,
+    /// Number of vectors to insert from the input.
+    ///
+    /// This value is bound by offset and the number of input vectors.
+    limit: Option<NonZero<usize>>,
+}
+
+fn insert_all<'a>(
+    mutator: &mut IndexMutator,
+    vectors: impl Iterator<Item = &'a [f32]>,
+) -> Result<Vec<Range<i64>>> {
+    let mut keys: Vec<Range<i64>> = vec![];
+    // I could probably write this as a fold but it seems annoying.
+    for vector in vectors {
+        let key = mutator.insert(vector)?;
+        if let Some(r) = keys.last_mut() {
+            if r.end == key {
+                r.end = key + 1;
+            } else {
+                keys.push(key..(key + 1))
+            }
+        } else {
+            keys.push(key..(key + 1))
+        }
+    }
+    Ok(keys)
+}
+
+pub fn insert(connection: Arc<Connection>, index_name: &str, args: InsertArgs) -> io::Result<()> {
+    let index = Arc::new(TableGraphVectorIndex::from_db(&connection, index_name)?);
+    let vectors = DerefVectorStore::<f32, _>::new(
+        unsafe { memmap2::Mmap::map(&File::open(args.vectors)?)? },
+        index.config().dimensions,
+    )?;
+
+    let session = connection.open_session()?;
+    session.begin_transaction(None)?;
+    let mut mutator = IndexMutator::new(index, session);
+    match insert_all(
+        &mut mutator,
+        vectors
+            .iter()
+            .skip(args.offset)
+            .take(args.limit.map(NonZero::get).unwrap_or(usize::MAX)),
+    ) {
+        Ok(keys) => {
+            println!("Inserted {:?}", keys);
+            mutator.into_session().commit_transaction(None)?;
+        }
+        Err(e) => {
+            println!("Insert failed with error {}", e);
+            mutator.into_session().rollback_transaction(None)?;
+        }
+    }
+
+    Ok(())
+}

--- a/et/src/main.rs
+++ b/et/src/main.rs
@@ -2,6 +2,7 @@ mod bulk_load;
 mod drop_index;
 mod exhaustive_search;
 mod init_index;
+mod insert;
 mod lookup;
 mod search;
 
@@ -15,6 +16,7 @@ use clap::{command, Parser, Subcommand};
 use drop_index::drop_index;
 use exhaustive_search::{exhaustive_search, ExhaustiveSearchArgs};
 use init_index::{init_index, InitIndexArgs};
+use insert::{insert, InsertArgs};
 use lookup::{lookup, LookupArgs};
 use search::{search, SearchArgs};
 use wt_mdb::{
@@ -58,8 +60,8 @@ enum Commands {
     Search(SearchArgs),
     /// Exhaustively search an index and create new Neighbors files.
     ExhaustiveSearch(ExhaustiveSearchArgs),
-    /// Insert a vector or vectors from a file into the index.
-    Insert,
+    /// Insert a vectors from a file into the index.
+    Insert(InsertArgs),
     /// Delete vectors by key range.
     Delete,
 }
@@ -78,7 +80,8 @@ fn main() -> io::Result<()> {
     match cli.command {
         Commands::BulkLoad(args) => bulk_load(connection, args, &cli.index_name),
         Commands::DropIndex => drop_index(connection, &cli.index_name),
-        Commands::InitIndex(args) => init_index(connection, args, &cli.index_name),
+        Commands::InitIndex(args) => init_index(connection, &cli.index_name, args),
+        Commands::Insert(args) => insert(connection, &cli.index_name, args),
         Commands::Lookup(args) => lookup(connection, &cli.index_name, args),
         Commands::Search(args) => search(connection, &cli.index_name, args),
         Commands::ExhaustiveSearch(args) => {

--- a/et/src/main.rs
+++ b/et/src/main.rs
@@ -1,4 +1,5 @@
 mod bulk_load;
+mod delete;
 mod drop_index;
 mod exhaustive_search;
 mod init_index;
@@ -7,12 +8,13 @@ mod lookup;
 mod search;
 
 use std::{
-    io::{self, ErrorKind},
+    io::{self},
     num::NonZero,
 };
 
 use bulk_load::{bulk_load, BulkLoadArgs};
 use clap::{command, Parser, Subcommand};
+use delete::{delete, DeleteArgs};
 use drop_index::drop_index;
 use exhaustive_search::{exhaustive_search, ExhaustiveSearchArgs};
 use init_index::{init_index, InitIndexArgs};
@@ -63,7 +65,7 @@ enum Commands {
     /// Insert a vectors from a file into the index.
     Insert(InsertArgs),
     /// Delete vectors by key range.
-    Delete,
+    Delete(DeleteArgs),
 }
 
 fn main() -> io::Result<()> {
@@ -79,6 +81,7 @@ fn main() -> io::Result<()> {
 
     match cli.command {
         Commands::BulkLoad(args) => bulk_load(connection, args, &cli.index_name),
+        Commands::Delete(args) => delete(connection, &cli.index_name, args),
         Commands::DropIndex => drop_index(connection, &cli.index_name),
         Commands::InitIndex(args) => init_index(connection, &cli.index_name, args),
         Commands::Insert(args) => insert(connection, &cli.index_name, args),
@@ -87,6 +90,5 @@ fn main() -> io::Result<()> {
         Commands::ExhaustiveSearch(args) => {
             exhaustive_search(connection.clone(), &cli.index_name, args)
         }
-        _ => Err(io::Error::from(ErrorKind::Unsupported)),
     }
 }

--- a/et/src/main.rs
+++ b/et/src/main.rs
@@ -1,6 +1,7 @@
 mod bulk_load;
 mod drop_index;
 mod exhaustive_search;
+mod init_index;
 mod lookup;
 mod search;
 
@@ -13,6 +14,7 @@ use bulk_load::{bulk_load, BulkLoadArgs};
 use clap::{command, Parser, Subcommand};
 use drop_index::drop_index;
 use exhaustive_search::{exhaustive_search, ExhaustiveSearchArgs};
+use init_index::{init_index, InitIndexArgs};
 use lookup::{lookup, LookupArgs};
 use search::{search, SearchArgs};
 use wt_mdb::{
@@ -44,7 +46,7 @@ struct Cli {
 #[derive(Subcommand)]
 enum Commands {
     /// Initialize a new (empty) index.
-    InitIndex,
+    InitIndex(InitIndexArgs),
     /// Bulk load a set of vectors into an index.
     /// Requires that the index be uninitialized.
     BulkLoad(BulkLoadArgs),
@@ -57,7 +59,7 @@ enum Commands {
     /// Exhaustively search an index and create new Neighbors files.
     ExhaustiveSearch(ExhaustiveSearchArgs),
     /// Insert a vector or vectors from a file into the index.
-    Add,
+    Insert,
     /// Delete vectors by key range.
     Delete,
 }
@@ -76,6 +78,7 @@ fn main() -> io::Result<()> {
     match cli.command {
         Commands::BulkLoad(args) => bulk_load(connection, args, &cli.index_name),
         Commands::DropIndex => drop_index(connection, &cli.index_name),
+        Commands::InitIndex(args) => init_index(connection, args, &cli.index_name),
         Commands::Lookup(args) => lookup(connection, &cli.index_name, args),
         Commands::Search(args) => search(connection, &cli.index_name, args),
         Commands::ExhaustiveSearch(args) => {

--- a/et/src/main.rs
+++ b/et/src/main.rs
@@ -44,7 +44,7 @@ struct Cli {
 #[derive(Subcommand)]
 enum Commands {
     /// Initialize a new (empty) index.
-    Init,
+    InitIndex,
     /// Bulk load a set of vectors into an index.
     /// Requires that the index be uninitialized.
     BulkLoad(BulkLoadArgs),
@@ -76,8 +76,8 @@ fn main() -> io::Result<()> {
     match cli.command {
         Commands::BulkLoad(args) => bulk_load(connection, args, &cli.index_name),
         Commands::DropIndex => drop_index(connection, &cli.index_name),
-        Commands::Lookup(args) => lookup(connection.clone(), &cli.index_name, args),
-        Commands::Search(args) => search(connection.clone(), &cli.index_name, args),
+        Commands::Lookup(args) => lookup(connection, &cli.index_name, args),
+        Commands::Search(args) => search(connection, &cli.index_name, args),
         Commands::ExhaustiveSearch(args) => {
             exhaustive_search(connection.clone(), &cli.index_name, args)
         }

--- a/et/src/main.rs
+++ b/et/src/main.rs
@@ -6,6 +6,7 @@ mod init_index;
 mod insert;
 mod lookup;
 mod search;
+mod ui;
 
 use std::{
     io::{self},

--- a/et/src/search.rs
+++ b/et/src/search.rs
@@ -19,11 +19,12 @@ use easy_tiger::{
     wt::{SessionGraphVectorIndexReader, TableGraphVectorIndex},
     Neighbor,
 };
-use indicatif::{ProgressBar, ProgressStyle};
 use memmap2::Mmap;
 use threadpool::ThreadPool;
 use wt_mdb::{Connection, Result, Session};
 use wt_sys::{WT_STAT_CONN_CURSOR_SEARCH, WT_STAT_CONN_READ_IO};
+
+use crate::ui::progress_bar;
 
 #[derive(Args)]
 pub struct SearchArgs {
@@ -179,16 +180,7 @@ fn search_phase<Q: Send + Sync, N: Send + Sync>(
         .cycle()
         .take(iters * limit)
         .collect::<Vec<_>>();
-    let progress = ProgressBar::new(query_indices.len() as u64)
-        .with_style(
-            ProgressStyle::default_bar()
-                .template(
-                    "{msg} {wide_bar} {pos}/{len} ETA: {eta_precise} Elapsed: {elapsed_precise}",
-                )
-                .unwrap(),
-        )
-        .with_message(name)
-        .with_finish(indicatif::ProgressFinish::AndLeave);
+    let progress = progress_bar(query_indices.len(), Some(name));
     let stats = query_indices
         .into_par_iter()
         .map_init(

--- a/et/src/ui.rs
+++ b/et/src/ui.rs
@@ -3,14 +3,14 @@ use indicatif::{ProgressBar, ProgressFinish, ProgressStyle};
 pub(crate) fn progress_bar(len: usize, message: Option<&'static str>) -> ProgressBar {
     if let Some(message) = message {
         ProgressBar::new(len as u64)
-        .with_style(
-            ProgressStyle::default_bar()
-                .template(
-                    "{msg} {wide_bar} {pos}/{len} ETA: {eta_precise} Elapsed: {elapsed_precise}",
-                )
-                .unwrap(),
-        )
-        .with_message(message)
+            .with_style(
+                ProgressStyle::default_bar()
+                    .template(
+                        "{msg} {wide_bar} {pos}/{len} ETA: {eta_precise} Elapsed: {elapsed_precise}",
+                    )
+                    .unwrap(),
+            )
+            .with_message(message)
     } else {
         ProgressBar::new(len as u64).with_style(
             ProgressStyle::default_bar()
@@ -19,4 +19,14 @@ pub(crate) fn progress_bar(len: usize, message: Option<&'static str>) -> Progres
         )
     }
     .with_finish(ProgressFinish::AndLeave)
+}
+
+pub(crate) fn progress_spinner() -> ProgressBar {
+    ProgressBar::new_spinner()
+        .with_style(
+            ProgressStyle::default_spinner()
+                .template("{wide_bar} {pos} Elapsed: {elapsed_precise}")
+                .unwrap(),
+        )
+        .with_finish(ProgressFinish::AndLeave)
 }

--- a/et/src/ui.rs
+++ b/et/src/ui.rs
@@ -1,0 +1,22 @@
+use indicatif::{ProgressBar, ProgressFinish, ProgressStyle};
+
+pub(crate) fn progress_bar(len: usize, message: Option<&'static str>) -> ProgressBar {
+    if let Some(message) = message {
+        ProgressBar::new(len as u64)
+        .with_style(
+            ProgressStyle::default_bar()
+                .template(
+                    "{msg} {wide_bar} {pos}/{len} ETA: {eta_precise} Elapsed: {elapsed_precise}",
+                )
+                .unwrap(),
+        )
+        .with_message(message)
+    } else {
+        ProgressBar::new(len as u64).with_style(
+            ProgressStyle::default_bar()
+                .template("{wide_bar} {pos}/{len} ETA: {eta_precise} Elapsed: {elapsed_precise}")
+                .unwrap(),
+        )
+    }
+    .with_finish(ProgressFinish::AndLeave)
+}

--- a/src/crud.rs
+++ b/src/crud.rs
@@ -42,6 +42,11 @@ impl IndexMutator {
         self.reader.into_session()
     }
 
+    /// Obtain a reference to the underlying [wt_mdb::Session]
+    pub fn session(&self) -> &Session {
+        self.reader.session()
+    }
+
     /// Insert a vertex for `vector`. Returns the assigned id.
     pub fn insert(&mut self, vector: &[f32]) -> Result<i64> {
         // A freshly initialized table might will have the metadata key but no entry point.

--- a/src/crud.rs
+++ b/src/crud.rs
@@ -338,7 +338,9 @@ mod tests {
             )
             .unwrap();
             let index = Arc::new(
-                TableGraphVectorIndex::from_init(
+                TableGraphVectorIndex::init_index(
+                    &conn,
+                    None,
                     GraphConfig {
                         dimensions: NonZero::new(2).unwrap(),
                         similarity: VectorSimilarity::Euclidean,
@@ -349,7 +351,6 @@ mod tests {
                 )
                 .unwrap(),
             );
-            index.init_index(&conn, None).unwrap();
             Self {
                 _dir: dir,
                 conn,

--- a/src/input.rs
+++ b/src/input.rs
@@ -18,7 +18,7 @@ pub trait VectorStore: Index<usize, Output = [Self::Elem]> {
     fn elem_stride(&self) -> usize;
 
     /// Return an iterator over all the vectors in the store.
-    fn iter(&self) -> impl Iterator<Item = &[Self::Elem]>;
+    fn iter(&self) -> impl Iterator<Item = &[Self::Elem]> + ExactSizeIterator;
 }
 
 pub struct DerefVectorStore<E: 'static, D> {
@@ -87,7 +87,7 @@ impl<E, D> VectorStore for DerefVectorStore<E, D> {
         self.stride
     }
 
-    fn iter(&self) -> impl Iterator<Item = &[Self::Elem]> {
+    fn iter(&self) -> impl Iterator<Item = &[Self::Elem]> + ExactSizeIterator {
         self.raw_vectors.chunks(self.stride)
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -18,7 +18,7 @@ pub trait VectorStore: Index<usize, Output = [Self::Elem]> {
     fn elem_stride(&self) -> usize;
 
     /// Return an iterator over all the vectors in the store.
-    fn iter(&self) -> impl Iterator<Item = &[Self::Elem]> + ExactSizeIterator;
+    fn iter(&self) -> impl ExactSizeIterator<Item = &[Self::Elem]>;
 }
 
 pub struct DerefVectorStore<E: 'static, D> {
@@ -87,7 +87,7 @@ impl<E, D> VectorStore for DerefVectorStore<E, D> {
         self.stride
     }
 
-    fn iter(&self) -> impl Iterator<Item = &[Self::Elem]> + ExactSizeIterator {
+    fn iter(&self) -> impl ExactSizeIterator<Item = &[Self::Elem]> {
         self.raw_vectors.chunks(self.stride)
     }
 }


### PR DESCRIPTION
`init-index` to create empty vector index tables.
`insert` to insert new entries from a numpy input.
`delete` to delete entries by key.