### PR TITLE
Implement a trivial quantizer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ default = ["simsimd"]
 simsimd = ["dep:simsimd"]
 
 [dependencies]
+bytemuck = "1.23.0"
 crossbeam-skiplist = "0.1.3"
 leb128 = "0.2.5"
 memmap2 = { version = "0.9.5", features = ["stable_deref_trait"] }

--- a/src/distance.rs
+++ b/src/distance.rs
@@ -113,7 +113,7 @@ fn byte_slice_to_float_vec(slice: &[u8]) -> Vec<f32> {
 
 // We may be able to cast the slice if the alignment is correct.
 #[cfg(target_endian = "little")]
-fn byte_slice_to_float_slice<'a>(slice: &'a [u8]) -> Cow<'a, [f32]> {
+fn byte_slice_to_float_slice(slice: &[u8]) -> Cow<'_, [f32]> {
     assert_eq!(slice.len() % std::mem::size_of::<f32>(), 0);
     bytemuck::try_cast_slice(slice)
         .map(Cow::from)

--- a/src/distance.rs
+++ b/src/distance.rs
@@ -104,6 +104,42 @@ impl F32VectorDistance for DotProductDistance {
     }
 }
 
+fn byte_slice_to_float_vec(slice: &[u8]) -> Vec<f32> {
+    slice
+        .chunks(4)
+        .map(|d| f32::from_le_bytes(d.try_into().expect("slice len divide by 4")))
+        .collect()
+}
+
+// We may be able to cast the slice if the alignment is correct.
+#[cfg(target_endian = "little")]
+fn byte_slice_to_float_slice<'a>(slice: &'a [u8]) -> Cow<'a, [f32]> {
+    assert_eq!(slice.len() % std::mem::size_of::<f32>(), 0);
+    bytemuck::try_cast_slice(slice)
+        .map(Cow::from)
+        .unwrap_or_else(|_| Cow::from(byte_slice_to_float_vec(slice)))
+}
+
+#[cfg(not(target_endian = "little"))]
+fn byte_slice_to_float_slice<'a>(slice: &'a [u8]) -> Cow<'a, [f32]> {
+    assert_eq!(slice.len() % std::mem::size_of::<f32>(), 0);
+    byte_slice_to_float_vec(slice).into()
+}
+
+/// Computes a score from two bitmaps using hamming distance.
+pub struct TrivialQuantizedDistance(pub(crate) VectorSimilarity);
+
+impl QuantizedVectorDistance for TrivialQuantizedDistance {
+    fn distance(&self, query: &[u8], doc: &[u8]) -> f64 {
+        let query = byte_slice_to_float_slice(query);
+        let doc = byte_slice_to_float_slice(doc);
+        match self.0 {
+            VectorSimilarity::Euclidean => EuclideanDistance.distance(&query, &doc),
+            VectorSimilarity::Dot => DotProductDistance.distance(&query, &doc),
+        }
+    }
+}
+
 /// Computes a score from two bitmaps using hamming distance.
 #[derive(Debug, Copy, Clone)]
 pub struct HammingDistance;


### PR DESCRIPTION
This encodes a float vector as a byte array, where each f32 is little endian ordered.

This is useful for testing placement of full fidelity vectors in places where we would otherwise use quantized vectors.
It is not a solution to the general problem of having two vector sets but sometimes wanting to have just one.