### PR TITLE
Use tracing for logging instead of raw println

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,11 @@ serde = { version = "1.0.215", features = ["serde_derive"] }
 serde_json = "1.0.132"
 simsimd = "6.0.1"
 stable_deref_trait = "1.2.0"
-tempfile = "3.14.0"
 thread_local = "1.1.8"
-threadpool = "1.8.1"
 wt_mdb = { path = "./wt_mdb" }
+
+[dev-dependencies]
+tempfile = "3.20.0"
 
 [workspace]
 members = ["et", "pt", "wt_mdb", "wt_sys"]

--- a/et/Cargo.toml
+++ b/et/Cargo.toml
@@ -10,5 +10,6 @@ indicatif = "0.17.8"
 memmap2 = { version = "0.9.5", features = ["stable_deref_trait"] }
 rayon = "1.10.0"
 stable_deref_trait = "1.2.0"
+tracing-subscriber = "0.3.19"
 wt_mdb = { path = "../wt_mdb" }
 wt_sys = { path = "../wt_sys" }

--- a/et/src/main.rs
+++ b/et/src/main.rs
@@ -70,6 +70,8 @@ enum Commands {
 }
 
 fn main() -> io::Result<()> {
+    tracing_subscriber::fmt::init();
+
     let cli = Cli::parse();
     // TODO: Connection.filename should accept &Path. This will likely be very annoying to plumb to CString.
     let mut connection_options = ConnectionOptionsBuilder::default()

--- a/wt_mdb/Cargo.toml
+++ b/wt_mdb/Cargo.toml
@@ -6,6 +6,7 @@ description = "WiredTiger bindings intended to be used MongoDB way."
 
 [dependencies]
 rustix = "0.38.41"
+tracing = "0.1.41"
 wt_sys = { path = "../wt_sys" }
 
 [dev-dependencies]

--- a/wt_mdb/src/connection.rs
+++ b/wt_mdb/src/connection.rs
@@ -10,6 +10,7 @@ use std::{
     sync::Arc,
 };
 
+use tracing::error;
 use wt_sys::{wiredtiger_open, WT_CONNECTION, WT_SESSION};
 
 /// A connection to a WiredTiger database.
@@ -63,8 +64,8 @@ unsafe impl Sync for Connection {}
 
 impl Drop for Connection {
     fn drop(&mut self) {
-        // TODO: log something when an error occurs here.
-        // This would be unexpected as the connection can't be dropped until all cursors and sessions have also been dropped.
-        let _ = unsafe { wt_call!(self.0, close, std::ptr::null()) };
+        if let Err(e) = unsafe { wt_call!(self.0, close, std::ptr::null()) } {
+            error!("Failed to close WT_CONNECTION: {}", e);
+        }
     }
 }

--- a/wt_mdb/src/session/mod.rs
+++ b/wt_mdb/src/session/mod.rs
@@ -11,6 +11,7 @@ use std::{
 };
 
 use rustix::io::Errno;
+use tracing::error;
 use wt_sys::{WT_CURSOR, WT_ITEM, WT_SESSION};
 
 use crate::{
@@ -114,8 +115,9 @@ impl InnerCursor {
 
 impl Drop for InnerCursor {
     fn drop(&mut self) {
-        // TODO: log this.
-        let _ = unsafe { wt_call!(self.ptr, close) };
+        if let Err(e) = unsafe { wt_call!(self.ptr, close) } {
+            error!("Failed to close WT_CURSOR: {}", e);
+        }
     }
 }
 
@@ -362,8 +364,9 @@ impl Drop for Session {
     fn drop(&mut self) {
         // Empty the cursor cache otherwise closing the session may fail.
         self.clear_cursor_cache();
-        // TODO: print something if this returns an error.
-        let _ = unsafe { wt_call!(self.ptr, close, std::ptr::null()) };
+        if let Err(e) = unsafe { wt_call!(self.ptr, close, std::ptr::null()) } {
+            error!("Failed to close WT_SESSION: {}", e);
+        }
     }
 }
 

--- a/wt_mdb/src/session/stat_cursor.rs
+++ b/wt_mdb/src/session/stat_cursor.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use crate::{map_not_found, wt_call, Error, Result};
+use tracing::error;
 use wt_sys::WT_CURSOR;
 
 use super::Session;
@@ -62,6 +63,8 @@ impl Iterator for StatCursor<'_> {
 impl Drop for StatCursor<'_> {
     fn drop(&mut self) {
         // TODO: print something if this returns an error.
-        let _ = unsafe { wt_call!(self.ptr, close) };
+        if let Err(e) = unsafe { wt_call!(self.ptr, close) } {
+            error!("Failed to close statistics WT_CURSOR: {}", e);
+        }
     }
 }


### PR DESCRIPTION
Use the tracing crate and format output to stdout/stderr for the `et` tool.