### PR TITLE
Implement an "index table" with byte-array typed keys

### DIFF
--- a/et/src/drop_index.rs
+++ b/et/src/drop_index.rs
@@ -6,7 +6,7 @@ use wt_mdb::{options::DropOptionsBuilder, Connection};
 pub fn drop_index(connection: Arc<Connection>, index_name: &str) -> io::Result<()> {
     let session = connection.open_session()?;
     for table_name in TableGraphVectorIndex::generate_table_names(index_name) {
-        session.drop_record_table(
+        session.drop_table(
             &table_name,
             Some(DropOptionsBuilder::default().set_force().into()),
         )?;

--- a/src/wt.rs
+++ b/src/wt.rs
@@ -216,8 +216,8 @@ impl TableGraphVectorIndex {
     ) -> io::Result<Self> {
         let index = Self::from_init(config, index_name)?;
         let session = connection.open_session()?;
-        session.create_record_table(&index.graph_table_name, table_options.clone())?;
-        session.create_record_table(&index.nav_table_name, table_options)?;
+        session.create_table(&index.graph_table_name, table_options.clone())?;
+        session.create_table(&index.nav_table_name, table_options)?;
         let mut cursor = session.open_record_cursor(&index.graph_table_name)?;
         cursor.set(&Record::new(CONFIG_KEY, serde_json::to_vec(&index.config)?))?;
         Ok(index)

--- a/wt_mdb/src/lib.rs
+++ b/wt_mdb/src/lib.rs
@@ -215,6 +215,7 @@ use wt_call;
 
 #[cfg(test)]
 mod test {
+    // XXX add index cursor tests.
     use std::io::ErrorKind;
 
     use rustix::io::Errno;

--- a/wt_mdb/src/lib.rs
+++ b/wt_mdb/src/lib.rs
@@ -14,9 +14,9 @@ use rustix::io::Errno;
 use wt_sys::wiredtiger_strerror;
 
 use std::ffi::CStr;
+use std::io;
 use std::io::ErrorKind;
 use std::num::NonZero;
-use std::{borrow::Cow, io};
 
 /// WiredTiger specific error codes.
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
@@ -123,58 +123,10 @@ impl From<Error> for std::io::Error {
     }
 }
 
-// XXX move this into record_cursor.
-/// A `RecordView` in a WiredTiger table with an i64 key and a byte array value.
-///
-/// The underlying byte array may or may not be owned, the `Record` type alias may be more
-/// convenient when the data is owned.
-#[derive(Clone, Debug, Hash, Eq, PartialEq)]
-pub struct RecordView<'a> {
-    key: i64,
-    value: Cow<'a, [u8]>,
-}
-
-impl<'a> RecordView<'a> {
-    /// Create a new `RecordView` from a key and an unowned byte array value.
-    pub fn new<V>(key: i64, value: V) -> Self
-    where
-        V: Into<Cow<'a, [u8]>>,
-    {
-        RecordView {
-            key,
-            value: value.into(),
-        }
-    }
-
-    /// Return the key.
-    pub fn key(&self) -> i64 {
-        self.key
-    }
-
-    /// Return the value.
-    pub fn value(&self) -> &[u8] {
-        self.value.as_ref()
-    }
-
-    /// Ensure that this RecordView owns the underlying value.
-    pub fn to_owned(self) -> Record {
-        Record::new(self.key(), self.value.to_vec())
-    }
-
-    /// Returns the inner value within the `RecordView`.
-    pub fn into_inner_value(self) -> Cow<'a, [u8]> {
-        self.value
-    }
-}
-
-/// An alias for `RecordView` with `'static` lifetime, may be more convenient when the value is
-/// actually owned.
-pub type Record = RecordView<'static>;
-
 pub use connection::Connection;
 pub use session::{
-    IndexCursor, IndexCursorGuard, IndexRecord, IndexRecordView, RecordCursor, RecordCursorGuard,
-    Session, StatCursor,
+    IndexCursor, IndexCursorGuard, IndexRecord, IndexRecordView, Record, RecordCursor,
+    RecordCursorGuard, RecordView, Session, StatCursor,
 };
 pub type Result<T> = std::result::Result<T, Error>;
 

--- a/wt_mdb/src/lib.rs
+++ b/wt_mdb/src/lib.rs
@@ -197,7 +197,7 @@ mod test {
         let tmpdir = tempfile::tempdir().unwrap();
         let conn = Connection::open(tmpdir.path().to_str().unwrap(), conn_options()).unwrap();
         let session = conn.open_session().unwrap();
-        session.create_record_table("test", None).unwrap();
+        session.create_table("test", None).unwrap();
         let mut cursor = session.open_record_cursor("test").unwrap();
         assert_eq!(cursor.set(&RecordView::new(11, b"bar")), Ok(()));
         assert_eq!(cursor.set(&RecordView::new(7, b"foo")), Ok(()));
@@ -211,9 +211,7 @@ mod test {
         let tmpdir = tempfile::tempdir().unwrap();
         let conn = Connection::open(tmpdir.path().to_str().unwrap(), conn_options()).unwrap();
         let session = conn.open_session().unwrap();
-        session
-            .create_record_table("test", index_table_options())
-            .unwrap();
+        session.create_table("test", index_table_options()).unwrap();
         let mut cursor = session.open_index_cursor("test").unwrap();
         assert_eq!(cursor.set(&IndexRecordView::new(b"b", b"bar")), Ok(()));
         assert_eq!(cursor.set(&IndexRecordView::new(b"a", b"foo")), Ok(()));
@@ -227,7 +225,7 @@ mod test {
         let tmpdir = tempfile::tempdir().unwrap();
         let conn = Connection::open(tmpdir.path().to_str().unwrap(), conn_options()).unwrap();
         let session = conn.open_session().unwrap();
-        session.create_record_table("test", None).unwrap();
+        session.create_table("test", None).unwrap();
         let mut cursor = session.open_record_cursor("test").unwrap();
         let value: &[u8] = b"bar";
         assert_eq!(cursor.set(&RecordView::new(7, value)), Ok(()));
@@ -241,9 +239,7 @@ mod test {
         let tmpdir = tempfile::tempdir().unwrap();
         let conn = Connection::open(tmpdir.path().to_str().unwrap(), conn_options()).unwrap();
         let session = conn.open_session().unwrap();
-        session
-            .create_record_table("test", index_table_options())
-            .unwrap();
+        session.create_table("test", index_table_options()).unwrap();
         let mut cursor = session.open_index_cursor("test").unwrap();
         let value: &[u8] = b"bar";
         assert_eq!(cursor.set(&IndexRecordView::new(b"a", value)), Ok(()));
@@ -263,7 +259,7 @@ mod test {
         let tmpdir = tempfile::tempdir().unwrap();
         let conn = Connection::open(tmpdir.path().to_str().unwrap(), conn_options()).unwrap();
         let session = conn.open_session().unwrap();
-        session.create_record_table("test", None).unwrap();
+        session.create_table("test", None).unwrap();
         let mut cursor = session.open_record_cursor("test").unwrap();
         assert_eq!(cursor.set(&RecordView::new(11, b"bar")), Ok(()));
         assert_eq!(cursor.set(&RecordView::new(7, b"foo")), Ok(()));
@@ -281,9 +277,7 @@ mod test {
         let tmpdir = tempfile::tempdir().unwrap();
         let conn = Connection::open(tmpdir.path().to_str().unwrap(), conn_options()).unwrap();
         let session = conn.open_session().unwrap();
-        session
-            .create_record_table("test", index_table_options())
-            .unwrap();
+        session.create_table("test", index_table_options()).unwrap();
         let mut cursor = session.open_index_cursor("test").unwrap();
         assert_eq!(cursor.set(&IndexRecordView::new(b"b", b"bar")), Ok(()));
         assert_eq!(cursor.set(&IndexRecordView::new(b"a", b"foo")), Ok(()));
@@ -301,7 +295,7 @@ mod test {
         let tmpdir = tempfile::tempdir().unwrap();
         let conn = Connection::open(tmpdir.path().to_str().unwrap(), conn_options()).unwrap();
         let session = conn.open_session().unwrap();
-        session.create_record_table("test", None).unwrap();
+        session.create_table("test", None).unwrap();
         let mut cursor = session.open_record_cursor("test").unwrap();
         assert_eq!(cursor.largest_key(), None);
         assert_eq!(cursor.set(&RecordView::new(-1, b"bar")), Ok(()));
@@ -315,9 +309,7 @@ mod test {
         let tmpdir = tempfile::tempdir().unwrap();
         let conn = Connection::open(tmpdir.path().to_str().unwrap(), conn_options()).unwrap();
         let session = conn.open_session().unwrap();
-        session
-            .create_record_table("test", index_table_options())
-            .unwrap();
+        session.create_table("test", index_table_options()).unwrap();
         let mut cursor = session.open_index_cursor("test").unwrap();
         assert_eq!(cursor.largest_key(), None);
         assert_eq!(cursor.set(&IndexRecordView::new(b"a", b"bar")), Ok(()));
@@ -331,7 +323,7 @@ mod test {
         let tmpdir = tempfile::tempdir().unwrap();
         let conn = Connection::open(tmpdir.path().to_str().unwrap(), conn_options()).unwrap();
         let session = conn.open_session().unwrap();
-        session.create_record_table("test", None).unwrap();
+        session.create_table("test", None).unwrap();
         let read_session = conn.open_session().unwrap();
         let mut read_cursor = read_session.open_record_cursor("test").unwrap();
 
@@ -350,7 +342,7 @@ mod test {
         let tmpdir = tempfile::tempdir().unwrap();
         let conn = Connection::open(tmpdir.path().to_str().unwrap(), conn_options()).unwrap();
         let session = conn.open_session().unwrap();
-        session.create_record_table("test", None).unwrap();
+        session.create_table("test", None).unwrap();
 
         let mut cursor = session.open_record_cursor("test").unwrap();
         assert_eq!(session.begin_transaction(None), Ok(()));
@@ -365,7 +357,7 @@ mod test {
         let tmpdir = tempfile::tempdir().unwrap();
         let conn = Connection::open(tmpdir.path().to_str().unwrap(), conn_options()).unwrap();
         let session = conn.open_session().unwrap();
-        session.create_record_table("test", None).unwrap();
+        session.create_table("test", None).unwrap();
 
         let mut cursor = session.get_record_cursor("test").unwrap();
         assert_eq!(cursor.set(&RecordView::new(1, b"foo")), Ok(()));
@@ -406,7 +398,7 @@ mod test {
         let session = conn.open_session().unwrap();
 
         // Bulk load will happily load into an empty table, so to get it to fail we insert a record.
-        assert_eq!(session.create_record_table("test", None), Ok(()));
+        assert_eq!(session.create_table("test", None), Ok(()));
         let mut cursor = session.open_record_cursor("test").unwrap();
         assert_eq!(cursor.set(&RecordView::new(1, b"bar")), Ok(()));
         assert_eq!(
@@ -445,7 +437,7 @@ mod test {
         )
         .unwrap();
         let session = conn.open_session().unwrap();
-        session.create_record_table("test", None).unwrap();
+        session.create_table("test", None).unwrap();
         let mut cursor = session.open_record_cursor("test").unwrap();
         assert_eq!(cursor.set(&RecordView::new(11, b"bar")), Ok(()));
         assert_eq!(cursor.set(&RecordView::new(7, b"foo")), Ok(()));

--- a/wt_mdb/src/lib.rs
+++ b/wt_mdb/src/lib.rs
@@ -123,6 +123,7 @@ impl From<Error> for std::io::Error {
     }
 }
 
+// XXX move this into record_cursor.
 /// A `RecordView` in a WiredTiger table with an i64 key and a byte array value.
 ///
 /// The underlying byte array may or may not be owned, the `Record` type alias may be more
@@ -171,7 +172,10 @@ impl<'a> RecordView<'a> {
 pub type Record = RecordView<'static>;
 
 pub use connection::Connection;
-pub use session::{RecordCursor, RecordCursorGuard, Session, StatCursor};
+pub use session::{
+    IndexCursor, IndexCursorGuard, IndexRecord, IndexRecordView, RecordCursor, RecordCursorGuard,
+    Session, StatCursor,
+};
 pub type Result<T> = std::result::Result<T, Error>;
 
 fn make_result<T>(code: i32, value: T) -> Result<T> {

--- a/wt_mdb/src/options.rs
+++ b/wt_mdb/src/options.rs
@@ -160,7 +160,7 @@ pub struct CreateOptionsBuilder(TableType);
 
 impl CreateOptionsBuilder {
     /// Set the table type for this table.
-    fn table_type(self, table_type: TableType) -> Self {
+    pub fn table_type(self, table_type: TableType) -> Self {
         Self(table_type)
     }
 }

--- a/wt_mdb/src/session/index_cursor.rs
+++ b/wt_mdb/src/session/index_cursor.rs
@@ -1,21 +1,66 @@
 use std::{
+    borrow::Cow,
     ffi::CStr,
     mem::ManuallyDrop,
     ops::{Bound, Deref, DerefMut, RangeBounds},
 };
 
-use crate::{map_not_found, wt_call, Record, RecordView, Result};
+use crate::{map_not_found, wt_call, Result};
 
 use super::{InnerCursor, Item, Session};
 
-/// A `RecordCursor` facilities viewing and mutating data in a WiredTiger table where
-/// the table is `i64` keyed and byte-string valued.
-pub struct RecordCursor<'a> {
+/// A `IndexRecordView` in a WiredTiger table with an i64 key and a byte array value.
+///
+/// The underlying byte array may or may not be owned, the `IndexRecord` type alias may be more
+/// convenient when the data is owned.
+#[derive(Clone, Debug, Hash, Eq, PartialEq)]
+pub struct IndexRecordView<'a, 'b> {
+    key: Cow<'a, [u8]>,
+    value: Cow<'b, [u8]>,
+}
+
+impl<'a, 'b> IndexRecordView<'a, 'b> {
+    /// Create a new `IndexRecordView` from a key and an unowned byte array value.
+    pub fn new<K: Into<Cow<'a, [u8]>>, V: Into<Cow<'b, [u8]>>>(key: K, value: V) -> Self {
+        IndexRecordView {
+            key: key.into(),
+            value: value.into(),
+        }
+    }
+
+    /// Return the key.
+    pub fn key(&self) -> &[u8] {
+        self.key.as_ref()
+    }
+
+    /// Return the value.
+    pub fn value(&self) -> &[u8] {
+        self.value.as_ref()
+    }
+
+    /// Ensure that this IndexRecordView owns the underlying value.
+    pub fn to_owned(self) -> IndexRecord {
+        IndexRecord::new(self.key().to_vec(), self.value.to_vec())
+    }
+
+    /// Returns the inner key and value within the `IndexRecordView`.
+    pub fn into_inner(self) -> (Cow<'a, [u8]>, Cow<'b, [u8]>) {
+        (self.key, self.value)
+    }
+}
+
+/// An alias for `IndexRecordView` with `'static` lifetime, may be more convenient when the value is
+/// actually owned.
+pub type IndexRecord = IndexRecordView<'static, 'static>;
+
+/// An `IndexCursor` facilities viewing and mutating data in a WiredTiger table where
+/// the table is byte-string keyed and byte-string valued.
+pub struct IndexCursor<'a> {
     inner: InnerCursor,
     session: &'a Session,
 }
 
-impl<'a> RecordCursor<'a> {
+impl<'a> IndexCursor<'a> {
     pub(super) fn new(inner: InnerCursor, session: &'a Session) -> Self {
         Self { inner, session }
     }
@@ -30,11 +75,11 @@ impl<'a> RecordCursor<'a> {
     }
 
     /// Set the contents of `record` in the collection.
-    pub fn set(&mut self, record: &RecordView<'_>) -> Result<()> {
+    pub fn set(&mut self, record: &IndexRecordView<'_, '_>) -> Result<()> {
         // safety: the memory passed to set_{key,value} need only be valid until a modifying
         // call like insert().
         unsafe {
-            wt_call!(void self.inner.ptr, set_key, record.key())?;
+            wt_call!(void self.inner.ptr, set_key, &Item::from(record.key()).0)?;
             wt_call!(void
                 self.inner.ptr,
                 set_value,
@@ -47,9 +92,9 @@ impl<'a> RecordCursor<'a> {
     /// Remove a record by `key`.
     ///
     /// This may return a `WiredTigerError::NotFound` if the key does not exist in the collection.
-    pub fn remove(&mut self, key: i64) -> Result<()> {
+    pub fn remove(&mut self, key: &[u8]) -> Result<()> {
         unsafe {
-            wt_call!(void self.inner.ptr, set_key, key)?;
+            wt_call!(void self.inner.ptr, set_key, &Item::from(key).0)?;
             wt_call!(self.inner.ptr, remove)
         }
     }
@@ -65,10 +110,8 @@ impl<'a> RecordCursor<'a> {
     /// If the cursor's parent session returns this record during a transaction and that transaction
     /// is rolled back, we cannot guarantee that view value data is safe to access. Use
     /// `Iterator.next()` to ensure safe access at the cost of a copy of the record value.
-    pub unsafe fn next_unsafe(&mut self) -> Option<Result<RecordView<'_>>> {
-        map_not_found(
-            unsafe { wt_call!(self.inner.ptr, next) }.and_then(|()| self.record_view(None)),
-        )
+    pub unsafe fn next_unsafe(&mut self) -> Option<Result<IndexRecordView<'_, '_>>> {
+        map_not_found(unsafe { wt_call!(self.inner.ptr, next) }.and_then(|()| self.record_view()))
     }
 
     /// Seek to the for `key` and return any associated `RecordView` if present.
@@ -77,23 +120,26 @@ impl<'a> RecordCursor<'a> {
     /// If the cursor's parent session returns this record during a transaction and that transaction
     /// is rolled back, we cannot guarantee that view value data is safe to access. Use
     /// `seek_exact()` to ensure safe access at the cost of a copy of the record value.
-    pub unsafe fn seek_exact_unsafe(&mut self, key: i64) -> Option<Result<RecordView<'_>>> {
+    pub unsafe fn seek_exact_unsafe<'k>(
+        &mut self,
+        key: &'k [u8],
+    ) -> Option<Result<IndexRecordView<'k, '_>>> {
         map_not_found(
             unsafe {
-                wt_call!(void self.inner.ptr, set_key, key)
+                wt_call!(void self.inner.ptr, set_key, &Item::from(key).0)
                     .and_then(|()| wt_call!(self.inner.ptr, search))
             }
-            .and_then(|()| self.record_view(Some(key))),
+            .and_then(|()| self.record_value().map(|v| IndexRecordView::new(key, v))),
         )
     }
 
     /// Seek to the for `key` and return any associated `Record` if present.
-    pub fn seek_exact(&mut self, key: i64) -> Option<Result<Record>> {
+    pub fn seek_exact(&mut self, key: &[u8]) -> Option<Result<IndexRecord>> {
         unsafe { self.seek_exact_unsafe(key) }.map(|r| r.map(|v| v.to_owned()))
     }
 
     /// Return the largest key in the collection or `None` if the collection is empty.
-    pub fn largest_key(&mut self) -> Option<Result<i64>> {
+    pub fn largest_key(&mut self) -> Option<Result<&[u8]>> {
         map_not_found(
             unsafe { wt_call!(self.inner.ptr, largest_key) }.and_then(|()| self.record_key()),
         )
@@ -103,7 +149,7 @@ impl<'a> RecordCursor<'a> {
     /// a `seek_exact()` with a key out of bounds might yield `None`.
     ///
     /// Cursor bounds are removed by `reset()`.
-    pub fn set_bounds(&mut self, bounds: impl RangeBounds<i64>) -> Result<()> {
+    pub fn set_bounds<'b>(&mut self, bounds: impl RangeBounds<&'b [u8]>) -> Result<()> {
         let (start_key, start_config_str) = match bounds.start_bound() {
             Bound::Included(key) => (Some(*key), c"bound=lower,action=set"),
             Bound::Excluded(key) => (Some(*key), c"bound=lower,action=set,inclusive=false"),
@@ -126,52 +172,51 @@ impl<'a> RecordCursor<'a> {
 
     /// Reset the cursor to an unpositioned state.
     pub fn reset(&mut self) -> Result<()> {
-        self.inner.reset()
+        unsafe { wt_call!(self.inner.ptr, reset) }
     }
 
     /// Return the current record key. This assumes that we have just positioned the cursor
     /// and WT_NOTFOUND will not be returned.
-    fn record_key(&self) -> Result<i64> {
-        let mut k = 0i64;
-        unsafe { wt_call!(self.inner.ptr, get_key, &mut k).map(|()| k) }
+    fn record_key(&self) -> Result<&[u8]> {
+        let mut k = Item::default();
+        unsafe { wt_call!(self.inner.ptr, get_key, &mut k.0).map(|()| k.into()) }
+    }
+
+    /// Return the current record value. This assumes that we have just positioned the cursor
+    /// and WT_NOTFOUND will not be returned.
+    fn record_value(&self) -> Result<&[u8]> {
+        let mut k = Item::default();
+        unsafe { wt_call!(self.inner.ptr, get_value, &mut k.0).map(|()| k.into()) }
     }
 
     /// Return the current record view. This assumes that we have just positioned the cursor
     /// and WT_NOTFOUND will not be returned.
-    ///
-    /// A `known_key` may be provided in cases where we seeked by key that will be used in
-    /// the returned record view rather than examining the cursor.
-    fn record_view(&self, known_key: Option<i64>) -> Result<RecordView<'_>> {
-        let key = known_key.map(Ok).unwrap_or_else(|| self.record_key())?;
-
-        let value: &[u8] = unsafe {
-            let mut item = Item::default();
-            wt_call!(self.inner.ptr, get_value, &mut item.0).map(|()| item.into())?
-        };
-
-        Ok(RecordView::new(key, value))
+    fn record_view(&self) -> Result<IndexRecordView<'_, '_>> {
+        let key = self.record_key()?;
+        let value = self.record_value()?;
+        Ok(IndexRecordView::new(key, value))
     }
 }
 
-impl Iterator for RecordCursor<'_> {
-    type Item = Result<Record>;
+impl Iterator for IndexCursor<'_> {
+    type Item = Result<IndexRecord>;
 
     /// Advance and return the next record.
     ///
     /// If this cursor is unpositioned, returns to the start of the collection.
     fn next(&mut self) -> Option<Self::Item> {
-        unsafe { self.next_unsafe() }.map(|r| r.map(RecordView::to_owned))
+        unsafe { self.next_unsafe() }.map(|r| r.map(IndexRecordView::to_owned))
     }
 }
 
-pub struct RecordCursorGuard<'a> {
+pub struct IndexCursorGuard<'a> {
     session: &'a Session,
     // On drop we will take the value and return it to session.
-    cursor: ManuallyDrop<RecordCursor<'a>>,
+    cursor: ManuallyDrop<IndexCursor<'a>>,
 }
 
-impl<'a> RecordCursorGuard<'a> {
-    pub(super) fn new(session: &'a Session, cursor: RecordCursor<'a>) -> Self {
+impl<'a> IndexCursorGuard<'a> {
+    pub(super) fn new(session: &'a Session, cursor: IndexCursor<'a>) -> Self {
         Self {
             session,
             cursor: ManuallyDrop::new(cursor),
@@ -179,23 +224,23 @@ impl<'a> RecordCursorGuard<'a> {
     }
 }
 
-impl<'a> Deref for RecordCursorGuard<'a> {
-    type Target = RecordCursor<'a>;
+impl<'a> Deref for IndexCursorGuard<'a> {
+    type Target = IndexCursor<'a>;
 
     fn deref(&self) -> &Self::Target {
         &self.cursor
     }
 }
 
-impl DerefMut for RecordCursorGuard<'_> {
+impl DerefMut for IndexCursorGuard<'_> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.cursor
     }
 }
 
-impl Drop for RecordCursorGuard<'_> {
+impl Drop for IndexCursorGuard<'_> {
     fn drop(&mut self) {
-        // Safety: we never intend to allow RecordCursorGuard to drop the value.
+        // Safety: we never intend to allow IndexCursorGuard to drop the value.
         self.session
             .return_cursor(unsafe { ManuallyDrop::take(&mut self.cursor).inner });
     }

--- a/wt_mdb/src/session/mod.rs
+++ b/wt_mdb/src/session/mod.rs
@@ -149,13 +149,8 @@ impl Session {
         &self.connection
     }
 
-    // XXX fix the name. this can create index type tables too now.
-    /// Create a new record table.
-    pub fn create_record_table(
-        &self,
-        table_name: &str,
-        config: Option<CreateOptions>,
-    ) -> Result<()> {
+    /// Create a new table.
+    pub fn create_table(&self, table_name: &str, config: Option<CreateOptions>) -> Result<()> {
         let uri = TableUri::from(table_name);
         unsafe {
             wt_call!(
@@ -167,12 +162,11 @@ impl Session {
         }
     }
 
-    // XXX fix the name. this can create index type tables too now.
-    /// Drop a record table.
+    /// Drop a table.
     ///
     /// This requires exclusive access -- if any cursors are open on the specified table the call will fail
     /// and return an EBUSY posix error.
-    pub fn drop_record_table(&self, table_name: &str, config: Option<DropOptions>) -> Result<()> {
+    pub fn drop_table(&self, table_name: &str, config: Option<DropOptions>) -> Result<()> {
         let uri = TableUri::from(table_name);
         unsafe {
             wt_call!(
@@ -345,7 +339,7 @@ impl Session {
     where
         I: Iterator<Item = RecordView<'a>>,
     {
-        self.create_record_table(table_name, options)?;
+        self.create_table(table_name, options)?;
         let mut cursor = self.open_record_cursor_with_options(table_name, Some(c"bulk=true"))?;
         for record in iter {
             cursor.set(&record)?;

--- a/wt_mdb/src/session/mod.rs
+++ b/wt_mdb/src/session/mod.rs
@@ -19,11 +19,11 @@ use crate::{
         BeginTransactionOptions, CommitTransactionOptions, ConfigurationString, CreateOptions,
         DropOptions, RollbackTransactionOptions, Statistics, TableType,
     },
-    wt_call, Error, RecordView, Result,
+    wt_call, Error, Result,
 };
 
 pub use index_cursor::{IndexCursor, IndexCursorGuard, IndexRecord, IndexRecordView};
-pub use record_cursor::{RecordCursor, RecordCursorGuard};
+pub use record_cursor::{Record, RecordCursor, RecordCursorGuard, RecordView};
 pub use stat_cursor::StatCursor;
 
 /// URI of a WT table encoded as a CString.

--- a/wt_mdb/src/session/record_cursor.rs
+++ b/wt_mdb/src/session/record_cursor.rs
@@ -1,12 +1,60 @@
 use std::{
+    borrow::Cow,
     ffi::CStr,
     mem::ManuallyDrop,
     ops::{Bound, Deref, DerefMut, RangeBounds},
 };
 
-use crate::{map_not_found, wt_call, Record, RecordView, Result};
+use crate::{map_not_found, wt_call, Result};
 
 use super::{InnerCursor, Item, Session};
+
+/// A `RecordView` in a WiredTiger table with an i64 key and a byte array value.
+///
+/// The underlying byte array may or may not be owned, the `Record` type alias may be more
+/// convenient when the data is owned.
+#[derive(Clone, Debug, Hash, Eq, PartialEq)]
+pub struct RecordView<'a> {
+    key: i64,
+    value: Cow<'a, [u8]>,
+}
+
+impl<'a> RecordView<'a> {
+    /// Create a new `RecordView` from a key and an unowned byte array value.
+    pub fn new<V>(key: i64, value: V) -> Self
+    where
+        V: Into<Cow<'a, [u8]>>,
+    {
+        RecordView {
+            key,
+            value: value.into(),
+        }
+    }
+
+    /// Return the key.
+    pub fn key(&self) -> i64 {
+        self.key
+    }
+
+    /// Return the value.
+    pub fn value(&self) -> &[u8] {
+        self.value.as_ref()
+    }
+
+    /// Ensure that this RecordView owns the underlying value.
+    pub fn to_owned(self) -> Record {
+        Record::new(self.key(), self.value.to_vec())
+    }
+
+    /// Returns the inner value within the `RecordView`.
+    pub fn into_inner_value(self) -> Cow<'a, [u8]> {
+        self.value
+    }
+}
+
+/// An alias for `RecordView` with `'static` lifetime, may be more convenient when the value is
+/// actually owned.
+pub type Record = RecordView<'static>;
 
 /// A `RecordCursor` facilities viewing and mutating data in a WiredTiger table where
 /// the table is `i64` keyed and byte-string valued.


### PR DESCRIPTION
This would allow implementing an index on top of a record table by generating custom keys to speed up access
and perform a certain amount of projection.

There is quite a bit of duplication between the record and index types for cursors and data access, maybe I will
factor this better if we end up with a third set of similar structs.