### PR TITLE
Allow a totally split physical layout

### DIFF
--- a/et/src/bulk_load.rs
+++ b/et/src/bulk_load.rs
@@ -30,6 +30,17 @@ pub struct BulkLoadArgs {
     /// This will also dictate the quantized scoring function used.
     #[arg(short, long, value_enum)]
     quantizer: VectorQuantizer,
+
+    /// Physical layout used for graph.
+    ///
+    /// `split` puts raw vectors, nav vectors, and graph edges each in separate tables. If results
+    /// are being re-ranked this will require additional reads to complete.
+    ///
+    /// `raw_vector_in_graph` places raw vectors and graph edges in the same table. When a vertex
+    /// is visited the raw vector is read and saved for re-scoring. This minimizes the number of
+    /// reads performed and is likely better for indices with less traffic.
+    #[arg(long, value_enum, default_value = "raw_vector_in_graph")]
+    layout: GraphLayout,
     /// If true, load all quantized vectors into a trivial memory store for bulk loading.
     /// This can be significantly faster than reading these values from WiredTiger.
     #[arg(long, default_value_t = false)]
@@ -80,7 +91,7 @@ pub fn bulk_load(
         dimensions: args.dimensions,
         similarity: args.similarity,
         quantizer: args.quantizer,
-        layout: GraphLayout::RawVectorInGraph, // XXX allow args
+        layout: args.layout,
         max_edges: args.max_edges,
         index_search_params: GraphSearchParams {
             beam_width: args.edge_candidates,

--- a/et/src/bulk_load.rs
+++ b/et/src/bulk_load.rs
@@ -3,7 +3,7 @@ use std::{fs::File, io, num::NonZero, path::PathBuf, sync::Arc};
 use clap::Args;
 use easy_tiger::{
     bulk::{BulkLoadBuilder, Options},
-    graph::{GraphConfig, GraphSearchParams},
+    graph::{GraphConfig, GraphLayout, GraphSearchParams},
     input::{DerefVectorStore, VectorStore},
     quantization::VectorQuantizer,
     scoring::VectorSimilarity,
@@ -80,6 +80,7 @@ pub fn bulk_load(
         dimensions: args.dimensions,
         similarity: args.similarity,
         quantizer: args.quantizer,
+        layout: GraphLayout::RawVectorInGraph, // XXX allow args
         max_edges: args.max_edges,
         index_search_params: GraphSearchParams {
             beam_width: args.edge_candidates,

--- a/et/src/init_index.rs
+++ b/et/src/init_index.rs
@@ -2,7 +2,7 @@ use std::{io, num::NonZero, sync::Arc};
 
 use clap::Args;
 use easy_tiger::{
-    graph::{GraphConfig, GraphSearchParams},
+    graph::{GraphConfig, GraphLayout, GraphSearchParams},
     quantization::VectorQuantizer,
     scoring::VectorSimilarity,
     wt::TableGraphVectorIndex,
@@ -70,6 +70,7 @@ pub fn init_index(
             dimensions: args.dimensions,
             similarity: args.similarity,
             quantizer: args.quantizer,
+            layout: GraphLayout::RawVectorInGraph, // XXX allow args
             max_edges: args.max_edges,
             index_search_params: GraphSearchParams {
                 beam_width: args.edge_candidates,

--- a/et/src/init_index.rs
+++ b/et/src/init_index.rs
@@ -25,6 +25,17 @@ pub struct InitIndexArgs {
     #[arg(short, long, value_enum)]
     quantizer: VectorQuantizer,
 
+    /// Physical layout used for graph.
+    ///
+    /// `split` puts raw vectors, nav vectors, and graph edges each in separate tables. If results
+    /// are being re-ranked this will require additional reads to complete.
+    ///
+    /// `raw_vector_in_graph` places raw vectors and graph edges in the same table. When a vertex
+    /// is visited the raw vector is read and saved for re-scoring. This minimizes the number of
+    /// reads performed and is likely better for indices with less traffic.
+    #[arg(long, value_enum, default_value = "raw_vector_in_graph")]
+    layout: GraphLayout,
+
     /// Maximum number of edges for any vertex.
     #[arg(long, default_value = "64")]
     max_edges: NonZero<usize>,
@@ -70,7 +81,7 @@ pub fn init_index(
             dimensions: args.dimensions,
             similarity: args.similarity,
             quantizer: args.quantizer,
-            layout: GraphLayout::RawVectorInGraph, // XXX allow args
+            layout: args.layout,
             max_edges: args.max_edges,
             index_search_params: GraphSearchParams {
                 beam_width: args.edge_candidates,

--- a/et/src/lookup.rs
+++ b/et/src/lookup.rs
@@ -28,7 +28,7 @@ pub fn lookup(connection: Arc<Connection>, index_name: &str, args: LookupArgs) -
         *index.config(),
         session.get_record_cursor(index.graph_table_name())?,
     );
-    match graph.get(args.id) {
+    match graph.get_vertex(args.id) {
         None => {
             println!("Not found!");
         }

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -439,11 +439,17 @@ where
                         if vertex.is_empty() {
                             stats.unconnected += 1;
                         }
+                        let vertex_vector =
+                            if self.index.config().layout == GraphLayout::RawVectorInGraph {
+                                Some(self.scorer.normalize_vector(v.into()))
+                            } else {
+                                None
+                            };
                         Record::new(
                             i as i64,
                             encode_graph_vertex(
                                 vertex.iter().map(|n| n.vertex()).collect(),
-                                Some(&self.scorer.normalize_vector(v.into())),
+                                vertex_vector.as_ref().map(|vv| vv.as_ref()),
                             ),
                         )
                     }),

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -311,12 +311,12 @@ where
                     v
                 );
 
-                let mut graph = reader.graph()?;
+                let mut raw_vectors = reader.raw_vectors()?;
                 let centroid_score = self.scorer.score(
-                    &graph.get_vertex(v as i64).unwrap().unwrap().vector(),
+                    &raw_vectors.get_raw_vector(v as i64).unwrap().unwrap(),
                     &self.centroid,
                 );
-                drop(graph);
+                drop(raw_vectors);
 
                 // Add each edge to this vertex and a reciprocal edge to make the graph
                 // undirected. If an edge does not fit on either vertex, save it for later.
@@ -723,11 +723,12 @@ impl<D: Send + Sync> GraphVertex for BulkLoadGraphVertex<'_, D> {
     where
         Self: 'c;
 
-    fn vector(&self) -> Cow<'_, [f32]> {
+    fn vector(&self) -> Option<Cow<'_, [f32]>> {
+        // XXX remove this, we shouldn't ever provide the vector this way.
         self.vertex
             .as_ref()
             .map(|v| v.vector())
-            .unwrap_or_else(|| self.builder.get_vector(self.vertex_id as usize))
+            .unwrap_or_else(|| Some(self.builder.get_vector(self.vertex_id as usize)))
     }
 
     fn edges(&self) -> Self::EdgeIterator<'_> {

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -35,8 +35,8 @@ use crate::{
     scoring::F32VectorScorer,
     search::GraphSearcher,
     wt::{
-        encode_graph_node, CursorGraph, CursorGraphVertex, CursorNavVectorStore,
-        TableGraphVectorIndex, CONFIG_KEY, ENTRY_POINT_KEY,
+        encode_graph_node, CursorGraph, CursorNavVectorStore, TableGraphVectorIndex, CONFIG_KEY,
+        ENTRY_POINT_KEY,
     },
     Neighbor,
 };
@@ -685,19 +685,10 @@ impl<D: Send + Sync> Graph for BulkLoadBuilderGraph<'_, D> {
     }
 
     fn get_vertex(&mut self, vertex_id: i64) -> Option<Result<Self::Vertex<'_>>> {
-        if let Some(cursor) = self.1.as_mut() {
-            Some(cursor.get_vertex(vertex_id)?.map(|v| BulkLoadGraphVertex {
-                builder: self.0,
-                vertex_id,
-                vertex: Some(v),
-            }))
-        } else {
-            Some(Ok(BulkLoadGraphVertex {
-                builder: self.0,
-                vertex_id,
-                vertex: None,
-            }))
-        }
+        Some(Ok(BulkLoadGraphVertex {
+            builder: self.0,
+            vertex_id,
+        }))
     }
 }
 
@@ -714,7 +705,6 @@ impl<D: Send + Sync> RawVectorStore for BulkLoadBuilderGraph<'_, D> {
 struct BulkLoadGraphVertex<'a, D> {
     builder: &'a BulkLoadBuilder<D>,
     vertex_id: i64,
-    vertex: Option<CursorGraphVertex<'a>>,
 }
 
 impl<D: Send + Sync> GraphVertex for BulkLoadGraphVertex<'_, D> {
@@ -724,11 +714,7 @@ impl<D: Send + Sync> GraphVertex for BulkLoadGraphVertex<'_, D> {
         Self: 'c;
 
     fn vector(&self) -> Option<Cow<'_, [f32]>> {
-        // XXX remove this, we shouldn't ever provide the vector this way.
-        self.vertex
-            .as_ref()
-            .map(|v| v.vector())
-            .unwrap_or_else(|| Some(self.builder.get_vector(self.vertex_id as usize)))
+        None
     }
 
     fn edges(&self) -> Self::EdgeIterator<'_> {

--- a/src/crud.rs
+++ b/src/crud.rs
@@ -188,7 +188,7 @@ impl IndexMutator {
                 raw_vector.map(|rv| (rv, v.edges().collect::<Vec<_>>()))
             })??;
 
-        // XXX this needs to remove from raw_vectors too.
+        // XXX this needs to remove from raw_vectors too. ideally it needs a unified mutator.
         graph.remove(vertex_id)?;
         self.reader.nav_vectors()?.remove(vertex_id)?;
 

--- a/src/crud.rs
+++ b/src/crud.rs
@@ -188,8 +188,9 @@ impl IndexMutator {
                 raw_vector.map(|rv| (rv, v.edges().collect::<Vec<_>>()))
             })??;
 
-        // XXX this needs to remove from raw_vectors too. ideally it needs a unified mutator.
+        // TODO: unified graph index writer trait to handles removal and other mutations.
         graph.remove(vertex_id)?;
+        raw_vectors.remove(vertex_id)?;
         self.reader.nav_vectors()?.remove(vertex_id)?;
 
         // Cache information about each vertex linked to vertex_id.
@@ -266,7 +267,6 @@ impl IndexMutator {
                             None
                         }
                     })
-                    // TODO: this feels unnecessary but it doesn't compile without it.
                     .collect::<Vec<_>>()
             })
             .collect::<Vec<_>>();

--- a/src/crud.rs
+++ b/src/crud.rs
@@ -308,7 +308,9 @@ mod tests {
     use wt_mdb::{options::ConnectionOptionsBuilder, Connection, Result};
 
     use crate::{
-        graph::{Graph, GraphConfig, GraphSearchParams, GraphVectorIndexReader, GraphVertex},
+        graph::{
+            Graph, GraphConfig, GraphLayout, GraphSearchParams, GraphVectorIndexReader, GraphVertex,
+        },
         quantization::VectorQuantizer,
         scoring::VectorSimilarity,
         search::GraphSearcher,
@@ -375,6 +377,7 @@ mod tests {
                         dimensions: NonZero::new(2).unwrap(),
                         similarity: VectorSimilarity::Euclidean,
                         quantizer: VectorQuantizer::Binary,
+                        layout: GraphLayout::Split,
                         max_edges: NonZero::new(4).unwrap(),
                         index_search_params: Self::search_params(),
                     },

--- a/src/crud.rs
+++ b/src/crud.rs
@@ -111,7 +111,7 @@ impl IndexMutator {
         // TODO: group and bulk delete if there are common src_vertex_id.
         for (src_vertex_id, dst_vertex_id) in pruned_edges {
             let vertex = graph
-                .get(src_vertex_id)
+                .get_vertex(src_vertex_id)
                 .unwrap_or(Err(Error::not_found_error()))?;
             let edges = vertex.edges().filter(|v| *v != dst_vertex_id).collect();
             let encoded = encode_graph_node_internal(vertex.vector_bytes(), edges);
@@ -130,7 +130,7 @@ impl IndexMutator {
         pruned_edges: &mut Vec<(i64, i64)>,
     ) -> Result<()> {
         let vertex = graph
-            .get(src_vertex_id)
+            .get_vertex(src_vertex_id)
             .unwrap_or(Err(Error::not_found_error()))?;
         let mut edges = std::iter::once(dst_vertex_id)
             .chain(vertex.edges().filter(|v| *v != dst_vertex_id))
@@ -141,7 +141,7 @@ impl IndexMutator {
                 .iter()
                 .map(|e| {
                     graph
-                        .get(*e)
+                        .get_vertex(*e)
                         .unwrap_or(Err(Error::not_found_error()))
                         .map(|dst| Neighbor::new(*e, scorer.score(&src_vector, &dst.vector())))
                 })
@@ -173,7 +173,7 @@ impl IndexMutator {
         let mut graph = self.reader.graph()?;
 
         let (vector, edges) = graph
-            .get(vertex_id)
+            .get_vertex(vertex_id)
             .unwrap_or(Err(Error::not_found_error()))
             .map(|v| (v.vector().to_vec(), v.edges().collect::<Vec<_>>()))?;
 
@@ -186,7 +186,7 @@ impl IndexMutator {
             .into_iter()
             .map(|e| {
                 graph
-                    .get(e)
+                    .get_vertex(e)
                     .unwrap_or(Err(Error::not_found_error()))
                     .map(|v| {
                         (
@@ -418,7 +418,7 @@ mod tests {
 
         let reader = fixture.new_reader();
         let mut graph = reader.graph()?;
-        let vertex = graph.get(vertex_ids[0]).unwrap()?;
+        let vertex = graph.get_vertex(vertex_ids[0]).unwrap()?;
         assert_eq!(vertex.edges().collect::<Vec<_>>(), &[1, 2, 3, 5]);
         assert_eq!(fixture.search(&[0.0, 0.0]), Ok(vec![0, 1, 2, 3, 5, 4]));
 
@@ -459,14 +459,14 @@ mod tests {
 
         let reader = fixture.new_reader();
         let mut graph = reader.graph()?;
-        let vertex = graph.get(vertex_ids[0]).unwrap()?;
+        let vertex = graph.get_vertex(vertex_ids[0]).unwrap()?;
         assert_eq!(vertex.edges().collect::<Vec<_>>(), &[1, 2, 3, 5]);
         assert_eq!(fixture.search(&[0.0, 0.0]), Ok(vec![0, 1, 2, 3, 5, 4]));
 
         fixture.new_mutator().delete(1)?;
         let reader = fixture.new_reader();
         let mut graph = reader.graph()?;
-        let vertex = graph.get(vertex_ids[0]).unwrap()?;
+        let vertex = graph.get_vertex(vertex_ids[0]).unwrap()?;
         assert_eq!(vertex.edges().collect::<Vec<_>>(), &[2, 3, 5]);
         assert_eq!(fixture.search(&[0.0, 0.0]), Ok(vec![0, 2, 3, 5, 4]));
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -165,6 +165,14 @@ impl<'a> RawVector<'a> {
         }
     }
 
+    pub fn bytes_len(&self) -> usize {
+        let dim = match self {
+            Self::Bytes { bytes: _, dim } => *dim,
+            Self::Cow(v) => v.len(),
+        };
+        dim * std::mem::size_of::<f32>()
+    }
+
     fn bytes_to_vec(bytes: Cow<'_, [u8]>, dim: usize) -> Vec<f32> {
         bytes
             .chunks(std::mem::size_of::<f32>())

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -113,8 +113,7 @@ pub enum RawVector<'a> {
 }
 
 impl<'a> RawVector<'a> {
-    // TODO: rename because this is shadowing all the From impls.
-    pub fn from(bytes: Cow<'a, [u8]>, dim: usize) -> Self {
+    pub fn from_cow_partial(bytes: Cow<'a, [u8]>, dim: usize) -> Self {
         #[cfg(target_endian = "little")]
         {
             // WiredTiger does not guarantee that the returned memory will be aligned, a

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -180,7 +180,7 @@ impl<'a> From<Cow<'a, [f32]>> for RawVector<'a> {
     }
 }
 
-impl<'a> From<Vec<f32>> for RawVector<'a> {
+impl From<Vec<f32>> for RawVector<'_> {
     fn from(value: Vec<f32>) -> Self {
         Self::Cow(value.into())
     }
@@ -192,14 +192,14 @@ impl<'a> From<&'a [f32]> for RawVector<'a> {
     }
 }
 
-impl<'a> Deref for RawVector<'a> {
+impl Deref for RawVector<'_> {
     type Target = [f32];
 
     fn deref(&self) -> &Self::Target {
         match self {
             // Safety: From conversion ensures that bytes is aligned before producing Borrowed.
             Self::Bytes { bytes, dim } => unsafe { &bytes.align_to::<f32>().1[..*dim] },
-            Self::Cow(v) => &v,
+            Self::Cow(v) => v,
         }
     }
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -26,7 +26,7 @@ pub struct GraphSearchParams {
 
 /// Describes how fields within the vector index are laid out -- split completely or with some
 /// colocated fields.
-#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum GraphLayout {
     /// Each field appears in its own table.
     Split,

--- a/src/search.rs
+++ b/src/search.rs
@@ -209,7 +209,7 @@ impl GraphSearcher {
             .map(|c| {
                 let vertex = c.neighbor.vertex();
                 let score = if let Some(candidate_vector) = c.state.vector() {
-                    Ok(scorer.score(&query, &candidate_vector))
+                    Ok(scorer.score(&query, candidate_vector))
                 } else {
                     raw_vectors
                         .as_mut()
@@ -419,7 +419,7 @@ mod test {
                 similarity: VectorSimilarity::Euclidean,
                 quantizer: VectorQuantizer::Binary,
                 layout: GraphLayout::RawVectorInGraph,
-                max_edges: max_edges,
+                max_edges,
                 index_search_params: GraphSearchParams {
                     beam_width: NonZero::new(usize::MAX).unwrap(),
                     num_rerank: usize::MAX,
@@ -482,7 +482,7 @@ mod test {
     #[derive(Debug)]
     pub struct TestGraphVectorIndexReader<'a>(&'a TestGraphVectorIndex);
 
-    impl<'a> GraphVectorIndexReader for TestGraphVectorIndexReader<'a> {
+    impl GraphVectorIndexReader for TestGraphVectorIndexReader<'_> {
         type Graph<'b>
             = TestGraphAccess<'b>
         where
@@ -516,7 +516,7 @@ mod test {
     #[derive(Debug)]
     pub struct TestGraphAccess<'a>(&'a TestGraphVectorIndex);
 
-    impl<'a> Graph for TestGraphAccess<'a> {
+    impl Graph for TestGraphAccess<'_> {
         type Vertex<'c>
             = TestGraphVertex<'c>
         where
@@ -539,7 +539,7 @@ mod test {
         }
     }
 
-    impl<'a> RawVectorStore for TestGraphAccess<'a> {
+    impl RawVectorStore for TestGraphAccess<'_> {
         fn get_raw_vector(&mut self, vertex_id: i64) -> Option<Result<RawVector<'_>>> {
             if vertex_id >= 0 && (vertex_id as usize) < self.0.data.len() {
                 Some(Ok((&*self.0.data[vertex_id as usize].vector).into()))
@@ -549,7 +549,7 @@ mod test {
         }
     }
 
-    impl<'a> NavVectorStore for TestGraphAccess<'a> {
+    impl NavVectorStore for TestGraphAccess<'_> {
         fn get_nav_vector(&mut self, vertex_id: i64) -> Option<Result<Cow<'_, [u8]>>> {
             if vertex_id >= 0 && (vertex_id as usize) < self.0.data.len() {
                 Some(Ok(Cow::from(&self.0.data[vertex_id as usize].nav_vector)))
@@ -562,7 +562,7 @@ mod test {
     #[derive(Debug)]
     pub struct TestGraph<'a>(&'a TestGraphVectorIndex);
 
-    impl<'a> Graph for TestGraph<'a> {
+    impl Graph for TestGraph<'_> {
         type Vertex<'c>
             = TestGraphVertex<'c>
         where
@@ -587,7 +587,7 @@ mod test {
 
     pub struct TestGraphVertex<'a>(&'a TestVector);
 
-    impl<'a> GraphVertex for TestGraphVertex<'a> {
+    impl GraphVertex for TestGraphVertex<'_> {
         type EdgeIterator<'c>
             = std::iter::Copied<std::slice::Iter<'c, i64>>
         where

--- a/src/search.rs
+++ b/src/search.rs
@@ -368,8 +368,8 @@ mod test {
 
     use crate::{
         graph::{
-            Graph, GraphConfig, GraphVectorIndexReader, GraphVertex, NavVectorStore, RawVector,
-            RawVectorStore,
+            Graph, GraphConfig, GraphLayout, GraphVectorIndexReader, GraphVertex, NavVectorStore,
+            RawVector, RawVectorStore,
         },
         quantization::{BinaryQuantizer, Quantizer, VectorQuantizer},
         scoring::{DotProductScorer, F32VectorScorer, VectorSimilarity},
@@ -418,6 +418,7 @@ mod test {
                 dimensions: NonZero::new(rep.first().map(|v| v.vector.len()).unwrap_or(1)).unwrap(),
                 similarity: VectorSimilarity::Euclidean,
                 quantizer: VectorQuantizer::Binary,
+                layout: GraphLayout::RawVectorInGraph,
                 max_edges: max_edges,
                 index_search_params: GraphSearchParams {
                     beam_width: NonZero::new(usize::MAX).unwrap(),

--- a/src/wt.rs
+++ b/src/wt.rs
@@ -102,7 +102,13 @@ impl<'a> CursorGraph<'a> {
     }
 
     pub(crate) fn remove(&mut self, vertex_id: i64) -> Result<()> {
-        self.cursor.remove(vertex_id)
+        self.cursor.remove(vertex_id).or_else(|e| {
+            if e == Error::not_found_error() {
+                Ok(())
+            } else {
+                Err(e)
+            }
+        })
     }
 }
 
@@ -147,7 +153,13 @@ impl<'a> CursorNavVectorStore<'a> {
     }
 
     pub(crate) fn remove(&mut self, vertex_id: i64) -> Result<()> {
-        self.cursor.remove(vertex_id)
+        self.cursor.remove(vertex_id).or_else(|e| {
+            if e == Error::not_found_error() {
+                Ok(())
+            } else {
+                Err(e)
+            }
+        })
     }
 }
 

--- a/src/wt.rs
+++ b/src/wt.rs
@@ -49,8 +49,8 @@ impl GraphVertex for CursorGraphVertex<'_> {
     where
         Self: 'c;
 
-    fn vector(&self) -> Cow<'_, [f32]> {
-        Cow::from(self.raw_vector.deref())
+    fn vector(&self) -> Option<Cow<'_, [f32]>> {
+        Some(Cow::from(self.raw_vector.deref()))
     }
 
     fn edges(&self) -> Self::EdgeIterator<'_> {

--- a/src/wt.rs
+++ b/src/wt.rs
@@ -30,7 +30,7 @@ pub struct CursorGraphVertex<'a> {
 
 impl<'a> CursorGraphVertex<'a> {
     fn new(config: &GraphConfig, data: Cow<'a, [u8]>) -> Self {
-        let raw_vector = RawVector::from(data.clone(), config.dimensions.get());
+        let raw_vector = RawVector::from_cow_partial(data.clone(), config.dimensions.get());
         Self {
             data,
             raw_vector,
@@ -128,7 +128,7 @@ impl RawVectorStore for CursorGraph<'_> {
     fn get_raw_vector(&mut self, vertex_id: i64) -> Option<Result<RawVector<'_>>> {
         let r =
             unsafe { self.cursor.seek_exact_unsafe(vertex_id)? }.map(RecordView::into_inner_value);
-        Some(r.map(|r| RawVector::from(r, self.config.dimensions.get())))
+        Some(r.map(|r| RawVector::from_cow_partial(r, self.config.dimensions.get())))
     }
 }
 


### PR DESCRIPTION
Allow a physical layout where each field -- graph edges, raw vectors, and nav vectors -- each appear in a different
table. The current scheme groups raw vectors and graph edges together which optimizes for latency when query
volumes are low, but may be cumbersome when filtering since reading graph edges becomes very expensive.