### PR TITLE
Improve bulk load performance

### DIFF
--- a/et/src/bulk_load.rs
+++ b/et/src/bulk_load.rs
@@ -35,13 +35,13 @@ pub struct BulkLoadArgs {
     memory_quantized_vectors: bool,
 
     /// Maximum number of edges for any vertex.
-    #[arg(short, long, default_value = "64")]
+    #[arg(short, long, default_value = "32")]
     max_edges: NonZero<usize>,
     /// Number of edges to search for when indexing a vertex.
     ///
     /// Larger values make indexing more expensive but may also produce a larger, more
     /// saturated graph that has higher recall.
-    #[arg(short, long, default_value = "256")]
+    #[arg(short, long, default_value = "128")]
     edge_candidates: NonZero<usize>,
     /// Number of edge candidates to rerank. Defaults to edge_candidates.
     ///

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -21,9 +21,7 @@ use std::{
 
 use crossbeam_skiplist::SkipSet;
 use memmap2::{Mmap, MmapMut};
-use rayon::iter::{
-    IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator, ParallelIterator,
-};
+use rayon::prelude::*;
 use wt_mdb::{Connection, Record, Result, Session};
 
 use crate::{
@@ -78,8 +76,6 @@ pub struct BulkLoadBuilder<D> {
     memory_quantized_vectors: bool,
     quantized_vectors: Option<DerefVectorStore<u8, Mmap>>,
 
-    // XXX store negative neighbor ids for "unchecked" nodes.
-    // use this unchecked-ness as part of pruning.
     graph: Box<[RwLock<Vec<Neighbor>>]>,
     entry_vertex: AtomicI64,
     scorer: Box<dyn F32VectorScorer>,
@@ -206,14 +202,47 @@ where
                     // Insert any other in-flight edges into the candidate queue. These are vertices we may have missed because
                     // they are being inserted concurrently in another thread.
                     self.insert_in_flight_edges(i, in_flight.iter().map(|e| *e), &mut edges);
+                    assert!(
+                        !edges.iter().any(|n| n.vertex() == i as i64),
+                        "Candidate edges for vertex {} contains self-edge.",
+                        i
+                    );
                     let centroid_score = self.scorer.score(&self.get_vector(i), &self.centroid);
-                    {
+                    // Add each edge to this vertex and a reciprocal edge to make the graph
+                    // undirected. If an edge does not fit on either vertex, save it for later.
+                    // We will prune any vertices in this state, but put together the pruned edge
+                    // list outside of `apply_mu` to maximize concurrency.
+                    loop {
                         let mut entry_point = apply_mu.lock().unwrap();
-                        self.apply_insert(i, edges)?;
-                        if centroid_score > entry_point.1 {
-                            entry_point.0 = i as i64;
-                            entry_point.1 = centroid_score;
-                            self.entry_vertex.store(i as i64, atomic::Ordering::SeqCst);
+
+                        edges.retain(|e| {
+                            let (mut iv, mut ev) = self.lock_edge(i, e.vertex() as usize);
+                            if iv.len() == iv.capacity() || ev.len() == ev.capacity() {
+                                true
+                            } else {
+                                iv.push(*e);
+                                let backedge = Neighbor::new(i as i64, e.score());
+                                if !ev.contains(&backedge) {
+                                    ev.push(backedge);
+                                }
+                                false
+                            }
+                        });
+
+                        if edges.is_empty() {
+                            if centroid_score > entry_point.1 {
+                                entry_point.0 = i as i64;
+                                entry_point.1 = centroid_score;
+                                self.entry_vertex.store(i as i64, atomic::Ordering::SeqCst);
+                            }
+                            break;
+                        }
+
+                        drop(entry_point);
+                        // Any edge still in the list is overful, so prune it.
+                        self.prune_and_apply(i, &apply_mu)?;
+                        for e in edges.iter() {
+                            self.prune_and_apply(e.vertex() as usize, &apply_mu)?;
                         }
                     }
                     // Close out the transaction. There should be no conflicts as we did not write to the database.
@@ -238,48 +267,11 @@ where
         // this is necessary to ensure the graph remains undirected.
         let apply_mu = Mutex::new(());
 
-        let max_edges = self.index.config().max_edges;
-        self.graph
-            .par_iter()
-            .enumerate()
-            .take(self.limit)
-            .try_for_each(|(i, m)| {
-                // Get the set of edges to prune while only holding a read lock on the vertex.
-                let pruned_edges = {
-                    let v = m.read().unwrap();
-                    let selected = select_pruned_edges(
-                        &v,
-                        max_edges,
-                        &mut BulkLoadBuilderGraph(self),
-                        self.scorer.as_ref(),
-                    )?;
-                    v.iter()
-                        .enumerate()
-                        .filter_map(|(i, e)| {
-                            if !selected.contains(&i) {
-                                Some(e.vertex())
-                            } else {
-                                None
-                            }
-                        })
-                        .collect::<Vec<_>>()
-                };
-
-                // Apply pruned_edges, starting with the lowest scoring edge.
-                let a = apply_mu.lock().unwrap();
-                for e in pruned_edges.into_iter().rev() {
-                    let mut iv = self.graph[i].write().unwrap();
-                    let mut ev = self.graph[e as usize].write().unwrap();
-                    if iv.len() > max_edges.get() || ev.len() > max_edges.get() {
-                        iv.retain(|n| n.vertex() != e);
-                        ev.retain(|n| n.vertex() != i as i64);
-                    }
-                }
-                drop(a);
-
-                progress();
-                Ok::<_, wt_mdb::Error>(())
-            })
+        (0..self.limit).into_par_iter().try_for_each(|v| {
+            self.prune_and_apply(v, &apply_mu)?;
+            progress();
+            Ok::<_, wt_mdb::Error>(())
+        })
     }
 
     /// Bulk load the graph table with raw vectors and graph edges.
@@ -345,6 +337,7 @@ where
         reader: &mut BulkLoadGraphVectorIndexReader<'_, D>,
     ) -> Result<Vec<Neighbor>> {
         let mut graph = BulkLoadBuilderGraph(self);
+        // TODO: return any vectors used for re-ranking here so that we can use them for pruning.
         let mut candidates = searcher.search_for_insert(vertex_id as i64, reader)?;
         let split = prune_edges(
             &mut candidates,
@@ -384,56 +377,73 @@ where
         }
     }
 
-    /// This function is the only mutator of self.graph and must not be run concurrently.
-    fn apply_insert(&self, index: usize, edges: Vec<Neighbor>) -> Result<()> {
-        assert!(
-            !edges.iter().any(|n| n.vertex() == index as i64),
-            "Candidate edges for vertex {} contains self-edge.",
-            index
-        );
-        self.graph[index].write().unwrap().extend_from_slice(&edges);
-        for e in edges.iter() {
-            let mut guard = self.graph[e.vertex() as usize].write().unwrap();
-            let backedge = Neighbor::new(index as i64, e.score());
-            if !guard.contains(&backedge) {
-                guard.push(backedge);
-                let max_edges = NonZero::new(guard.capacity() - 1).unwrap();
-                self.maybe_prune_node(index, guard, max_edges)?;
+    fn prune_and_apply<T>(&self, vertex: usize, apply_mu: &Mutex<T>) -> Result<()> {
+        // Get the set of edges to prune while only holding a read lock on the vertex.
+        let max_edges = self.index.config().max_edges;
+        let pruned_edges = {
+            let v = self.graph[vertex].read().unwrap();
+            if v.len() > max_edges.get() {
+                // We copy the contents of the graph because they need to be sorted to prune.
+                // XXX We still hold the mutex. why???
+                let mut edges = v.clone();
+                edges.sort_unstable();
+                let selected = select_pruned_edges(
+                    &edges,
+                    max_edges,
+                    &mut BulkLoadBuilderGraph(self),
+                    self.scorer.as_ref(),
+                )?;
+                edges
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(i, e)| {
+                        if !selected.contains(&i) {
+                            Some(e.vertex())
+                        } else {
+                            None
+                        }
+                    })
+                    .collect::<Vec<_>>()
+            } else {
+                vec![]
+            }
+        };
+
+        if pruned_edges.is_empty() {
+            return Ok(());
+        }
+
+        // Apply pruned_edges, starting with the lowest scoring edge.
+        let _a = apply_mu.lock().unwrap();
+        for e in pruned_edges.into_iter().rev() {
+            let (mut iv, mut ev) = self.lock_edge(vertex, e as usize);
+            if iv.len() > max_edges.get() || ev.len() > max_edges.get() {
+                iv.retain(|n| n.vertex() != e);
+                ev.retain(|n| n.vertex() != vertex as i64);
             }
         }
         Ok(())
     }
 
-    fn maybe_prune_node(
+    // Lock the vertices related to the edge in a consistent order (lowest ord first).
+    fn lock_edge(
         &self,
-        index: usize,
-        mut guard: RwLockWriteGuard<'_, Vec<Neighbor>>,
-        max_edges: NonZero<usize>,
-    ) -> Result<()> {
-        if guard.len() <= max_edges.get() {
-            return Ok(());
+        vertex0: usize,
+        vertex1: usize,
+    ) -> (
+        RwLockWriteGuard<'_, Vec<Neighbor>>,
+        RwLockWriteGuard<'_, Vec<Neighbor>>,
+    ) {
+        assert_ne!(vertex0, vertex1);
+        if vertex0 < vertex1 {
+            (
+                self.graph[vertex0].write().unwrap(),
+                self.graph[vertex1].write().unwrap(),
+            )
+        } else {
+            let g1 = self.graph[vertex1].write().unwrap();
+            (self.graph[vertex0].write().unwrap(), g1)
         }
-
-        guard.sort();
-        let split = prune_edges(
-            &mut guard,
-            self.index.config().max_edges,
-            &mut BulkLoadBuilderGraph(self),
-            self.scorer.as_ref(),
-        )?;
-        let dropped = guard.split_off(split);
-        drop(guard);
-
-        // Remove in-links from nodes that we dropped out-links to.
-        // If we maintain the invariant that all links are reciprocated then it will be easier
-        // to mutate the index without requiring a cleaning process.
-        for n in dropped {
-            self.graph[n.vertex() as usize]
-                .write()
-                .unwrap()
-                .retain(|e| e.vertex() != index as i64);
-        }
-        Ok(())
     }
 
     fn get_vector(&self, index: usize) -> Cow<'_, [f32]> {

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -384,8 +384,9 @@ where
             let v = self.graph[vertex].read().unwrap();
             if v.len() > max_edges.get() {
                 // We copy the contents of the graph because they need to be sorted to prune.
-                // XXX We still hold the mutex. why???
                 let mut edges = v.clone();
+                drop(v);
+
                 edges.sort_unstable();
                 let selected = select_pruned_edges(
                     &edges,

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -129,22 +129,24 @@ pub trait NavVectorStore {
     fn get(&mut self, vertex_id: i64) -> Option<Result<Cow<'_, [u8]>>>;
 }
 
-/// Prune `edges` down to at most `max_edges`. Use `graph` and `scorer` to inform this decision.
-/// Returns a split point: all edges before that point are selected, all after are to be dropped.
+/// Select the indices of `edges` that should remain when pruning down to at most `max_edges`.
+/// `graph` is used to access vectors and `scorer` is used to compare vectors when making pruning
+/// decisions.
 /// REQUIRES: `edges.is_sorted()`.
 // TODO: alpha value(s) should be tuneable.
-pub(crate) fn prune_edges(
-    edges: &mut [Neighbor],
+pub(crate) fn select_pruned_edges(
+    edges: &[Neighbor],
     max_edges: NonZero<usize>,
     graph: &mut impl Graph,
     scorer: &dyn F32VectorScorer,
-) -> Result<usize> {
+) -> Result<BTreeSet<usize>> {
     if edges.is_empty() {
-        return Ok(0);
+        return Ok(BTreeSet::new());
     }
 
     debug_assert!(edges.is_sorted());
 
+    // XXX do this incrementally rather than pre-emptively.
     // Obtain all the vectors to make relative neighbor graph scoring easier.
     let vectors = edges
         .iter()
@@ -182,6 +184,21 @@ pub(crate) fn prune_edges(
             break;
         }
     }
+
+    Ok(selected)
+}
+
+/// Prune `edges` down to at most `max_edges`. Use `graph` and `scorer` to inform this decision.
+/// Returns a split point: all edges before that point are selected, all after are to be dropped.
+/// REQUIRES: `edges.is_sorted()`.
+// TODO: alpha value(s) should be tuneable.
+pub(crate) fn prune_edges(
+    edges: &mut [Neighbor],
+    max_edges: NonZero<usize>,
+    graph: &mut impl Graph,
+    scorer: &dyn F32VectorScorer,
+) -> Result<usize> {
+    let selected = select_pruned_edges(edges, max_edges, graph, scorer)?;
 
     // Partition edges into selected and unselected.
     for (i, j) in selected.iter().enumerate() {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -146,7 +146,6 @@ pub(crate) fn select_pruned_edges(
 
     debug_assert!(edges.is_sorted());
 
-    // XXX do this incrementally rather than pre-emptively.
     // Obtain all the vectors to make relative neighbor graph scoring easier.
     let vectors = edges
         .iter()


### PR DESCRIPTION
Make the critical section for graph mutations much shorter in all cases:
* During build do not hold the mutex if you need to prune a vertex's edges. If one of the target vertices for an edge is "full" we will defer until after we've pruned.
* Select edges to prune without holding any locks, then remove pruned edges worst-to-best.
* During the cleanup step parallelize selection of pruned edges.