### PR TITLE
Add a default simsimd feature and naive implementations if it is disabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,10 @@ name = "easy_tiger"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+default = ["simsimd"]
+simsimd = ["dep:simsimd"]
+
 [dependencies]
 crossbeam-skiplist = "0.1.3"
 leb128 = "0.2.5"
@@ -11,7 +15,7 @@ rand = "0.8.5"
 rayon = "1.10.0"
 serde = { version = "1.0.215", features = ["serde_derive"] }
 serde_json = "1.0.132"
-simsimd = "6.4.4"
+simsimd = { version = "6.4.4", optional = true }
 stable_deref_trait = "1.2.0"
 tempfile = "3.14.0"
 thread_local = "1.1.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ rand = "0.8.5"
 rayon = "1.10.0"
 serde = { version = "1.0.215", features = ["serde_derive"] }
 serde_json = "1.0.132"
-simsimd = "6.0.1"
+simsimd = "6.4.4"
 stable_deref_trait = "1.2.0"
 tempfile = "3.14.0"
 thread_local = "1.1.8"

--- a/src/quantization.rs
+++ b/src/quantization.rs
@@ -5,7 +5,6 @@
 use std::{io, str::FromStr};
 
 use serde::{Deserialize, Serialize};
-use simsimd::SpatialSimilarity;
 
 use crate::distance::{
     AsymmetricHammingDistance, HammingDistance, I8NaiveDistance, QuantizedVectorDistance,
@@ -232,7 +231,7 @@ pub struct I8NaiveQuantizer;
 
 impl Quantizer for I8NaiveQuantizer {
     fn for_doc(&self, vector: &[f32]) -> Vec<u8> {
-        let norm = SpatialSimilarity::dot(vector, vector).unwrap().sqrt() as f32;
+        let norm = crate::distance::dot(vector, vector).sqrt() as f32;
         let mut normalized_vector = vector.to_vec();
         for d in normalized_vector.iter_mut() {
             *d /= norm;


### PR DESCRIPTION
This is useful if you are struggling with a cc toolchain.

"simsimd" is a default feature, so default features must be disabled to turn this off. When disabled distance
function implementations are replaced with trivial iterator-based implementations. These are _probably_
pretty fast as it should be possible to auto-vectorize them, but success is not guaranteed.