### PR TITLE
Improve bulk load edge computation consistency

### DIFF
--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -347,9 +347,12 @@ where
         self.graph[index].write().unwrap().extend_from_slice(&edges);
         for e in edges.iter() {
             let mut guard = self.graph[e.vertex() as usize].write().unwrap();
-            guard.push(Neighbor::new(index as i64, e.score()));
-            let max_edges = NonZero::new(guard.capacity() - 1).unwrap();
-            self.maybe_prune_node(index, guard, max_edges)?;
+            let backedge = Neighbor::new(index as i64, e.score());
+            if !guard.contains(&backedge) {
+                guard.push(backedge);
+                let max_edges = NonZero::new(guard.capacity() - 1).unwrap();
+                self.maybe_prune_node(index, guard, max_edges)?;
+            }
         }
         Ok(())
     }

--- a/src/crud.rs
+++ b/src/crud.rs
@@ -60,8 +60,9 @@ impl IndexMutator {
         assert_eq!(self.reader.config().dimensions.get(), vector.len());
 
         let scorer = self.reader.config().new_scorer();
+        let vector = scorer.normalize_vector(vector.into());
         // TODO: normalize input vector.
-        let mut candidate_edges = self.searcher.search(vector, &mut self.reader)?;
+        let mut candidate_edges = self.searcher.search(&vector, &mut self.reader)?;
         let mut graph = self.reader.graph()?;
         if candidate_edges.is_empty() {
             // Proceed through the rest of the function so that the inserts happen.
@@ -79,13 +80,13 @@ impl IndexMutator {
         graph.set(
             vertex_id,
             &encode_graph_node_internal(
-                vector,
+                vector.as_ref(),
                 candidate_edges.iter().map(|n| n.vertex()).collect(),
             ),
         )?;
         self.reader
             .nav_vectors()?
-            .set(vertex_id, binary_quantize(vector).into())?;
+            .set(vertex_id, binary_quantize(vector.as_ref()).into())?;
 
         let mut pruned_edges = vec![];
         for src_vertex_id in candidate_edges.into_iter().map(|n| n.vertex()) {

--- a/src/search.rs
+++ b/src/search.rs
@@ -263,9 +263,8 @@ impl GraphSearcher {
         reader: &R,
     ) -> Vec<Neighbor> {
         if self.params.num_rerank > 0 {
-            let mut normalized_query = query.to_vec();
             let scorer = reader.config().new_scorer();
-            scorer.normalize(&mut normalized_query);
+            let normalized_query = scorer.normalize_vector(query.into());
             let mut rescored = self
                 .candidates
                 .iter()
@@ -486,8 +485,7 @@ mod test {
             let mut rep = iter
                 .into_iter()
                 .map(|x| {
-                    let mut v = x.into();
-                    scorer.normalize(&mut v);
+                    let v = x.into();
                     let b = binary_quantize(&v);
                     TestVector {
                         vector: v,
@@ -502,7 +500,7 @@ mod test {
             }
             let config = GraphConfig {
                 dimensions: NonZero::new(rep.first().map(|v| v.vector.len()).unwrap_or(1)).unwrap(),
-                similarity: VectorSimilarity::Dot,
+                similarity: VectorSimilarity::Euclidean,
                 max_edges: max_edges,
                 index_search_params: GraphSearchParams {
                     beam_width: NonZero::new(usize::MAX).unwrap(),
@@ -683,7 +681,7 @@ mod test {
                 Neighbor::new(0, 1.0),
                 Neighbor::new(1, 1.0),
                 Neighbor::new(4, 1.0),
-                Neighbor::new(5, 1.0)
+                Neighbor::new(16, 1.0)
             ]
         );
     }
@@ -702,10 +700,10 @@ mod test {
                     .unwrap()
             ),
             vec![
-                Neighbor::new(0, 1.0),
-                Neighbor::new(1, 0.98536),
-                Neighbor::new(4, 0.98536),
-                Neighbor::new(5, 0.97434)
+                Neighbor::new(1, 0.93622),
+                Neighbor::new(4, 0.93622),
+                Neighbor::new(16, 0.93622),
+                Neighbor::new(0, 0.91743),
             ]
         );
     }

--- a/src/search.rs
+++ b/src/search.rs
@@ -264,7 +264,7 @@ impl GraphSearcher {
     ) -> Vec<Neighbor> {
         if self.params.num_rerank > 0 {
             let scorer = reader.config().new_scorer();
-            let normalized_query = scorer.normalize_vector(query.into());
+            let query = scorer.normalize_vector(query.into());
             let mut rescored = self
                 .candidates
                 .iter()
@@ -272,7 +272,7 @@ impl GraphSearcher {
                 .map(|c| {
                     Neighbor::new(
                         c.neighbor.vertex(),
-                        scorer.score(&normalized_query, c.state.vector().expect("node visited")),
+                        scorer.score(&query, c.state.vector().expect("node visited")),
                     )
                 })
                 .collect::<Vec<_>>();


### PR DESCRIPTION
* Add in-flight vectors in a way more consistent with policy by inserting them into the candidate list in sorted order.
* Don't add duplicate edges during backlinking. This may happen between concurrent insertion nodes.
* Normalize vector values consistently thoughout bulk loader.