### PR TITLE
Fix gcc build in release mode

### DIFF
--- a/wt_sys/build.rs
+++ b/wt_sys/build.rs
@@ -8,6 +8,7 @@ fn build_wt() -> PathBuf {
         .define("ENABLE_STATIC", "1")
         .define("HAVE_DIAGNOSTIC", if have_diagnostic { "1" } else { "0" })
         .define("ENABLE_PYTHON", "0")
+        .cflag("-Wno-array-bounds")
         // CMake crate is not doing this correctly for whatever reason.
         .build_arg(format!("-j{}", jobs))
         .build();


### PR DESCRIPTION
This only seems to affect release mode with gcc:

```
  In function '__wt_vunpack_uint',
      inlined from '__wt_cell_unpack_safe.constprop.isra' at /home/mccullocht/projects/easy_tiger/wt_sys/wiredtiger/src/include/cell_inline.h:894:9:
  /home/mccullocht/projects/easy_tiger/wt_sys/wiredtiger/src/include/intpack_inline.h:273:13: error: array subscript 0 is outside array bounds of 'wt_timestamp_t[0]' {aka 'long unsigned int[]'} [-Werror=array-bounds=]
    273 |         *xp = GET_BITS(*p++, 5, 0) << 8;
        |         ~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
  In function '__wt_cell_unpack_safe.constprop.isra':
  cc1: note: source object is likely at address zero
```