### PR TITLE
KMeans partitioning improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ threadpool = "1.8.1"
 wt_mdb = { path = "./wt_mdb" }
 
 [workspace]
-members = ["et", "wt_mdb", "wt_sys"]
+members = ["et", "pt", "wt_mdb", "wt_sys"]
 
 [profile.profiling]
 inherits = "release"

--- a/pt/Cargo.toml
+++ b/pt/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "pt"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+clap = { version = "4.5.34", features = ["derive"] }
+easy_tiger = { path = "../" }
+histogram = "0.11.3"
+indicatif = "0.17.11"
+memmap2 = { version = "0.9.5", features = ["stable_deref_trait"] }
+rand = "0.8.5"
+stable_deref_trait = "1.2.0"

--- a/pt/Cargo.toml
+++ b/pt/Cargo.toml
@@ -10,4 +10,6 @@ histogram = "0.11.3"
 indicatif = "0.17.11"
 memmap2 = { version = "0.9.5", features = ["stable_deref_trait"] }
 rand = "0.8.5"
+rayon = "1.10.0"
+simsimd = "6.4.2"
 stable_deref_trait = "1.2.0"

--- a/pt/src/main.rs
+++ b/pt/src/main.rs
@@ -26,6 +26,9 @@ struct Cli {
     /// Run up to this many k-means iterations before terminating.
     #[arg(short, long, default_value_t = NonZero::new(15).unwrap())]
     iters: NonZero<usize>,
+    /// Exit early from iteration if new centroids are within epsilon of the previous iteration.
+    #[arg(long, default_value_t = 0.01)]
+    epsilon: f64,
     /// Run this many initializations of the centroids before proceeding.
     #[arg(long, default_value_t = NonZero::new(3).unwrap())]
     init_iters: NonZero<usize>,
@@ -50,6 +53,7 @@ fn main() -> io::Result<()> {
         &Params {
             iters: cli.iters.get(),
             init_iters: cli.init_iters.get(),
+            epsilon: cli.epsilon,
             ..Default::default()
         },
         &mut thread_rng(),

--- a/pt/src/main.rs
+++ b/pt/src/main.rs
@@ -26,6 +26,9 @@ struct Cli {
     /// Run up to this many k-means iterations before terminating.
     #[arg(short, long, default_value_t = NonZero::new(15).unwrap())]
     iters: NonZero<usize>,
+    /// Run this many initializations of the centroids before proceeding.
+    #[arg(long, default_value_t = NonZero::new(3).unwrap())]
+    init_iters: NonZero<usize>,
     /// Size of k-means batches. Larger numbers improve convergence rate but are more expensive.
     #[arg(short, long, default_value_t = NonZero::new(10_000).unwrap())]
     batch_size: NonZero<usize>,
@@ -39,7 +42,6 @@ fn main() -> io::Result<()> {
         cli.dimensions,
     )?;
 
-    // XXX iterations for centroid selection vs batch iteration.
     println!("Computing {} centroids", cli.num_partitions.get());
     let centroids = match batch_kmeans(
         &input_vectors,
@@ -47,7 +49,7 @@ fn main() -> io::Result<()> {
         cli.batch_size.get(),
         &Params {
             iters: cli.iters.get(),
-            // XXX add an option to use kmeans++.
+            init_iters: cli.init_iters.get(),
             ..Default::default()
         },
         &mut thread_rng(),
@@ -70,7 +72,7 @@ fn main() -> io::Result<()> {
     for (c, _) in assignments.iter() {
         centroid_counts[*c] += 1;
     }
-    let mut histogram = Histogram::new(2, 16).unwrap();
+    let mut histogram = Histogram::new(2, 18).unwrap();
     for c in centroid_counts.iter() {
         histogram.add(*c as u64, 1).unwrap();
     }

--- a/pt/src/main.rs
+++ b/pt/src/main.rs
@@ -4,11 +4,11 @@ use std::num::NonZero;
 use std::path::PathBuf;
 
 use clap::Parser;
-use easy_tiger::input::{DerefVectorStore, VectorStore};
-use easy_tiger::kmeans::{Params, batch_kmeans, compute_assignments};
+use easy_tiger::input::{DerefVectorStore, SubsetViewVectorStore, VecVectorStore, VectorStore};
+use easy_tiger::kmeans::{self, Params, batch_kmeans, compute_assignments};
 use histogram::Histogram;
 use memmap2::Mmap;
-use rand::thread_rng;
+use rand::{Rng, thread_rng};
 
 #[derive(Parser)]
 #[command(version, about = "Tool for instrumenting vector partitioning techniques", long_about = None)]
@@ -35,6 +35,74 @@ struct Cli {
     /// Size of k-means batches. Larger numbers improve convergence rate but are more expensive.
     #[arg(short, long, default_value_t = NonZero::new(10_000).unwrap())]
     batch_size: NonZero<usize>,
+
+    /// Keep splitting the largest centroid until no centroid is larger than this target size.
+    #[arg(long)]
+    iter_target_size: Option<usize>,
+}
+
+fn split_to_target_size<V: VectorStore<Elem = f32> + Send + Sync>(
+    dataset: &V,
+    mut centroids: VecVectorStore<f32>,
+    mut assignments: Vec<(usize, f64)>,
+    target_size: usize,
+    batch_size: usize,
+    params: &kmeans::Params,
+    rng: &mut impl Rng,
+) -> (VecVectorStore<f32>, Vec<(usize, f64)>) {
+    loop {
+        let centroid_assignments = assignments.iter().enumerate().fold(
+            vec![vec![]; centroids.len()],
+            |mut centroids, (i, (c, _))| {
+                centroids[*c].push(i);
+                centroids
+            },
+        );
+
+        if centroid_assignments.iter().all(|c| c.len() <= target_size) {
+            println!("  reached max target_size {}; terminating", target_size);
+            break (centroids, assignments);
+        }
+
+        let mut new_centroids = VecVectorStore::new(centroids.elem_stride());
+        for (c, centroid_vectors) in centroid_assignments.into_iter().enumerate() {
+            if centroid_vectors.len() <= target_size {
+                new_centroids.push(&centroids[c]);
+                continue;
+            }
+
+            let k = centroid_vectors.len() / target_size + 1;
+            println!(
+                "  partitioning centroid {} of {} vectors into {} parts",
+                c,
+                centroid_vectors.len(),
+                k,
+            );
+            let subset = SubsetViewVectorStore::new(dataset, centroid_vectors);
+            let subset_centroids = match batch_kmeans(&subset, k, batch_size, params, rng) {
+                Ok(c) => c,
+                Err(e) => {
+                    println!("k-means failed to converge!");
+                    e
+                }
+            };
+
+            for c in subset_centroids.iter() {
+                new_centroids.push(c);
+            }
+        }
+
+        // enumerate split centroids (old indices)
+        // enumerate split generated centroids (new indices)
+        // - if the previous assignment is in the first set need to totally recompute centroids.
+        // - else compute against only the new centroids.
+
+        centroids = new_centroids;
+        println!("  recomputing assignments to {} centroids", centroids.len());
+        // XXX I can make this less exhaustive -- if the assigned centroid was not split then I only
+        // need to compute distances against the added centroids.
+        assignments = compute_assignments(dataset, &centroids);
+    }
 }
 
 fn main() -> io::Result<()> {
@@ -46,16 +114,17 @@ fn main() -> io::Result<()> {
     )?;
 
     println!("Computing {} centroids", cli.num_partitions.get());
-    let centroids = match batch_kmeans(
+    let kemans_params = Params {
+        iters: cli.iters.get(),
+        init_iters: cli.init_iters.get(),
+        epsilon: cli.epsilon,
+        ..Default::default()
+    };
+    let mut centroids = match batch_kmeans(
         &input_vectors,
         cli.num_partitions.get(),
         cli.batch_size.get(),
-        &Params {
-            iters: cli.iters.get(),
-            init_iters: cli.init_iters.get(),
-            epsilon: cli.epsilon,
-            ..Default::default()
-        },
+        &kemans_params,
         &mut thread_rng(),
     ) {
         Ok(c) => c,
@@ -70,13 +139,29 @@ fn main() -> io::Result<()> {
         input_vectors.len(),
         cli.num_partitions.get()
     );
-    let assignments = compute_assignments(&input_vectors, &centroids);
+    let mut assignments = compute_assignments(&input_vectors, &centroids);
 
-    let mut centroid_counts = vec![0usize; cli.num_partitions.get()];
-    for (c, _) in assignments.iter() {
-        centroid_counts[*c] += 1;
+    if let Some(target_size) = cli.iter_target_size {
+        (centroids, assignments) = split_to_target_size(
+            &input_vectors,
+            centroids,
+            assignments,
+            target_size,
+            cli.batch_size.get(),
+            &kemans_params,
+            &mut thread_rng(),
+        );
     }
-    let mut histogram = Histogram::new(2, 18).unwrap();
+
+    let centroid_counts =
+        assignments
+            .iter()
+            .fold(vec![0usize; centroids.len()], |mut counts, (c, _)| {
+                counts[*c] += 1;
+                counts
+            });
+
+    let mut histogram = Histogram::new(2, 20).unwrap();
     for c in centroid_counts.iter() {
         histogram.add(*c as u64, 1).unwrap();
     }

--- a/pt/src/main.rs
+++ b/pt/src/main.rs
@@ -1,0 +1,95 @@
+use std::fs::File;
+use std::io;
+use std::num::NonZero;
+use std::path::PathBuf;
+
+use clap::Parser;
+use easy_tiger::input::{DerefVectorStore, VectorStore};
+use easy_tiger::kmeans::{Params, batch_kmeans, compute_assignments};
+use histogram::Histogram;
+use memmap2::Mmap;
+use rand::thread_rng;
+
+#[derive(Parser)]
+#[command(version, about = "Tool for instrumenting vector partitioning techniques", long_about = None)]
+struct Cli {
+    /// Input vector file for partitioning.
+    #[arg(short = 'v', long)]
+    input_vectors: PathBuf,
+    /// Vector dimensions in --input-vectors
+    #[arg(short, long)]
+    dimensions: NonZero<usize>,
+
+    /// Number of partitions to divide the input set into.
+    #[arg(short = 'k', long)]
+    num_partitions: NonZero<usize>,
+    /// Run up to this many k-means iterations before terminating.
+    #[arg(short, long, default_value_t = NonZero::new(15).unwrap())]
+    iters: NonZero<usize>,
+    /// Size of k-means batches. Larger numbers improve convergence rate but are more expensive.
+    #[arg(short, long, default_value_t = NonZero::new(10_000).unwrap())]
+    batch_size: NonZero<usize>,
+}
+
+fn main() -> io::Result<()> {
+    let cli = Cli::parse();
+
+    let input_vectors: DerefVectorStore<f32, Mmap> = DerefVectorStore::new(
+        unsafe { Mmap::map(&File::open(cli.input_vectors)?)? },
+        cli.dimensions,
+    )?;
+
+    // XXX iterations for centroid selection vs batch iteration.
+    println!("Computing {} centroids", cli.num_partitions.get());
+    let centroids = match batch_kmeans(
+        &input_vectors,
+        cli.num_partitions.get(),
+        cli.batch_size.get(),
+        &Params {
+            iters: cli.iters.get(),
+            // XXX add an option to use kmeans++.
+            ..Default::default()
+        },
+        &mut thread_rng(),
+    ) {
+        Ok(c) => c,
+        Err(e) => {
+            println!("k-means failed to converge!");
+            e
+        }
+    };
+
+    println!(
+        "Computing assignments for {} vectors into {} centroids",
+        input_vectors.len(),
+        cli.num_partitions.get()
+    );
+    let assignments = compute_assignments(&input_vectors, &centroids);
+
+    let mut centroid_counts = vec![0usize; cli.num_partitions.get()];
+    for (c, _) in assignments.iter() {
+        centroid_counts[*c] += 1;
+    }
+    let mut histogram = Histogram::new(2, 16).unwrap();
+    for c in centroid_counts.iter() {
+        histogram.add(*c as u64, 1).unwrap();
+    }
+
+    for bucket in histogram.into_iter().filter(|b| b.count() > 0) {
+        println!(
+            "[{:5}..{:5}] {:4}",
+            bucket.start(),
+            bucket.end(),
+            bucket.count()
+        );
+    }
+
+    println!(
+        "total {:9} min {:9} max {:9}",
+        centroid_counts.iter().copied().sum::<usize>(),
+        centroid_counts.iter().copied().min().unwrap(),
+        centroid_counts.iter().copied().max().unwrap()
+    );
+
+    Ok(())
+}

--- a/src/input.rs
+++ b/src/input.rs
@@ -134,6 +134,10 @@ impl<E: Clone> VecVectorStore<E> {
         self.data.extend_from_slice(vector);
     }
 
+    pub fn capacity(&self) -> usize {
+        self.data.capacity() / self.elem_stride
+    }
+
     fn index_range(&self, index: usize) -> Range<usize> {
         let start = index * self.elem_stride;
         start..(start + self.elem_stride)

--- a/src/kmeans.rs
+++ b/src/kmeans.rs
@@ -23,6 +23,8 @@ pub enum InitializationMethod {
 pub struct Params {
     /// Maximum number of iterations to run before exiting, even if the centers have not converged.
     pub iters: usize,
+    /// Maximum number of iterations when initializing centroids.
+    pub init_iters: usize,
     /// Convergence epsilon. Computation is considered to have converged if the sum of distances
     /// between two iterations of centroid is less than this amount.
     pub epsilon: f64,
@@ -34,6 +36,7 @@ impl Default for Params {
     fn default() -> Self {
         Self {
             iters: 15,
+            init_iters: 3,
             epsilon: 0.01,
             initialization: InitializationMethod::Random,
         }
@@ -107,7 +110,7 @@ fn initialize_batch_centroids<V: VectorStore<Elem = f32> + Send + Sync>(
     params: &Params,
     rng: &mut impl Rng,
 ) -> VecVectorStore<f32> {
-    (0..params.iters)
+    (0..params.init_iters)
         .map(|_| initialize_centroids(training_data, k, params.initialization, rng))
         .min_by(|a, b| a.1.total_cmp(&b.1))
         .expect("non-zero iters")

--- a/src/quantization.rs
+++ b/src/quantization.rs
@@ -120,7 +120,7 @@ impl Quantizer for BinaryQuantizer {
     }
 
     fn doc_bytes(&self, dimensions: usize) -> usize {
-        (dimensions + 7) / 8
+        dimensions.div_ceil(8)
     }
 
     fn for_query(&self, vector: &[f32]) -> Vec<u8> {


### PR DESCRIPTION
Add `iterative_balanced_kmeans` partitioning scheme.

This scheme limits itself to partitioning using an intermediate k value with the goal of reaching the actual k value. At each step we may partition centroids that are too large. A balancing factor is used to decide when a partition is "too large" and must be split. This is much faster than running k-means with a very large value (~1k) and yields a more balanced distribution.

* Select random vectors for k-means initialization from the complete dataset.
* Evaluate initial centers using a random subset of vectors to control cost.
* Terminate based on max centroid distance. Summing did not work particularly well when k was large.
* Add a tool to help observe iterative partitioning algorithm