### PR TITLE
Handle new version of clang released on macos

### DIFF
--- a/pt/src/main.rs
+++ b/pt/src/main.rs
@@ -56,7 +56,7 @@ fn main() -> io::Result<()> {
     let (centroids, assignments) = iterative_balanced_kmeans(
         &input_vectors,
         cli.num_partitions.get(),
-        cli.num_partitions.get().min(32),
+        cli.num_partitions.get().min(64),
         1.5,
         cli.batch_size.get(),
         &kmeans_params,

--- a/pt/src/main.rs
+++ b/pt/src/main.rs
@@ -56,7 +56,7 @@ fn main() -> io::Result<()> {
     let (centroids, assignments) = iterative_balanced_kmeans(
         &input_vectors,
         cli.num_partitions.get(),
-        cli.num_partitions.get().min(64),
+        cli.num_partitions.get().min(32),
         1.5,
         cli.batch_size.get(),
         &kmeans_params,

--- a/wt_sys/build.rs
+++ b/wt_sys/build.rs
@@ -8,9 +8,12 @@ fn build_wt() -> PathBuf {
         .define("ENABLE_STATIC", "1")
         .define("HAVE_DIAGNOSTIC", if have_diagnostic { "1" } else { "0" })
         .define("ENABLE_PYTHON", "0")
-        .cflag("-Wno-array-bounds")
+        .define("HAVE_UNITTEST", "0")
+        // We have quasi-vendored WT and won't change upstream source to handle errors from new compiler versions.
+        .cflag("-Wno-everything")
         // CMake crate is not doing this correctly for whatever reason.
         .build_arg(format!("-j{}", jobs))
+        .build_target("wiredtiger_static")
         .build();
     PathBuf::from_iter([build_path, PathBuf::from("build")])
 }


### PR DESCRIPTION
By ignoring new errors that were added.

Try to filter down the build a little in hopes of making it faster.