### PR TITLE
Implement naive i8 quantization

### DIFF
--- a/src/distance.rs
+++ b/src/distance.rs
@@ -133,38 +133,38 @@ impl QuantizedVectorDistance for AsymmetricHammingDistance {
     }
 }
 
-struct I8NaiveVector<'a> {
-    vector: &'a [i8],
-    #[allow(dead_code)]
-    squared_l2_norm: f32,
-}
+#[derive(Debug, Copy, Clone)]
+pub struct I8NaiveDistance(pub(crate) VectorSimilarity);
 
-impl<'a> From<&'a [u8]> for I8NaiveVector<'a> {
-    fn from(value: &'a [u8]) -> Self {
-        assert!(value.len() >= std::mem::size_of::<f32>());
-        let (vector_bytes, norm_bytes) = value.split_at(value.len() - std::mem::size_of::<f32>());
-        Self {
-            vector: unsafe {
+impl I8NaiveDistance {
+    fn unpack(raw: &[u8]) -> (&[i8], f32) {
+        assert!(raw.len() >= std::mem::size_of::<f32>());
+        let (vector_bytes, norm_bytes) = raw.split_at(raw.len() - std::mem::size_of::<f32>());
+        (
+            unsafe {
                 std::slice::from_raw_parts(vector_bytes.as_ptr() as *const i8, vector_bytes.len())
             },
-            squared_l2_norm: f32::from_le_bytes(norm_bytes.try_into().unwrap()),
-        }
+            f32::from_le_bytes(norm_bytes.try_into().unwrap()),
+        )
     }
 }
 
-// XXX need a euclidean impl. to do this we might want to fix the distance function.
-#[derive(Debug, Copy, Clone)]
-pub struct I8DotScorer;
-
-impl QuantizedVectorScorer for I8DotScorer {
-    fn score(&self, query: &[u8], doc: &[u8]) -> f64 {
-        let qv = I8NaiveVector::from(query);
-        let dv = I8NaiveVector::from(doc);
+impl QuantizedVectorDistance for I8NaiveDistance {
+    fn distance(&self, query: &[u8], doc: &[u8]) -> f64 {
+        let (qv, qnorm) = Self::unpack(query);
+        let (dv, dnorm) = Self::unpack(doc);
         let divisor = i8::MAX as f32 * i8::MAX as f32;
-        qv.vector
+        // NB: we may be able to accelerate this further with manual SIMD implementations.
+        let dot = qv
             .iter()
-            .zip(dv.vector.iter())
-            .map(|(q, d)| (*q as i16 * *d as i16) as f32 / divisor)
-            .sum::<f32>() as f64
+            .zip(dv.iter())
+            .map(|(q, d)| *q as i32 * *d as i32)
+            .sum::<i32>() as f64
+            / divisor as f64;
+        let distance = (-dot + 1.0) / 2.0;
+        match self.0 {
+            VectorSimilarity::Dot => distance,
+            VectorSimilarity::Euclidean => distance + qnorm as f64 + dnorm as f64,
+        }
     }
 }

--- a/src/distance.rs
+++ b/src/distance.rs
@@ -152,6 +152,7 @@ impl<'a> From<&'a [u8]> for I8NaiveVector<'a> {
     }
 }
 
+// XXX need a euclidean impl. to do this we might want to fix the distance function.
 #[derive(Debug, Copy, Clone)]
 pub struct I8DotScorer;
 
@@ -159,6 +160,11 @@ impl QuantizedVectorScorer for I8DotScorer {
     fn score(&self, query: &[u8], doc: &[u8]) -> f64 {
         let qv = I8NaiveVector::from(query);
         let dv = I8NaiveVector::from(doc);
-        SpatialSimilarity::dot(qv.vector, dv.vector).unwrap()
+        let divisor = i8::MAX as f32 * i8::MAX as f32;
+        qv.vector
+            .iter()
+            .zip(dv.vector.iter())
+            .map(|(q, d)| (*q as i16 * *d as i16) as f32 / divisor)
+            .sum::<f32>() as f64
     }
 }

--- a/src/quantization.rs
+++ b/src/quantization.rs
@@ -229,7 +229,6 @@ impl Quantizer for AsymmetricBinaryQuantizer {
     }
 }
 
-// XXX I8NaiveQuantizer
 #[derive(Debug, Copy, Clone)]
 pub struct I8NaiveQuantizer;
 
@@ -242,6 +241,9 @@ impl Quantizer for I8NaiveQuantizer {
         }
 
         // In the normalized vector all dimensions are in [-1.0, 1.0], so we can multiply by i8::MAX and round.
+        // TODO: this is very conservative, we could probably be less conservative and choose a larger value
+        // (with a clamp) based on dimensionality. We could also adjust values for matryoshka models.
+        //
         // Save the squared l2 norm for use computing l2 distance.
         // TODO: only store this for l2 similarity, it's unnecessary for dot.
         let mut quantized = Vec::with_capacity(self.doc_bytes(vector.len()));
@@ -256,6 +258,7 @@ impl Quantizer for I8NaiveQuantizer {
         dimensions + std::mem::size_of::<f32>()
     }
 
+    // TODO: "quantize" the query as [f32] and score asymmetrically to preserve precision.
     fn for_query(&self, vector: &[f32]) -> Vec<u8> {
         self.for_doc(vector)
     }

--- a/src/quantization.rs
+++ b/src/quantization.rs
@@ -8,7 +8,8 @@ use serde::{Deserialize, Serialize};
 use simsimd::SpatialSimilarity;
 
 use crate::distance::{
-    AsymmetricHammingDistance, HammingDistance, QuantizedVectorDistance, VectorSimilarity,
+    AsymmetricHammingDistance, HammingDistance, I8NaiveDistance, QuantizedVectorDistance,
+    VectorSimilarity,
 };
 
 /// `Quantizer` is used to perform lossy quantization of input vectors.
@@ -57,15 +58,12 @@ impl VectorQuantizer {
     /// Create a new distance function for this quantization method.
     pub fn new_distance_function(
         &self,
-        _similarity: &VectorSimilarity,
+        similarity: &VectorSimilarity,
     ) -> Box<dyn QuantizedVectorDistance> {
         match self {
             Self::Binary => Box::new(HammingDistance),
             Self::AsymmetricBinary { n: _ } => Box::new(AsymmetricHammingDistance),
-            Self::I8Naive => {
-                assert_eq!(*similarity, VectorSimilarity::Dot);
-                Box::new(I8DotScorer)
-            }
+            Self::I8Naive => Box::new(I8NaiveDistance(*similarity)),
         }
     }
 }

--- a/src/quantization.rs
+++ b/src/quantization.rs
@@ -5,6 +5,7 @@
 use std::{io, str::FromStr};
 
 use serde::{Deserialize, Serialize};
+use simsimd::SpatialSimilarity;
 
 use crate::distance::{
     AsymmetricHammingDistance, HammingDistance, QuantizedVectorDistance, VectorSimilarity,
@@ -38,6 +39,9 @@ pub enum VectorQuantizer {
     /// Binary quantizes indexed vectors; produces an n-bit representation at
     /// query time to increase precision. This is also used during indexing.
     AsymmetricBinary { n: usize },
+    /// Reduces each dimension to an 8-bit integer.
+    /// This implementation does not train on any input to decide how to quantize.
+    I8Naive,
 }
 
 impl VectorQuantizer {
@@ -46,6 +50,7 @@ impl VectorQuantizer {
         match self {
             Self::Binary => Box::new(BinaryQuantizer),
             Self::AsymmetricBinary { n } => Box::new(AsymmetricBinaryQuantizer::new(*n)),
+            Self::I8Naive => Box::new(I8NaiveQuantizer),
         }
     }
 
@@ -57,6 +62,10 @@ impl VectorQuantizer {
         match self {
             Self::Binary => Box::new(HammingDistance),
             Self::AsymmetricBinary { n: _ } => Box::new(AsymmetricHammingDistance),
+            Self::I8Naive => {
+                assert_eq!(*similarity, VectorSimilarity::Dot);
+                Box::new(I8DotScorer)
+            }
         }
     }
 }
@@ -84,6 +93,8 @@ impl FromStr for VectorQuantizer {
                 .and_then(|b| if (1..=8).contains(&b) { Some(b) } else { None })
                 .map(|n| Self::AsymmetricBinary { n })
                 .ok_or_else(|| input_err(format!("invalid asymmetric_binary bits {}", bits_str)))
+        } else if s == "i8naive" {
+            Ok(Self::I8Naive)
         } else {
             Err(input_err(format!("unknown quantizer function {}", s)))
         }
@@ -215,5 +226,41 @@ impl Quantizer for AsymmetricBinaryQuantizer {
 
     fn query_bytes(&self, dimensions: usize) -> usize {
         self.doc_bytes(dimensions) * self.n
+    }
+}
+
+// XXX I8NaiveQuantizer
+#[derive(Debug, Copy, Clone)]
+pub struct I8NaiveQuantizer;
+
+impl Quantizer for I8NaiveQuantizer {
+    fn for_doc(&self, vector: &[f32]) -> Vec<u8> {
+        let norm = SpatialSimilarity::dot(vector, vector).unwrap().sqrt() as f32;
+        let mut normalized_vector = vector.to_vec();
+        for d in normalized_vector.iter_mut() {
+            *d /= norm;
+        }
+
+        // In the normalized vector all dimensions are in [-1.0, 1.0], so we can multiply by i8::MAX and round.
+        // Save the squared l2 norm for use computing l2 distance.
+        // TODO: only store this for l2 similarity, it's unnecessary for dot.
+        let mut quantized = Vec::with_capacity(self.doc_bytes(vector.len()));
+        for f in normalized_vector {
+            quantized.push(((f * i8::MAX as f32).round() as i8).to_le_bytes()[0]);
+        }
+        quantized.extend_from_slice(&(norm * norm).to_le_bytes());
+        quantized
+    }
+
+    fn doc_bytes(&self, dimensions: usize) -> usize {
+        dimensions + std::mem::size_of::<f32>()
+    }
+
+    fn for_query(&self, vector: &[f32]) -> Vec<u8> {
+        self.for_doc(vector)
+    }
+
+    fn query_bytes(&self, dimensions: usize) -> usize {
+        self.doc_bytes(dimensions)
     }
 }


### PR DESCRIPTION
Implement a naive i8 quantization scheme based on the ScaNN implementation.

This scheme does not train on a data set at all. Input float vectors are l2 normalized before quantization, and we quantize
values assuming they may occupy any part of the range [-1,1]. The norm is stored alongside the quantized vector and
query and doc norms are added to the distance when computing euclidean distance.

Compared to raw float distances this has a loss of 3-3.5% recall but at roughly a quarter of the cost.

There are a couple of potential extensions to this scheme:
* Train on data to bound the quantization range and increase precision.
* Quantize asymmetrically: score float query vectors against i8 doc vectors. I tried this and it was worth about 1% recall precision.

The scoring function implementation is written in scalar code as `simsimd` insists on performing cosine similarity
for i8 vectors for reasons that are unclear. This implementation auto-vectorizes alright but in the long run might be
better off using `std::simd` or manually writing vectorized code for this.