### PR TITLE
Refactor scoring into distance

### DIFF
--- a/et/src/bulk_load.rs
+++ b/et/src/bulk_load.rs
@@ -3,10 +3,10 @@ use std::{fs::File, io, num::NonZero, path::PathBuf, sync::Arc};
 use clap::Args;
 use easy_tiger::{
     bulk::{BulkLoadBuilder, Options},
+    distance::VectorSimilarity,
     graph::{GraphConfig, GraphLayout, GraphSearchParams},
     input::{DerefVectorStore, VectorStore},
     quantization::VectorQuantizer,
-    scoring::VectorSimilarity,
     wt::TableGraphVectorIndex,
 };
 use wt_mdb::{Connection, Result, Session};

--- a/et/src/exhaustive_search.rs
+++ b/et/src/exhaustive_search.rs
@@ -48,7 +48,7 @@ pub fn exhaustive_search(
     results.resize_with(query_vectors.len(), || {
         BinaryHeap::with_capacity(args.neighbors_len.get())
     });
-    let scorer = index.config().new_scorer();
+    let distance_fn = index.config().new_distance_function();
 
     let session = connection.open_session()?;
     let mut cursor = session.open_record_cursor(index.graph_table_name())?;
@@ -68,7 +68,7 @@ pub fn exhaustive_search(
 
         let similarities = (0..query_vectors.len())
             .into_par_iter()
-            .map(|i| scorer.distance(&index_vector, &query_vectors[i]))
+            .map(|i| distance_fn.distance(&index_vector, &query_vectors[i]))
             .collect::<Vec<_>>();
         for (i, s) in similarities.into_iter().enumerate() {
             let n = Neighbor::new(record.key(), s);

--- a/et/src/exhaustive_search.rs
+++ b/et/src/exhaustive_search.rs
@@ -68,7 +68,7 @@ pub fn exhaustive_search(
 
         let similarities = (0..query_vectors.len())
             .into_par_iter()
-            .map(|i| scorer.score(&index_vector, &query_vectors[i]))
+            .map(|i| scorer.distance(&index_vector, &query_vectors[i]))
             .collect::<Vec<_>>();
         for (i, s) in similarities.into_iter().enumerate() {
             let n = Neighbor::new(record.key(), s);

--- a/et/src/init_index.rs
+++ b/et/src/init_index.rs
@@ -2,9 +2,9 @@ use std::{io, num::NonZero, sync::Arc};
 
 use clap::Args;
 use easy_tiger::{
+    distance::VectorSimilarity,
     graph::{GraphConfig, GraphLayout, GraphSearchParams},
     quantization::VectorQuantizer,
-    scoring::VectorSimilarity,
     wt::TableGraphVectorIndex,
 };
 use wt_mdb::Connection;

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -27,12 +27,12 @@ use thread_local::ThreadLocal;
 use wt_mdb::{options::DropOptionsBuilder, Connection, Record, Result, Session};
 
 use crate::{
+    distance::F32VectorDistance,
     graph::{
         prune_edges, select_pruned_edges, Graph, GraphConfig, GraphLayout, GraphVectorIndexReader,
         GraphVertex, NavVectorStore, RawVectorStore,
     },
     input::{DerefVectorStore, VectorStore},
-    scoring::F32VectorDistance,
     search::GraphSearcher,
     wt::{
         encode_graph_vertex, encode_raw_vector, CursorGraph, CursorNavVectorStore,

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -332,7 +332,7 @@ where
                             true
                         } else {
                             iv.push(*e);
-                            let backedge = Neighbor::new(v as i64, e.score());
+                            let backedge = Neighbor::new(v as i64, e.distance());
                             if !ev.contains(&backedge) {
                                 ev.push(backedge);
                             }

--- a/src/crud.rs
+++ b/src/crud.rs
@@ -2,8 +2,8 @@
 use std::{ops::Deref, sync::Arc};
 
 use crate::{
+    distance::F32VectorDistance,
     graph::{prune_edges, Graph, GraphLayout, GraphVectorIndexReader, GraphVertex, RawVectorStore},
-    scoring::F32VectorDistance,
     search::GraphSearcher,
     wt::{
         encode_graph_vertex, encode_raw_vector, SessionGraphVectorIndexReader,
@@ -364,11 +364,11 @@ mod tests {
     use wt_mdb::{options::ConnectionOptionsBuilder, Connection, Result};
 
     use crate::{
+        distance::VectorSimilarity,
         graph::{
             Graph, GraphConfig, GraphLayout, GraphSearchParams, GraphVectorIndexReader, GraphVertex,
         },
         quantization::VectorQuantizer,
-        scoring::VectorSimilarity,
         search::GraphSearcher,
         wt::{SessionGraphVectorIndexReader, TableGraphVectorIndex},
     };

--- a/src/crud.rs
+++ b/src/crud.rs
@@ -3,7 +3,7 @@ use std::{ops::Deref, sync::Arc};
 
 use crate::{
     graph::{prune_edges, Graph, GraphLayout, GraphVectorIndexReader, GraphVertex, RawVectorStore},
-    scoring::F32VectorScorer,
+    scoring::F32VectorDistance,
     search::GraphSearcher,
     wt::{
         encode_graph_vertex, encode_raw_vector, SessionGraphVectorIndexReader,
@@ -63,9 +63,8 @@ impl IndexMutator {
         // TODO: make this an error instead of panicking.
         assert_eq!(self.reader.config().dimensions.get(), vector.len());
 
-        let scorer = self.reader.config().new_scorer();
-        let vector = scorer.normalize_vector(vector.into());
-        // TODO: normalize input vector.
+        let distance_fn = self.reader.config().new_distance_function();
+        let vector = distance_fn.normalize_vector(vector.into());
         let mut candidate_edges = self.searcher.search(&vector, &mut self.reader)?;
         let mut graph = self.reader.graph()?;
         let mut raw_vectors = self.reader.raw_vectors()?;
@@ -78,7 +77,7 @@ impl IndexMutator {
             &mut candidate_edges,
             self.reader.config().max_edges,
             &mut raw_vectors,
-            scorer.as_ref(),
+            distance_fn.as_ref(),
         )?;
         candidate_edges.truncate(selected_len);
 
@@ -98,7 +97,7 @@ impl IndexMutator {
             self.insert_edge(
                 &mut graph,
                 &mut raw_vectors,
-                scorer.as_ref(),
+                distance_fn.as_ref(),
                 src_vertex_id,
                 vertex_id,
                 &mut pruned_edges,
@@ -121,7 +120,7 @@ impl IndexMutator {
         &self,
         graph: &mut impl Graph,
         raw_vectors: &mut impl RawVectorStore,
-        scorer: &dyn F32VectorScorer,
+        distance_fn: &dyn F32VectorDistance,
         src_vertex_id: i64,
         dst_vertex_id: i64,
         pruned_edges: &mut Vec<(i64, i64)>,
@@ -146,7 +145,7 @@ impl IndexMutator {
                     raw_vectors
                         .get_raw_vector(*e)
                         .unwrap_or(Err(Error::not_found_error()))
-                        .map(|dst| Neighbor::new(*e, scorer.distance(&src_vector, &dst)))
+                        .map(|dst| Neighbor::new(*e, distance_fn.distance(&src_vector, &dst)))
                 })
                 .collect::<Result<Vec<Neighbor>>>()?;
             neighbors.sort();
@@ -154,7 +153,7 @@ impl IndexMutator {
                 &mut neighbors,
                 self.reader.config().max_edges,
                 raw_vectors,
-                scorer,
+                distance_fn,
             )?;
             // Ensure the graph is undirected by removing links from pruned edges back to this node.
             for v in neighbors.iter().skip(selected_len).map(Neighbor::vertex) {
@@ -168,7 +167,7 @@ impl IndexMutator {
 
     /// Delete `vertex_id`, removing both the vertex and any incoming edges.
     pub fn delete(&mut self, vertex_id: i64) -> Result<()> {
-        let scorer = self.reader.config().new_scorer();
+        let distance_fn = self.reader.config().new_distance_function();
         let mut graph = self.reader.graph()?;
         let mut raw_vectors = self.reader.raw_vectors()?;
 
@@ -217,7 +216,7 @@ impl IndexMutator {
             .collect::<Result<Result<Vec<_>>>>()??;
 
         // Create links between edges of the deleted node if needed.
-        self.cross_link_peer_vertices(&mut vertex_data, scorer.as_ref())?;
+        self.cross_link_peer_vertices(&mut vertex_data, distance_fn.as_ref())?;
 
         // Oh no, we've deleted the entry point! Find the closes point amongst the
         // edges of this node to use as a new one. So long as at least one vector is in
@@ -225,7 +224,7 @@ impl IndexMutator {
         if graph.entry_point().unwrap()? == vertex_id {
             let mut neighbors = vertex_data
                 .iter()
-                .map(|(id, vec, _)| Neighbor::new(*id, scorer.distance(&vector, vec)))
+                .map(|(id, vec, _)| Neighbor::new(*id, distance_fn.distance(&vector, vec)))
                 .collect::<Vec<_>>();
             neighbors.sort();
             if let Some(ep_neighbor) = neighbors.first() {
@@ -246,7 +245,7 @@ impl IndexMutator {
     fn cross_link_peer_vertices(
         &self,
         vertex_data: &mut [(i64, Vec<f32>, Vec<i64>)],
-        scorer: &dyn F32VectorScorer,
+        distance_fn: &dyn F32VectorDistance,
     ) -> Result<()> {
         // Score all pairs of vectors among the passed vertices.
         let mut candidate_links = vertex_data
@@ -259,7 +258,7 @@ impl IndexMutator {
                     .skip(src + 1)
                     .filter_map(|(dst, (dst_vertex, dst_vector, _))| {
                         if !src_edges.contains(dst_vertex) {
-                            Some((src, dst, scorer.distance(src_vector, dst_vector)))
+                            Some((src, dst, distance_fn.distance(src_vector, dst_vector)))
                         } else {
                             None
                         }

--- a/src/distance.rs
+++ b/src/distance.rs
@@ -1,6 +1,5 @@
 //! Dense vector scoring traits and implementations.
 
-// TODO: rename the module and everything else from scoring/scorer to distance.
 use std::{borrow::Cow, io, str::FromStr};
 
 use serde::{Deserialize, Serialize};

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -265,7 +265,7 @@ pub(crate) fn select_pruned_edges(
             if !selected
                 .iter()
                 .take_while(|s| **s < i)
-                .any(|s| scorer.score(e_vec, &vectors[*s]) > e.score * alpha)
+                .any(|s| scorer.score(e_vec, &vectors[*s]) < e.distance * alpha)
             {
                 selected.insert(i);
                 if selected.len() >= max_edges.get() {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -265,7 +265,7 @@ pub(crate) fn select_pruned_edges(
             if !selected
                 .iter()
                 .take_while(|s| **s < i)
-                .any(|s| scorer.score(e_vec, &vectors[*s]) < e.distance * alpha)
+                .any(|s| scorer.distance(e_vec, &vectors[*s]) < e.distance * alpha)
             {
                 selected.insert(i);
                 if selected.len() >= max_edges.get() {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -9,8 +9,8 @@ use serde::{Deserialize, Serialize};
 use wt_mdb::{Error, Result};
 
 use crate::{
+    distance::{F32VectorDistance, QuantizedVectorDistance, VectorSimilarity},
     quantization::{Quantizer, VectorQuantizer},
-    scoring::{F32VectorDistance, QuantizedVectorDistance, VectorSimilarity},
     Neighbor,
 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,34 +17,34 @@ pub mod wt;
 
 /// `Neighbor` is a node and a distance relative to some other node.
 ///
-/// During a search score might be relative to the query vector.
-/// In a graph index, score might be relative to another node in the index.
+/// During a search distance might be relative to the query vector.
+/// In a graph index, distance might be relative to another node in the index.
 ///
-/// When compared `Neighbor`s are ordered first in descending order by score,
+/// When compared `Neighbor`s are ordered first by distance then by vertex id.
 /// then in ascending order by vertex id.
 #[derive(Debug, Copy, Clone)]
 pub struct Neighbor {
     vertex: i64,
-    score: f64,
+    distance: f64,
 }
 
 impl Neighbor {
-    pub fn new(vertex: i64, score: f64) -> Self {
-        Self { vertex, score }
+    pub fn new(vertex: i64, distance: f64) -> Self {
+        Self { vertex, distance }
     }
 
     pub fn vertex(&self) -> i64 {
         self.vertex
     }
 
-    pub fn score(&self) -> f64 {
-        self.score
+    pub fn distance(&self) -> f64 {
+        self.distance
     }
 }
 
 impl PartialEq for Neighbor {
     fn eq(&self, other: &Self) -> bool {
-        self.vertex == other.vertex && self.score.total_cmp(&other.score).is_eq()
+        self.vertex == other.vertex && self.distance.total_cmp(&other.distance).is_eq()
     }
 }
 
@@ -58,11 +58,9 @@ impl PartialOrd for Neighbor {
 
 impl Ord for Neighbor {
     fn cmp(&self, other: &Self) -> Ordering {
-        let c = self.score.total_cmp(&other.score).reverse();
-        match c {
-            Ordering::Equal => self.vertex.cmp(&other.vertex),
-            _ => c,
-        }
+        self.distance
+            .total_cmp(&other.distance)
+            .then_with(|| self.vertex.cmp(&other.vertex))
     }
 }
 
@@ -86,11 +84,11 @@ mod test_lib {
         );
         assert_eq!(
             Neighbor::new(1, 1.1).cmp(&Neighbor::new(1, 1.0)),
-            Ordering::Less
+            Ordering::Greater
         );
         assert_eq!(
             Neighbor::new(1, 1.0).cmp(&Neighbor::new(1, 1.1)),
-            Ordering::Greater
+            Ordering::Less
         );
         assert_eq!(
             Neighbor::new(1, 1.0).cmp(&Neighbor::new(2, 1.0)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,11 +7,11 @@ use std::cmp::Ordering;
 
 pub mod bulk;
 pub mod crud;
+pub mod distance;
 pub mod graph;
 pub mod input;
 pub mod kmeans;
 pub mod quantization;
-pub mod scoring;
 pub mod search;
 pub mod wt;
 

--- a/src/quantization.rs
+++ b/src/quantization.rs
@@ -7,7 +7,7 @@ use std::{io, str::FromStr};
 use serde::{Deserialize, Serialize};
 
 use crate::scoring::{
-    AsymmetricHammingScorer, HammingScorer, QuantizedVectorScorer, VectorSimilarity,
+    AsymmetricHammingDistance, HammingDistance, QuantizedVectorDistance, VectorSimilarity,
 };
 
 /// `Quantizer` is used to perform lossy quantization of input vectors.
@@ -49,11 +49,14 @@ impl VectorQuantizer {
         }
     }
 
-    /// Create a new scorer for this quantization method.
-    pub fn new_scorer(&self, _similarity: &VectorSimilarity) -> Box<dyn QuantizedVectorScorer> {
+    /// Create a new distance function for this quantization method.
+    pub fn new_distance_function(
+        &self,
+        _similarity: &VectorSimilarity,
+    ) -> Box<dyn QuantizedVectorDistance> {
         match self {
-            Self::Binary => Box::new(HammingScorer),
-            Self::AsymmetricBinary { n: _ } => Box::new(AsymmetricHammingScorer),
+            Self::Binary => Box::new(HammingDistance),
+            Self::AsymmetricBinary { n: _ } => Box::new(AsymmetricHammingDistance),
         }
     }
 }

--- a/src/quantization.rs
+++ b/src/quantization.rs
@@ -6,7 +6,7 @@ use std::{io, str::FromStr};
 
 use serde::{Deserialize, Serialize};
 
-use crate::scoring::{
+use crate::distance::{
     AsymmetricHammingDistance, HammingDistance, QuantizedVectorDistance, VectorSimilarity,
 };
 

--- a/src/scoring.rs
+++ b/src/scoring.rs
@@ -15,11 +15,7 @@ pub trait F32VectorScorer: Send + Sync {
     /// where larger values are better matches.
     ///
     /// Input vectors must be the same length or this function may panic.
-    fn score(&self, a: &[f32], b: &[f32]) -> f64;
-
-    /// Normalize a vector for use with this scoring function.
-    /// By default, does nothing.
-    fn normalize(&self, _vector: &mut [f32]) {}
+    fn distance(&self, a: &[f32], b: &[f32]) -> f64;
 
     /// Normalize a vector for use with this scoring function.
     /// By default, does nothing.
@@ -38,7 +34,7 @@ pub trait QuantizedVectorScorer {
     ///
     /// This function is not required to be commutative and may panic if
     /// one of the inputs is misshapen.
-    fn score(&self, query: &[u8], doc: &[u8]) -> f64;
+    fn distance(&self, query: &[u8], doc: &[u8]) -> f64;
 }
 
 /// Functions used for computing a similarity score for high fidelity vectors.
@@ -86,7 +82,7 @@ impl FromStr for VectorSimilarity {
 pub struct EuclideanScorer;
 
 impl F32VectorScorer for EuclideanScorer {
-    fn score(&self, a: &[f32], b: &[f32]) -> f64 {
+    fn distance(&self, a: &[f32], b: &[f32]) -> f64 {
         SpatialSimilarity::l2sq(a, b).unwrap()
     }
 }
@@ -96,7 +92,7 @@ impl F32VectorScorer for EuclideanScorer {
 pub struct DotProductScorer;
 
 impl F32VectorScorer for DotProductScorer {
-    fn score(&self, a: &[f32], b: &[f32]) -> f64 {
+    fn distance(&self, a: &[f32], b: &[f32]) -> f64 {
         // Assuming values are normalized, this will produce a distance in [0,1]
         (-SpatialSimilarity::dot(a, b).unwrap() + 1.0) / 2.0
     }
@@ -115,7 +111,7 @@ impl F32VectorScorer for DotProductScorer {
 pub struct HammingScorer;
 
 impl QuantizedVectorScorer for HammingScorer {
-    fn score(&self, a: &[u8], b: &[u8]) -> f64 {
+    fn distance(&self, a: &[u8], b: &[u8]) -> f64 {
         BinarySimilarity::hamming(a, b).unwrap()
     }
 }
@@ -125,7 +121,7 @@ impl QuantizedVectorScorer for HammingScorer {
 pub struct AsymmetricHammingScorer;
 
 impl QuantizedVectorScorer for AsymmetricHammingScorer {
-    fn score(&self, query: &[u8], doc: &[u8]) -> f64 {
+    fn distance(&self, query: &[u8], doc: &[u8]) -> f64 {
         assert_eq!(query.len() % doc.len(), 0);
         query
             .chunks(doc.len())

--- a/src/search.rs
+++ b/src/search.rs
@@ -6,12 +6,12 @@ use std::{
 };
 
 use crate::{
+    distance::QuantizedVectorDistance,
     graph::{
         Graph, GraphSearchParams, GraphVectorIndexReader, GraphVertex, NavVectorStore,
         RawVectorStore,
     },
     quantization::Quantizer,
-    scoring::QuantizedVectorDistance,
     Neighbor,
 };
 
@@ -369,12 +369,12 @@ mod test {
     use wt_mdb::Result;
 
     use crate::{
+        distance::{DotProductDistance, F32VectorDistance, VectorSimilarity},
         graph::{
             Graph, GraphConfig, GraphLayout, GraphVectorIndexReader, GraphVertex, NavVectorStore,
             RawVector, RawVectorStore,
         },
         quantization::{BinaryQuantizer, Quantizer, VectorQuantizer},
-        scoring::{DotProductDistance, F32VectorDistance, VectorSimilarity},
         Neighbor,
     };
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -470,7 +470,7 @@ mod test {
                 let q = &graph[n.vertex() as usize].vector;
                 if !selected
                     .iter()
-                    .any(|p| scorer.score(q, &graph[p.vertex() as usize].vector) > n.score())
+                    .any(|p| scorer.score(q, &graph[p.vertex() as usize].vector) < n.distance())
                 {
                     selected.push(*n);
                 }
@@ -620,7 +620,7 @@ mod test {
 
     fn normalize_scores(mut results: Vec<Neighbor>) -> Vec<Neighbor> {
         for n in results.iter_mut() {
-            n.score = (n.score * 100000.0).round() / 100000.0;
+            n.distance = (n.distance * 100000.0).round() / 100000.0;
         }
         results
     }
@@ -637,10 +637,10 @@ mod test {
                 .search(&[-0.1, -0.1, -0.1, -0.1], &mut index.reader())
                 .unwrap(),
             vec![
-                Neighbor::new(0, 1.0),
-                Neighbor::new(1, 1.0),
-                Neighbor::new(4, 1.0),
-                Neighbor::new(16, 1.0)
+                Neighbor::new(0, 0.0),
+                Neighbor::new(1, 0.0),
+                Neighbor::new(4, 0.0),
+                Neighbor::new(16, 0.0)
             ]
         );
     }
@@ -659,10 +659,10 @@ mod test {
                     .unwrap()
             ),
             vec![
-                Neighbor::new(1, 0.93622),
-                Neighbor::new(4, 0.93622),
-                Neighbor::new(16, 0.93622),
-                Neighbor::new(0, 0.91743),
+                Neighbor::new(1, 0.06813),
+                Neighbor::new(4, 0.06813),
+                Neighbor::new(16, 0.06813),
+                Neighbor::new(0, 0.09),
             ]
         );
     }

--- a/src/search.rs
+++ b/src/search.rs
@@ -149,7 +149,7 @@ impl GraphSearcher {
                     .get_nav_vector(edge)
                     .unwrap_or(Err(Error::not_found_error()))?;
                 self.candidates
-                    .add_unvisited(Neighbor::new(edge, nav_scorer.score(&nav_query, &vec)));
+                    .add_unvisited(Neighbor::new(edge, nav_scorer.distance(&nav_query, &vec)));
             }
         }
 
@@ -177,7 +177,7 @@ impl GraphSearcher {
                 .unwrap_or(Err(Error::not_found_error()))?;
             self.candidates.add_unvisited(Neighbor::new(
                 entry_point,
-                nav_scorer.score(&nav_query, &entry_vector),
+                nav_scorer.distance(&nav_query, &entry_vector),
             ));
             self.seen.insert(entry_point);
         }
@@ -209,14 +209,14 @@ impl GraphSearcher {
             .map(|c| {
                 let vertex = c.neighbor.vertex();
                 let score = if let Some(candidate_vector) = c.state.vector() {
-                    Ok(scorer.score(&query, candidate_vector))
+                    Ok(scorer.distance(&query, candidate_vector))
                 } else {
                     raw_vectors
                         .as_mut()
                         .expect("set if any")
                         .get_raw_vector(vertex)
                         .expect("row exists")
-                        .map(|rv| scorer.score(&query, &rv))
+                        .map(|rv| scorer.distance(&query, &rv))
                 };
                 score.map(|s| Neighbor::new(vertex, s))
             })
@@ -447,7 +447,7 @@ mod test {
                 .enumerate()
                 .filter_map(|(i, n)| {
                     if i != index {
-                        Some(Neighbor::new(i as i64, scorer.score(q, &n.vector)))
+                        Some(Neighbor::new(i as i64, scorer.distance(q, &n.vector)))
                     } else {
                         None
                     }
@@ -470,7 +470,7 @@ mod test {
                 let q = &graph[n.vertex() as usize].vector;
                 if !selected
                     .iter()
-                    .any(|p| scorer.score(q, &graph[p.vertex() as usize].vector) < n.distance())
+                    .any(|p| scorer.distance(q, &graph[p.vertex() as usize].vector) < n.distance())
                 {
                     selected.push(*n);
                 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -11,7 +11,7 @@ use crate::{
         RawVectorStore,
     },
     quantization::Quantizer,
-    scoring::QuantizedVectorScorer,
+    scoring::QuantizedVectorDistance,
     Neighbor,
 };
 
@@ -120,13 +120,13 @@ impl GraphSearcher {
         let mut graph = reader.graph()?;
         let mut nav = reader.nav_vectors()?;
         let quantizer = reader.config().new_quantizer();
-        let nav_scorer = reader.config().new_nav_scorer();
+        let nav_distance_fn = reader.config().new_nav_distance_function();
         let nav_query = self.init_candidates(
             query,
             &mut graph,
             &mut nav,
             quantizer.as_ref(),
-            nav_scorer.as_ref(),
+            nav_distance_fn.as_ref(),
         )?;
 
         while let Some(mut best_candidate) = self.candidates.next_unvisited() {
@@ -148,8 +148,10 @@ impl GraphSearcher {
                 let vec = nav
                     .get_nav_vector(edge)
                     .unwrap_or(Err(Error::not_found_error()))?;
-                self.candidates
-                    .add_unvisited(Neighbor::new(edge, nav_scorer.distance(&nav_query, &vec)));
+                self.candidates.add_unvisited(Neighbor::new(
+                    edge,
+                    nav_distance_fn.distance(&nav_query, &vec),
+                ));
             }
         }
 
@@ -163,7 +165,7 @@ impl GraphSearcher {
         graph: &mut G,
         nav: &mut N,
         quantizer: &dyn Quantizer,
-        nav_scorer: &dyn QuantizedVectorScorer,
+        nav_distance_fn: &dyn QuantizedVectorDistance,
     ) -> Result<Vec<u8>>
     where
         G: Graph,
@@ -177,7 +179,7 @@ impl GraphSearcher {
                 .unwrap_or(Err(Error::not_found_error()))?;
             self.candidates.add_unvisited(Neighbor::new(
                 entry_point,
-                nav_scorer.distance(&nav_query, &entry_vector),
+                nav_distance_fn.distance(&nav_query, &entry_vector),
             ));
             self.seen.insert(entry_point);
         }
@@ -195,8 +197,8 @@ impl GraphSearcher {
             return Ok(self.candidates.iter().map(|c| c.neighbor).collect());
         }
 
-        let scorer = reader.config().new_scorer();
-        let query = scorer.normalize_vector(query.into());
+        let distance_fn = reader.config().new_distance_function();
+        let query = distance_fn.normalize_vector(query.into());
         let mut raw_vectors = if self.candidates.iter().any(|c| c.state.vector().is_none()) {
             Some(reader.raw_vectors()?)
         } else {
@@ -208,17 +210,17 @@ impl GraphSearcher {
             .take(self.params.num_rerank)
             .map(|c| {
                 let vertex = c.neighbor.vertex();
-                let score = if let Some(candidate_vector) = c.state.vector() {
-                    Ok(scorer.distance(&query, candidate_vector))
+                let distance = if let Some(candidate_vector) = c.state.vector() {
+                    Ok(distance_fn.distance(&query, candidate_vector))
                 } else {
                     raw_vectors
                         .as_mut()
                         .expect("set if any")
                         .get_raw_vector(vertex)
                         .expect("row exists")
-                        .map(|rv| scorer.distance(&query, &rv))
+                        .map(|rv| distance_fn.distance(&query, &rv))
                 };
-                score.map(|s| Neighbor::new(vertex, s))
+                distance.map(|s| Neighbor::new(vertex, s))
             })
             .collect::<Result<Vec<_>>>();
         rescored.map(|mut r| {
@@ -372,7 +374,7 @@ mod test {
             RawVector, RawVectorStore,
         },
         quantization::{BinaryQuantizer, Quantizer, VectorQuantizer},
-        scoring::{DotProductScorer, F32VectorScorer, VectorSimilarity},
+        scoring::{DotProductDistance, F32VectorDistance, VectorSimilarity},
         Neighbor,
     };
 
@@ -392,9 +394,9 @@ mod test {
     }
 
     impl TestGraphVectorIndex {
-        pub fn new<S, T, V>(max_edges: NonZero<usize>, scorer: S, iter: T) -> Self
+        pub fn new<S, T, V>(max_edges: NonZero<usize>, distance_fn: S, iter: T) -> Self
         where
-            S: F32VectorScorer,
+            S: F32VectorDistance,
             T: IntoIterator<Item = V>,
             V: Into<Vec<f32>>,
         {
@@ -412,7 +414,7 @@ mod test {
                 .collect::<Vec<_>>();
 
             for i in 0..rep.len() {
-                rep[i].edges = Self::compute_edges(&rep, i, max_edges, &scorer);
+                rep[i].edges = Self::compute_edges(&rep, i, max_edges, &distance_fn);
             }
             let config = GraphConfig {
                 dimensions: NonZero::new(rep.first().map(|v| v.vector.len()).unwrap_or(1)).unwrap(),
@@ -436,10 +438,10 @@ mod test {
             graph: &[TestVector],
             index: usize,
             max_edges: NonZero<usize>,
-            scorer: &S,
+            distance_fn: &S,
         ) -> Vec<i64>
         where
-            S: F32VectorScorer,
+            S: F32VectorDistance,
         {
             let q = &graph[index].vector;
             let mut scored = graph
@@ -447,7 +449,7 @@ mod test {
                 .enumerate()
                 .filter_map(|(i, n)| {
                     if i != index {
-                        Some(Neighbor::new(i as i64, scorer.distance(q, &n.vector)))
+                        Some(Neighbor::new(i as i64, distance_fn.distance(q, &n.vector)))
                     } else {
                         None
                     }
@@ -468,10 +470,9 @@ mod test {
                 }
 
                 let q = &graph[n.vertex() as usize].vector;
-                if !selected
-                    .iter()
-                    .any(|p| scorer.distance(q, &graph[p.vertex() as usize].vector) < n.distance())
-                {
+                if !selected.iter().any(|p| {
+                    distance_fn.distance(q, &graph[p.vertex() as usize].vector) < n.distance()
+                }) {
                     selected.push(*n);
                 }
             }
@@ -606,7 +607,7 @@ mod test {
         let dim_values = [-0.25, -0.125, 0.125, 0.25];
         TestGraphVectorIndex::new(
             NonZero::new(max_edges).unwrap(),
-            DotProductScorer,
+            DotProductDistance,
             (0..256).map(|v| {
                 Vec::from([
                     dim_values[v & 0x3],


### PR DESCRIPTION
Replace scoring (descending order) with distance (ascending order).

Rewriting scoring as distance is more straightforward to compute:
* euclidean distance and hamming distance require no massaging of the similarity result.
* dot product requires some minimal changes but they are fairly simple.

This will make it easier to do some i8 quantization tasks in the near future.