### PR TITLE
Use quantized vectors in index build when num_rerank is 0

### DIFF
--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -494,7 +494,7 @@ where
             &mut candidates,
             self.index.config().max_edges,
             edge_set_distance_computer,
-        )?;
+        );
         candidates.truncate(split);
         Ok(candidates)
     }
@@ -547,7 +547,7 @@ where
                     &edges,
                     max_edges,
                     EdgeSetDistanceComputer::new(reader, &edges)?,
-                )?;
+                );
                 edges
                     .iter()
                     .enumerate()

--- a/src/crud.rs
+++ b/src/crud.rs
@@ -3,7 +3,10 @@ use std::{ops::Deref, sync::Arc};
 
 use crate::{
     distance::F32VectorDistance,
-    graph::{prune_edges, Graph, GraphLayout, GraphVectorIndexReader, GraphVertex, RawVectorStore},
+    graph::{
+        prune_edges, EdgeSetDistanceComputer, Graph, GraphLayout, GraphVectorIndexReader,
+        GraphVertex, RawVectorStore,
+    },
     search::GraphSearcher,
     wt::{
         encode_graph_vertex, encode_raw_vector, SessionGraphVectorIndexReader,
@@ -73,11 +76,12 @@ impl IndexMutator {
             // This is mostly as a noop because there are no edges.
             graph.set_entry_point(vertex_id)?;
         }
+        let edge_set_distance_computer =
+            EdgeSetDistanceComputer::new(&self.reader, &candidate_edges)?;
         let selected_len = prune_edges(
             &mut candidate_edges,
             self.reader.config().max_edges,
-            &mut raw_vectors,
-            distance_fn.as_ref(),
+            edge_set_distance_computer,
         )?;
         candidate_edges.truncate(selected_len);
 
@@ -149,11 +153,12 @@ impl IndexMutator {
                 })
                 .collect::<Result<Vec<Neighbor>>>()?;
             neighbors.sort();
+            let edge_set_distance_computer =
+                EdgeSetDistanceComputer::new(&self.reader, &neighbors)?;
             let selected_len = prune_edges(
                 &mut neighbors,
                 self.reader.config().max_edges,
-                raw_vectors,
-                distance_fn,
+                edge_set_distance_computer,
             )?;
             // Ensure the graph is undirected by removing links from pruned edges back to this node.
             for v in neighbors.iter().skip(selected_len).map(Neighbor::vertex) {

--- a/src/crud.rs
+++ b/src/crud.rs
@@ -82,7 +82,7 @@ impl IndexMutator {
             &mut candidate_edges,
             self.reader.config().max_edges,
             edge_set_distance_computer,
-        )?;
+        );
         candidate_edges.truncate(selected_len);
 
         self.set_vertex(
@@ -159,7 +159,7 @@ impl IndexMutator {
                 &mut neighbors,
                 self.reader.config().max_edges,
                 edge_set_distance_computer,
-            )?;
+            );
             // Ensure the graph is undirected by removing links from pruned edges back to this node.
             for v in neighbors.iter().skip(selected_len).map(Neighbor::vertex) {
                 pruned_edges.push((v, src_vertex_id))

--- a/src/distance.rs
+++ b/src/distance.rs
@@ -27,7 +27,7 @@ pub trait F32VectorDistance: Send + Sync {
 ///
 /// This trait is object-safe; it may be instantiated at runtime based on
 /// data that appears in a file or other backing store.
-pub trait QuantizedVectorDistance {
+pub trait QuantizedVectorDistance: Send + Sync {
     /// Score the `query` vector against the `doc` vector. Returns a score
     /// where larger values are better matches.
     ///

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -294,14 +294,13 @@ impl EdgeSetDistanceComputer {
 /// decisions.
 /// REQUIRES: `edges.is_sorted()`.
 // TODO: alpha value(s) should be tuneable.
-// XXX this no longer fails
-pub(crate) fn select_pruned_edges<'a>(
+pub(crate) fn select_pruned_edges(
     edges: &[Neighbor],
     max_edges: NonZero<usize>,
     edge_distance_computer: EdgeSetDistanceComputer,
-) -> Result<BTreeSet<usize>> {
+) -> BTreeSet<usize> {
     if edges.is_empty() {
-        return Ok(BTreeSet::new());
+        return BTreeSet::new();
     }
 
     debug_assert!(edges.is_sorted());
@@ -332,25 +331,22 @@ pub(crate) fn select_pruned_edges<'a>(
         }
     }
 
-    Ok(selected)
+    selected
 }
 
 /// Prune `edges` down to at most `max_edges`. Use `graph` and `distance_fn` to inform this decision.
 /// Returns a split point: all edges before that point are selected, all after are to be dropped.
 /// REQUIRES: `edges.is_sorted()`.
 // TODO: alpha value(s) should be tuneable.
-// XXX this no longer fails
-pub(crate) fn prune_edges<'a>(
+pub(crate) fn prune_edges(
     edges: &mut [Neighbor],
     max_edges: NonZero<usize>,
     edge_distance_computer: EdgeSetDistanceComputer,
-) -> Result<usize> {
-    let selected = select_pruned_edges(edges, max_edges, edge_distance_computer)?;
-
+) -> usize {
+    let selected = select_pruned_edges(edges, max_edges, edge_distance_computer);
     // Partition edges into selected and unselected.
     for (i, j) in selected.iter().enumerate() {
         edges.swap(i, *j);
     }
-
-    Ok(selected.len())
+    selected.len()
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -114,7 +114,8 @@ impl GraphSearcher {
         // Marking this vertex as seen ensures we don't traverse or score ourselves (should be identity score).
         self.seen.insert(vertex_id);
 
-        // NB: if inserting in a WT backed graph this will create a cursor that we immediately discard.
+        // XXX if we are not re-ranking then search _quantized_ without performing this read.
+        // it would put way less pressure on the cache.
         let query = reader
             .raw_vectors()?
             .get_raw_vector(vertex_id)

--- a/src/search.rs
+++ b/src/search.rs
@@ -6,12 +6,10 @@ use std::{
 };
 
 use crate::{
-    distance::QuantizedVectorDistance,
     graph::{
         Graph, GraphSearchParams, GraphVectorIndexReader, GraphVertex, NavVectorStore,
         RawVectorStore,
     },
-    quantization::Quantizer,
     Neighbor,
 };
 
@@ -85,7 +83,7 @@ impl GraphSearcher {
         reader: &mut impl GraphVectorIndexReader,
     ) -> Result<Vec<Neighbor>> {
         self.seen.clear();
-        self.search_internal(query, |_| true, reader)
+        self.search_internal_raw(query, |_| true, reader)
     }
 
     /// Search for `query` in the given graph `reader`, with oracle function `filter_predicate` dictating which
@@ -100,7 +98,7 @@ impl GraphSearcher {
         reader: &mut impl GraphVectorIndexReader,
     ) -> Result<Vec<Neighbor>> {
         self.seen.clear();
-        self.search_internal(query, filter_predicate, reader)
+        self.search_internal_raw(query, filter_predicate, reader)
     }
 
     /// Search for the vector at `vertex_id` and return matching candidates.
@@ -114,107 +112,34 @@ impl GraphSearcher {
         // Marking this vertex as seen ensures we don't traverse or score ourselves (should be identity score).
         self.seen.insert(vertex_id);
 
-        // XXX if we are not re-ranking then search _quantized_ without performing this read.
-        // it would put way less pressure on the cache.
-        let query = reader
-            .raw_vectors()?
-            .get_raw_vector(vertex_id)
-            .unwrap_or(Err(Error::not_found_error()))?
-            .to_vec();
-        self.search_internal(&query, |_| true, reader)
+        if self.params.num_rerank > 0 {
+            let query = reader
+                .raw_vectors()?
+                .get_raw_vector(vertex_id)
+                .unwrap_or(Err(Error::not_found_error()))?
+                .to_vec();
+            self.search_internal_raw(&query, |_| true, reader)
+        } else {
+            let nav_query = reader
+                .nav_vectors()?
+                .get_nav_vector(vertex_id)
+                .unwrap_or(Err(Error::not_found_error()))?
+                .to_vec();
+            self.search_internal_quantized(&nav_query, |_| true, reader)?;
+            Ok(self.candidates.iter().map(|c| c.neighbor).collect())
+        }
     }
 
-    fn search_internal(
+    fn search_internal_raw(
         &mut self,
         query: &[f32],
-        mut filter_predicate: impl FnMut(i64) -> bool,
+        filter_predicate: impl FnMut(i64) -> bool,
         reader: &mut impl GraphVectorIndexReader,
     ) -> Result<Vec<Neighbor>> {
-        // TODO: come up with a better way of managing re-used state.
-        self.candidates.clear();
-        self.visited = 0;
-
-        let mut graph = reader.graph()?;
-        let mut nav = reader.nav_vectors()?;
         let quantizer = reader.config().new_quantizer();
-        let nav_distance_fn = reader.config().new_nav_distance_function();
-        let nav_query = self.init_candidates(
-            query,
-            &mut graph,
-            &mut nav,
-            quantizer.as_ref(),
-            nav_distance_fn.as_ref(),
-        )?;
-
-        while let Some(best_candidate) = self.candidates.next_unvisited() {
-            self.visited += 1;
-            let vertex_id = best_candidate.neighbor().vertex();
-            let node = graph
-                .get_vertex(vertex_id)
-                .unwrap_or_else(|| Err(Error::not_found_error()))?;
-            if filter_predicate(vertex_id) {
-                // If we aren't reranking we don't need to copy the actual vector.
-                best_candidate.visit(if self.params.num_rerank > 0 {
-                    node.vector().map(|v| v.to_vec())
-                } else {
-                    None
-                });
-            } else {
-                best_candidate.remove();
-            }
-
-            for edge in node.edges() {
-                if !self.seen.insert(edge) {
-                    continue;
-                }
-                let vec = nav
-                    .get_nav_vector(edge)
-                    .unwrap_or(Err(Error::not_found_error()))?;
-                self.candidates.add_unvisited(Neighbor::new(
-                    edge,
-                    nav_distance_fn.distance(&nav_query, &vec),
-                ));
-            }
-        }
-
-        self.extract_results(query, reader)
-    }
-
-    // Initialize the candidate queue and return the binary quantized query.
-    fn init_candidates<G, N>(
-        &mut self,
-        query: &[f32],
-        graph: &mut G,
-        nav: &mut N,
-        quantizer: &dyn Quantizer,
-        nav_distance_fn: &dyn QuantizedVectorDistance,
-    ) -> Result<Vec<u8>>
-    where
-        G: Graph,
-        N: NavVectorStore,
-    {
         let nav_query = quantizer.for_query(query);
-        if let Some(epr) = graph.entry_point() {
-            let entry_point = epr?;
-            let entry_vector = nav
-                .get_nav_vector(entry_point)
-                .unwrap_or(Err(Error::not_found_error()))?;
-            self.candidates.add_unvisited(Neighbor::new(
-                entry_point,
-                nav_distance_fn.distance(&nav_query, &entry_vector),
-            ));
-            self.seen.insert(entry_point);
-        }
-        // We don't treat failing to obtain an entry point as an error because
-        // the graph may be empty.
-        Ok(nav_query)
-    }
+        self.search_internal_quantized(&nav_query, filter_predicate, reader)?;
 
-    fn extract_results<R: GraphVectorIndexReader>(
-        &mut self,
-        query: &[f32],
-        reader: &R,
-    ) -> Result<Vec<Neighbor>> {
         if self.params.num_rerank == 0 {
             return Ok(self.candidates.iter().map(|c| c.neighbor).collect());
         }
@@ -249,6 +174,63 @@ impl GraphSearcher {
             r.sort();
             r
         })
+    }
+
+    fn search_internal_quantized(
+        &mut self,
+        query: &[u8],
+        mut filter_predicate: impl FnMut(i64) -> bool,
+        reader: &mut impl GraphVectorIndexReader,
+    ) -> Result<()> {
+        // TODO: come up with a better way of managing re-used state.
+        self.candidates.clear();
+        self.visited = 0;
+
+        let mut graph = reader.graph()?;
+        let mut nav = reader.nav_vectors()?;
+        let nav_distance_fn = reader.config().new_nav_distance_function();
+        if let Some(epr) = graph.entry_point() {
+            let entry_point = epr?;
+            let entry_vector = nav
+                .get_nav_vector(entry_point)
+                .unwrap_or(Err(Error::not_found_error()))?;
+            self.candidates.add_unvisited(Neighbor::new(
+                entry_point,
+                nav_distance_fn.distance(query, &entry_vector),
+            ));
+            self.seen.insert(entry_point);
+        }
+
+        while let Some(best_candidate) = self.candidates.next_unvisited() {
+            self.visited += 1;
+            let vertex_id = best_candidate.neighbor().vertex();
+            let node = graph
+                .get_vertex(vertex_id)
+                .unwrap_or_else(|| Err(Error::not_found_error()))?;
+            if filter_predicate(vertex_id) {
+                // If we aren't reranking we don't need to copy the actual vector.
+                best_candidate.visit(if self.params.num_rerank > 0 {
+                    node.vector().map(|v| v.to_vec())
+                } else {
+                    None
+                });
+            } else {
+                best_candidate.remove();
+            }
+
+            for edge in node.edges() {
+                if !self.seen.insert(edge) {
+                    continue;
+                }
+                let vec = nav
+                    .get_nav_vector(edge)
+                    .unwrap_or(Err(Error::not_found_error()))?;
+                self.candidates
+                    .add_unvisited(Neighbor::new(edge, nav_distance_fn.distance(query, &vec)));
+            }
+        }
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Add an edge set distance computation abstraction to switch between raw and nav vectors.

Fix an inversion in bulk load entry point selection.