### PR TITLE
SPANN build improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ bytemuck = "1.23.0"
 crossbeam-skiplist = "0.1.3"
 leb128 = "0.2.5"
 memmap2 = { version = "0.9.5", features = ["stable_deref_trait"] }
-rand = "0.8.5"
+rand = "0.9.1"
 rayon = "1.10.0"
 serde = { version = "1.0.215", features = ["serde_derive"] }
 serde_json = "1.0.132"

--- a/et/Cargo.toml
+++ b/et/Cargo.toml
@@ -8,7 +8,8 @@ clap = { version = "4.5.20", features = ["derive"] }
 easy_tiger = { path = "../" }
 indicatif = "0.17.8"
 memmap2 = { version = "0.9.5", features = ["stable_deref_trait"] }
-rand = "0.8.5"
+rand = "0.9.1"
+rand_xoshiro = "0.7.0"
 rayon = "1.10.0"
 stable_deref_trait = "1.2.0"
 thread_local = "1.1.8"

--- a/et/Cargo.toml
+++ b/et/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.5.20", features = ["derive"] }
 easy_tiger = { path = "../" }
+histogram = "0.11.3"
 indicatif = "0.17.8"
 memmap2 = { version = "0.9.5", features = ["stable_deref_trait"] }
 rand = "0.9.1"

--- a/et/src/spann/bulk_load.rs
+++ b/et/src/spann/bulk_load.rs
@@ -10,6 +10,7 @@ use easy_tiger::{
     quantization::VectorQuantizer,
     spann::{IndexConfig, SessionIndexWriter, TableIndex},
 };
+use histogram::Histogram;
 use rand_xoshiro::{rand_core::SeedableRng, Xoshiro128PlusPlus};
 use rayon::prelude::*;
 use thread_local::ThreadLocal;
@@ -212,19 +213,17 @@ pub fn bulk_load(
 
     // TODO: consider writing a dedicated bulk loader. The bulk loader should at least do the raw
     // vectors to avoid writing to the checkpoint.
-    let inserted = {
+    let (inserted, assignment_stats) = {
         let tl_writer: ThreadLocal<RefCell<SessionIndexWriter>> = ThreadLocal::new();
         let progress = progress_bar(limit, "postings index");
-        (0..index_vectors.len())
+        let assignment_stats = (0..limit)
             .into_par_iter()
             .map(|i| {
                 let mut writer = tl_writer
                     .get_or_try(|| {
-                        let session = connection.open_session()?;
-                        Ok::<_, wt_mdb::Error>(RefCell::new(SessionIndexWriter::new(
-                            index.clone(),
-                            session,
-                        )))
+                        connection
+                            .open_session()
+                            .map(|s| RefCell::new(SessionIndexWriter::new(index.clone(), s)))
                     })?
                     .borrow_mut();
                 writer.session().begin_transaction(None)?;
@@ -233,7 +232,16 @@ pub fn bulk_load(
                 progress.inc(1);
                 Ok::<_, wt_mdb::Error>(inserted)
             })
-            .try_reduce(|| 0usize, |a, b| Ok(a + b))?
+            .try_fold(
+                || CentroidAssignmentStats::new(centroids_len),
+                |stats, r| r.map(|c| stats.fold(&c)),
+            )
+            .try_reduce(
+                || CentroidAssignmentStats::new(centroids_len),
+                CentroidAssignmentStats::reduce,
+            )?;
+        let inserted = assignment_stats.total_assigned();
+        (inserted, assignment_stats)
     };
 
     println!(
@@ -242,10 +250,94 @@ pub fn bulk_load(
         (centroids_len as f64 / index_vectors.len() as f64) * 100.0
     );
     println!(
-        "Inserted {} posting entries (avg {:4.2})",
+        "Inserted {} tail posting entries (avg {:4.2})",
         inserted,
         inserted as f64 / limit as f64
     );
+    println!("Primary assignments per centroid:");
+    CentroidAssignmentStats::print_histogram(assignment_stats.primary_assignment_histogram())?;
+    println!("Secondary assignments per centroid:");
+    CentroidAssignmentStats::print_histogram(assignment_stats.secondary_assignment_histogram())?;
+    println!("Total assignments per centroid:");
+    CentroidAssignmentStats::print_histogram(assignment_stats.total_assignment_histogram())?;
 
     Ok(())
+}
+
+struct CentroidAssignmentStats {
+    primary: Vec<usize>,
+    secondary: Vec<usize>,
+}
+
+impl CentroidAssignmentStats {
+    pub fn new(centroids_len: usize) -> Self {
+        Self {
+            primary: vec![0; centroids_len],
+            secondary: vec![0; centroids_len],
+        }
+    }
+
+    pub fn fold(mut self, centroids: &[u32]) -> Self {
+        if let Some((primary, secondaries)) = centroids.split_first() {
+            self.primary[*primary as usize] += 1;
+            for s in secondaries {
+                self.secondary[*s as usize] += 1;
+            }
+        }
+        self
+    }
+
+    pub fn reduce(mut a: Self, b: Self) -> wt_mdb::Result<Self> {
+        for (a, b) in a.primary.iter_mut().zip(b.primary.iter()) {
+            *a += *b;
+        }
+        for (a, b) in a.secondary.iter_mut().zip(b.secondary.iter()) {
+            *a += *b;
+        }
+        Ok(a)
+    }
+
+    pub fn total_assigned(&self) -> usize {
+        self.primary.iter().copied().sum::<usize>() + self.secondary.iter().copied().sum::<usize>()
+    }
+
+    pub fn primary_assignment_histogram(&self) -> Histogram {
+        Self::make_histogram(self.primary.iter().copied())
+    }
+
+    pub fn secondary_assignment_histogram(&self) -> Histogram {
+        Self::make_histogram(self.secondary.iter().copied())
+    }
+
+    pub fn total_assignment_histogram(&self) -> Histogram {
+        Self::make_histogram(
+            self.primary
+                .iter()
+                .zip(self.secondary.iter())
+                .map(|(p, s)| *p + *s),
+        )
+    }
+
+    pub fn print_histogram(histogram: Histogram) -> io::Result<()> {
+        use std::io::Write;
+        let mut lock = std::io::stdout().lock();
+        for b in histogram.into_iter().filter(|b| b.count() > 0) {
+            writeln!(lock, "[{:5}..{:5}] {:7}", b.start(), b.end(), b.count())?;
+        }
+        Ok(())
+    }
+
+    fn make_histogram(centroid_sizes: impl Iterator<Item = usize> + Clone) -> Histogram {
+        let max_value_power = centroid_sizes
+            .clone()
+            .max()
+            .unwrap()
+            .next_power_of_two()
+            .ilog2() as u8;
+        let mut histogram = Histogram::new(2, max_value_power.max(2)).unwrap();
+        for c in centroid_sizes {
+            histogram.add(c as u64, 1).unwrap();
+        }
+        histogram
+    }
 }

--- a/pt/Cargo.toml
+++ b/pt/Cargo.toml
@@ -9,7 +9,7 @@ easy_tiger = { path = "../" }
 histogram = "0.11.3"
 indicatif = "0.17.11"
 memmap2 = { version = "0.9.5", features = ["stable_deref_trait"] }
-rand = "0.8.5"
+rand = "0.9.1"
 rayon = "1.10.0"
 simsimd = "6.4.2"
 stable_deref_trait = "1.2.0"

--- a/pt/src/main.rs
+++ b/pt/src/main.rs
@@ -8,7 +8,6 @@ use easy_tiger::input::{DerefVectorStore, VectorStore};
 use easy_tiger::kmeans::{Params, iterative_balanced_kmeans};
 use histogram::Histogram;
 use memmap2::Mmap;
-use rand::thread_rng;
 
 #[derive(Parser)]
 #[command(version, about = "Tool for instrumenting vector partitioning techniques", long_about = None)]
@@ -66,7 +65,7 @@ fn main() -> io::Result<()> {
         32,
         cli.batch_size.get(),
         &kmeans_params,
-        &mut thread_rng(),
+        &mut rand::rng(),
         |_| {},
     );
 

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -22,7 +22,6 @@ use std::{
 
 use crossbeam_skiplist::SkipSet;
 use memmap2::{Mmap, MmapMut};
-use rand::thread_rng;
 use rayon::prelude::*;
 use thread_local::ThreadLocal;
 use wt_mdb::{options::DropOptionsBuilder, Connection, Record, Result, Session};
@@ -272,6 +271,7 @@ where
     }
 
     fn cluster_vectors<P: Fn(u64) + Send + Sync>(&mut self, progress: P) -> Result<()> {
+        // TODO: this should accept a random number generator
         let subset = SubsetViewVectorStore::new(&self.vectors, (0..self.limit).collect());
         self.clustered_order = Some(graph_clustering::cluster_for_reordering(
             &subset,
@@ -282,7 +282,7 @@ where
                 epsilon: 0.01,
                 ..Default::default()
             },
-            &mut thread_rng(),
+            &mut rand::rng(),
             progress,
         ));
         Ok(())

--- a/src/kmeans.rs
+++ b/src/kmeans.rs
@@ -4,7 +4,7 @@ use std::iter::Cycle;
 use std::ops::RangeInclusive;
 
 use rand::seq::index;
-use rand::{distributions::WeightedIndex, prelude::*};
+use rand::{distr::weighted::WeightedIndex, prelude::*};
 use rayon::prelude::*;
 use tracing::debug;
 
@@ -464,7 +464,7 @@ fn initialize_centroids<
             compute_assignments(training_data, &centroids)
         }
         InitializationMethod::KMeansPlusPlus => {
-            centroids.push(&dataset[rng.gen_range(0..dataset.len())]);
+            centroids.push(&dataset[rng.random_range(0..dataset.len())]);
             let mut assignments = compute_assignments(training_data, &centroids);
             while centroids.len() < k {
                 let index = WeightedIndex::new(assignments.iter().map(|a| a.1))


### PR DESCRIPTION
The biggest change here is allowing clustered means to be replaced with the closest mediod, which greatly improves
recall at lower parameter settings. With means we would often get 0 secondary assignments for most vectors, but this
functions more naturally with mediods and we end up with an avg of R - 0.5 assignments for each vector. Based on
stats the new assignments also seem to be better balanced.

I can get ~93% recall with just 32 centroids in the search at about 5ms latency with 4 replicas.

This differs from the SPANN paper in that we performing mediod replacement at the end instead of incrementally at
each step.

Smaller changes:
* Upgrade rand and use a more specific, seeded RNG for clustering.
* Print assignment stats for primary, secondary, and total assignments.