### PR TITLE
Add support for table metadata, metadata cursors and config parsing

### DIFF
--- a/wt_mdb/src/config.rs
+++ b/wt_mdb/src/config.rs
@@ -121,7 +121,7 @@ impl<'a> ConfigItem<'a> {
         // NB: we assume that because the source string is utf8 that a substring gnereated from it
         // will also be utf8.
         unsafe {
-            str::from_utf8(std::slice::from_raw_parts::<'a, _>(
+            std::str::from_utf8(std::slice::from_raw_parts::<'a, _>(
                 item.str_ as *const u8,
                 item.len,
             ))

--- a/wt_mdb/src/config.rs
+++ b/wt_mdb/src/config.rs
@@ -46,10 +46,8 @@ impl<'a> ConfigParser<'a> {
     }
 
     pub fn get(&mut self, key: &str) -> Option<Result<ConfigItem<'a>>> {
-        // NB: the expected key is a null-terminated cstring.
-        let mut key_bytes = key.to_string().into_bytes();
-        key_bytes.push(0);
-        let key = CString::from_vec_with_nul(key_bytes).expect("key doesn't contain nulls");
+        // NB: WT expects a null terminated string.
+        let key = CString::new(key.to_string()).expect("key doesn't contain nulls");
         let mut item = ConfigItem::default_wt_item();
         map_not_found(
             unsafe { wt_call!(self.ptr, get, key.as_ptr(), &mut item) }

--- a/wt_mdb/src/config.rs
+++ b/wt_mdb/src/config.rs
@@ -1,0 +1,143 @@
+//! WiredTiger config parsing APIs.
+//!
+//! These are useful when writing WiredTiger extensions or reading db metadata.
+
+use std::{ffi::CString, os::raw::c_char, ptr::NonNull};
+
+use tracing::error;
+use wt_sys::{WT_CONFIG_ITEM, WT_CONFIG_PARSER};
+
+use crate::{make_result, map_not_found, wt_call, Error, Result};
+
+/// A parser for WiredTiger config strings.
+///
+/// This struct allows both linear and random access over the config.
+/// If random access is used, iteration behavior is not well defined.
+pub struct ConfigParser<'a> {
+    ptr: NonNull<wt_sys::WT_CONFIG_PARSER>,
+    config: &'a str,
+}
+
+impl<'a> ConfigParser<'a> {
+    /// Create a new config parser.
+    ///
+    /// Errors that occur will be logged to stderr.
+    pub fn new(config: &'a str) -> Result<Self> {
+        let mut handle: *mut WT_CONFIG_PARSER = std::ptr::null_mut();
+        make_result(
+            unsafe {
+                wt_sys::wiredtiger_config_parser_open(
+                    std::ptr::null_mut(),
+                    config.as_bytes().as_ptr() as *const c_char,
+                    config.len(),
+                    &mut handle,
+                )
+            },
+            (),
+        )?;
+        NonNull::new(handle)
+            .ok_or(Error::generic_error())
+            .map(|ptr| Self { ptr, config })
+    }
+
+    /// Return the config string being parsed.
+    pub fn config_str(&self) -> &'a str {
+        self.config
+    }
+
+    pub fn get(&self, key: &str) -> Option<Result<ConfigItem<'a>>> {
+        // NB: the expected key is a null-terminated cstring.
+        let mut key_bytes = key.to_string().into_bytes();
+        key_bytes.push(0);
+        let key = CString::from_vec_with_nul(key_bytes).expect("key doesn't contain nulls");
+        let mut item = ConfigItem::default_wt_item();
+        map_not_found(
+            unsafe { wt_call!(self.ptr, get, key.as_ptr(), &mut item) }
+                .and_then(|()| ConfigItem::from_config_item(&item).ok_or(Error::generic_error())),
+        )
+    }
+}
+
+impl<'a> Iterator for ConfigParser<'a> {
+    type Item = Result<(&'a str, ConfigItem<'a>)>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut key = ConfigItem::default_wt_item();
+        let mut value = ConfigItem::default_wt_item();
+        map_not_found(
+            unsafe { wt_call!(self.ptr, next, &mut key, &mut value) }
+                .and_then(|()| ConfigItem::from_config_item(&value).ok_or(Error::generic_error()))
+                .map(|v| (ConfigItem::get_str(&key), v)),
+        )
+    }
+}
+
+impl Drop for ConfigParser<'_> {
+    fn drop(&mut self) {
+        if let Err(e) = unsafe { wt_call!(self.ptr, close) } {
+            error!("Failed to close config parser: {}", e);
+        }
+    }
+}
+
+unsafe impl Send for ConfigParser<'_> {}
+
+/// Types of entries that can appear in config.
+#[derive(Debug, Copy, Clone)]
+pub enum ConfigItem<'a> {
+    /// A string
+    String(&'a str),
+    /// A boolean literal ("true" or "false")
+    Bool(bool),
+    /// Something that is like a string but not exactly a string.
+    Id(&'a str),
+    /// An integer, but not a floating point number.
+    Num(i64),
+    /// A nested structure. Use another [ConfigParser] to parse it.
+    Struct(&'a str),
+}
+
+impl<'a> ConfigItem<'a> {
+    fn default_wt_item() -> WT_CONFIG_ITEM {
+        WT_CONFIG_ITEM {
+            str_: std::ptr::null(),
+            len: 0,
+            val: 0,
+            type_: wt_sys::__wt_config_item_WT_CONFIG_ITEM_TYPE_WT_CONFIG_ITEM_STRING,
+        }
+    }
+
+    fn get_str(item: &WT_CONFIG_ITEM) -> &'a str {
+        // NB: we assume that because the source string is utf8 that a substring gnereated from it
+        // will also be utf8.
+        unsafe {
+            str::from_utf8(std::slice::from_raw_parts::<'a, _>(
+                item.str_ as *const u8,
+                item.len,
+            ))
+            .expect("source string is also utf8")
+        }
+    }
+
+    #[allow(non_upper_case_globals, non_snake_case)]
+    fn from_config_item(item: &WT_CONFIG_ITEM) -> Option<Self> {
+        match item.type_ {
+            wt_sys::__wt_config_item_WT_CONFIG_ITEM_TYPE_WT_CONFIG_ITEM_STRING => {
+                Some(Self::String(Self::get_str(item)))
+            }
+            wt_sys::__wt_config_item_WT_CONFIG_ITEM_TYPE_WT_CONFIG_ITEM_BOOL => {
+                Some(Self::Bool(item.val != 0))
+            }
+            wt_sys::__wt_config_item_WT_CONFIG_ITEM_TYPE_WT_CONFIG_ITEM_ID => {
+                Some(Self::Id(Self::get_str(item)))
+            }
+            wt_sys::__wt_config_item_WT_CONFIG_ITEM_TYPE_WT_CONFIG_ITEM_NUM => {
+                Some(Self::Num(item.val))
+            }
+            wt_sys::__wt_config_item_WT_CONFIG_ITEM_TYPE_WT_CONFIG_ITEM_STRUCT => {
+                Some(Self::Struct(Self::get_str(item)))
+            }
+            _ => unreachable!(),
+        }
+    }
+}

--- a/wt_mdb/src/config.rs
+++ b/wt_mdb/src/config.rs
@@ -98,6 +98,16 @@ pub enum ConfigItem<'a> {
 }
 
 impl<'a> ConfigItem<'a> {
+    /// If this is a [ConfigItem::String](`String`) or [ConfigItem::Id](`Id`) then return the inner
+    /// string value.
+    pub fn str_or_id(&self) -> Option<&'a str> {
+        match self {
+            Self::String(s) => Some(s),
+            Self::Id(s) => Some(s),
+            _ => None,
+        }
+    }
+
     fn default_wt_item() -> WT_CONFIG_ITEM {
         WT_CONFIG_ITEM {
             str_: std::ptr::null(),
@@ -205,5 +215,20 @@ mod test {
                 Ok(("doc", ConfigItem::Struct("{ \"json\": true }"))),
             ]
         );
+    }
+
+    #[test]
+    fn parse_json() {
+        let mut parser = ConfigParser::new("{ \"json\": true }").unwrap();
+        assert_eq!(parser.get("json"), Some(Ok(ConfigItem::Bool(true))));
+    }
+
+    #[test]
+    fn item_str_or_id() {
+        assert_eq!(ConfigItem::String("s").str_or_id(), Some("s"));
+        assert_eq!(ConfigItem::Id("s").str_or_id(), Some("s"));
+        assert_eq!(ConfigItem::Struct("s").str_or_id(), None);
+        assert_eq!(ConfigItem::Num(1).str_or_id(), None);
+        assert_eq!(ConfigItem::Bool(true).str_or_id(), None);
     }
 }

--- a/wt_mdb/src/config.rs
+++ b/wt_mdb/src/config.rs
@@ -116,7 +116,7 @@ impl<'a> ConfigItem<'a> {
     }
 
     fn get_str(item: &WT_CONFIG_ITEM) -> &'a str {
-        // NB: we assume that because the source string is utf8 that a substring gnereated from it
+        // NB: we assume that because the source string is utf8 that a substring generated from it
         // will also be utf8.
         unsafe {
             std::str::from_utf8(std::slice::from_raw_parts::<'a, _>(

--- a/wt_mdb/src/lib.rs
+++ b/wt_mdb/src/lib.rs
@@ -6,6 +6,7 @@
 //!
 //! Unlike the general-purpose WiredTiger library, this library only allows tables
 //! that are keyed by `i64` with byte array payloads.
+pub mod config;
 mod connection;
 pub mod options;
 mod session;

--- a/wt_mdb/src/lib.rs
+++ b/wt_mdb/src/lib.rs
@@ -476,6 +476,28 @@ mod test {
     }
 
     #[test]
+    fn metadata_cursors() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let conn = Connection::open(tmpdir.path().to_str().unwrap(), conn_options()).unwrap();
+        let session = conn.open_session().unwrap();
+        session.create_table("test", None).unwrap();
+        let cursor = session.open_metadata_cursor().unwrap();
+        assert_eq!(
+            cursor
+                .map(|e| e.map(|(k, _)| k))
+                .collect::<Result<Vec<_>, crate::Error>>()
+                .unwrap(),
+            vec![
+                "metadata:",
+                "colgroup:test",
+                "file:WiredTigerHS.wt",
+                "file:test.wt",
+                "table:test"
+            ],
+        );
+    }
+
+    #[test]
     fn io_error() {
         let err = Error::WiredTiger(WiredTigerError::NotFound);
         assert_eq!(

--- a/wt_mdb/src/options.rs
+++ b/wt_mdb/src/options.rs
@@ -221,9 +221,7 @@ impl From<CreateOptionsBuilder> for CreateOptions {
         if let Some(metadata) = value.app_metadata {
             parts.push(metadata);
         }
-        let mut s = parts.join(",").into_bytes();
-        s.push(0);
-        Self(CString::from_vec_with_nul(s).expect("no nulls"))
+        Self(CString::new(parts.join(",")).expect("no nulls"))
     }
 }
 

--- a/wt_mdb/src/session/metadata_cursor.rs
+++ b/wt_mdb/src/session/metadata_cursor.rs
@@ -1,0 +1,145 @@
+use std::{
+    ffi::{c_char, CStr, CString},
+    mem::ManuallyDrop,
+    ops::{Bound, Deref, DerefMut, RangeBounds},
+};
+
+use rustix::io::Errno;
+
+use crate::{map_not_found, wt_call, Error, Result};
+
+use super::{InnerCursor, Session};
+
+/// An `MetadataCursor` allows reading metadata associated with objects in the database.
+pub struct MetadataCursor<'a> {
+    inner: InnerCursor,
+    session: &'a Session,
+}
+
+impl<'a> MetadataCursor<'a> {
+    pub(super) fn new(inner: InnerCursor, session: &'a Session) -> Self {
+        Self { inner, session }
+    }
+
+    pub fn session(&self) -> &Session {
+        self.session
+    }
+
+    /// Seek to the for `key` and returns the associated value if present.
+    pub fn seek_exact(&mut self, key: &str) -> Option<Result<String>> {
+        let key = match Self::str_to_cstring(key) {
+            Ok(k) => k,
+            Err(e) => return Some(Err(e)),
+        };
+        map_not_found(
+            unsafe {
+                wt_call!(void self.inner.ptr, set_key, key.as_ptr())
+                    .and_then(|()| wt_call!(self.inner.ptr, search))
+            }
+            .and_then(|()| self.get_value()),
+        )
+    }
+
+    /// Set the bounds this cursor. This affects almost all positioning operations, so for instance
+    /// a `seek_exact()` with a key out of bounds might yield `None`.
+    ///
+    /// Cursor bounds are removed by `reset()`.
+    pub fn set_bounds<'b>(&mut self, bounds: impl RangeBounds<&'b str>) -> Result<()> {
+        let (start_key, start_config_str) = match bounds.start_bound() {
+            Bound::Included(key) => (Some(*key), c"bound=lower,action=set"),
+            Bound::Excluded(key) => (Some(*key), c"bound=lower,action=set,inclusive=false"),
+            Bound::Unbounded => (None, c"bound=lower,action=clear"),
+        };
+        if let Some(k) = start_key {
+            let k = Self::str_to_cstring(k)?;
+            unsafe { wt_call!(void self.inner.ptr, set_key, k.as_ptr()) }?;
+        }
+        unsafe { wt_call!(self.inner.ptr, bound, start_config_str.as_ptr())? };
+        let (end_key, end_config_str) = match bounds.end_bound() {
+            Bound::Included(key) => (Some(*key), c"bound=upper,action=set"),
+            Bound::Excluded(key) => (Some(*key), c"bound=upper,action=set,inclusive=false"),
+            Bound::Unbounded => (None, c"bound=upper,action=clear"),
+        };
+        if let Some(k) = end_key {
+            let k = Self::str_to_cstring(k)?;
+            unsafe { wt_call!(void self.inner.ptr, set_key, k.as_ptr()) }?;
+        }
+        unsafe { wt_call!(self.inner.ptr, bound, end_config_str.as_ptr()) }
+    }
+
+    /// Reset the cursor to an unpositioned state.
+    pub fn reset(&mut self) -> Result<()> {
+        unsafe { wt_call!(self.inner.ptr, reset) }
+    }
+
+    fn get_key(&self) -> Result<String> {
+        let mut key: *const c_char = std::ptr::null();
+        unsafe { wt_call!(self.inner.ptr, get_key, &mut key) }?;
+        unsafe { Self::cstr_ptr_to_string(key) }
+    }
+
+    fn get_value(&self) -> Result<String> {
+        let mut value: *const c_char = std::ptr::null();
+        unsafe { wt_call!(self.inner.ptr, get_value, &mut value) }?;
+        unsafe { Self::cstr_ptr_to_string(value) }
+    }
+
+    // NB: c_char varies depending on the platform; it may be u8 or i8.
+    #[allow(clippy::unnecessary_cast)]
+    unsafe fn cstr_ptr_to_string(ptr: *const c_char) -> Result<String> {
+        CString::from(unsafe { CStr::from_ptr(ptr as *const i8) })
+            .into_string()
+            .map_err(|_| Error::Errno(Errno::INVAL))
+    }
+
+    fn str_to_cstring(s: &str) -> Result<CString> {
+        let mut sbytes: Vec<u8> = s.to_owned().into();
+        sbytes.push(0);
+        CString::from_vec_with_nul(sbytes).map_err(|_| Error::Errno(Errno::INVAL))
+    }
+}
+
+impl Iterator for MetadataCursor<'_> {
+    type Item = Result<(String, String)>;
+
+    /// Advance and return the next record.
+    ///
+    /// If this cursor is unpositioned, returns to the start of the collection.
+    fn next(&mut self) -> Option<Self::Item> {
+        map_not_found(
+            unsafe { wt_call!(self.inner.ptr, next) }
+                .and_then(|()| self.get_key())
+                .and_then(|k| self.get_value().map(|v| (k, v))),
+        )
+    }
+}
+
+/// Holds the cursor and returns it to the session when out of scope.
+pub struct MetadataCursorGuard<'a>(ManuallyDrop<MetadataCursor<'a>>);
+
+impl<'a> MetadataCursorGuard<'a> {
+    pub(super) fn new(cursor: MetadataCursor<'a>) -> Self {
+        Self(ManuallyDrop::new(cursor))
+    }
+}
+
+impl<'a> Deref for MetadataCursorGuard<'a> {
+    type Target = MetadataCursor<'a>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for MetadataCursorGuard<'_> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl Drop for MetadataCursorGuard<'_> {
+    fn drop(&mut self) {
+        let cursor = unsafe { ManuallyDrop::take(&mut self.0) };
+        cursor.session.return_cursor(cursor.inner);
+    }
+}

--- a/wt_mdb/src/session/metadata_cursor.rs
+++ b/wt_mdb/src/session/metadata_cursor.rs
@@ -93,9 +93,7 @@ impl<'a> MetadataCursor<'a> {
     }
 
     fn str_to_cstring(s: &str) -> Result<CString> {
-        let mut sbytes: Vec<u8> = s.to_owned().into();
-        sbytes.push(0);
-        CString::from_vec_with_nul(sbytes).map_err(|_| Error::Errno(Errno::INVAL))
+        CString::new(s.to_owned()).map_err(|_| Error::Errno(Errno::INVAL))
     }
 }
 

--- a/wt_mdb/src/session/mod.rs
+++ b/wt_mdb/src/session/mod.rs
@@ -29,7 +29,7 @@ pub use index_cursor::{IndexCursor, IndexCursorGuard, IndexRecord, IndexRecordVi
 pub use record_cursor::{Record, RecordCursor, RecordCursorGuard, RecordView};
 pub use stat_cursor::StatCursor;
 
-const METADATA_URI: &'static CStr = c"metadata:";
+const METADATA_URI: &CStr = c"metadata:";
 
 /// URI of a WT table encoded as a CString.
 #[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord)]

--- a/wt_mdb/src/session/mod.rs
+++ b/wt_mdb/src/session/mod.rs
@@ -29,6 +29,8 @@ pub use index_cursor::{IndexCursor, IndexCursorGuard, IndexRecord, IndexRecordVi
 pub use record_cursor::{Record, RecordCursor, RecordCursorGuard, RecordView};
 pub use stat_cursor::StatCursor;
 
+const METADATA_URI: &'static CStr = c"metadata:";
+
 /// URI of a WT table encoded as a CString.
 #[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
 struct TableUri(CString);
@@ -225,11 +227,11 @@ impl Session {
 
     /// Open a cursor over database metadata.
     pub fn open_metadata_cursor(&self) -> Result<MetadataCursor> {
-        self.new_cursor_pointer(c"metadata:", None).map(|ptr| {
+        self.new_cursor_pointer(METADATA_URI, None).map(|ptr| {
             MetadataCursor::new(
                 InnerCursor {
                     ptr,
-                    uri: TableUri(c"metadata:".to_owned()),
+                    uri: TableUri(METADATA_URI.to_owned()),
                 },
                 self,
             )
@@ -268,7 +270,7 @@ impl Session {
         let mut cursor_cache = self.cached_cursors.borrow_mut();
         cursor_cache
             .iter()
-            .position(|c| c.uri.table_name() == c"metadata:")
+            .position(|c| c.uri.table_name() == METADATA_URI)
             .map(|i| Ok(MetadataCursor::new(cursor_cache.remove(i), self)))
             .unwrap_or_else(|| self.open_metadata_cursor())
             .map(MetadataCursorGuard::new)

--- a/wt_mdb/src/session/mod.rs
+++ b/wt_mdb/src/session/mod.rs
@@ -1,4 +1,5 @@
 mod index_cursor;
+mod metadata_cursor;
 mod record_cursor;
 mod stat_cursor;
 
@@ -10,6 +11,7 @@ use std::{
     sync::Arc,
 };
 
+use metadata_cursor::{MetadataCursor, MetadataCursorGuard};
 use rustix::io::Errno;
 use tracing::error;
 use wt_sys::{WT_CURSOR, WT_ITEM, WT_SESSION};
@@ -221,6 +223,19 @@ impl Session {
         }
     }
 
+    /// Open a cursor over database metadata.
+    pub fn open_metadata_cursor(&self) -> Result<MetadataCursor> {
+        self.new_cursor_pointer(c"metadata:", None).map(|ptr| {
+            MetadataCursor::new(
+                InnerCursor {
+                    ptr,
+                    uri: TableUri(c"metadata:".to_owned()),
+                },
+                self,
+            )
+        })
+    }
+
     /// Get a cached [RecordCursor] or create a new cursor over `table_name`.
     pub fn get_record_cursor(&self, table_name: &str) -> Result<RecordCursorGuard<'_>> {
         self.get_typed_cursor(table_name, TableType::Record)
@@ -247,6 +262,16 @@ impl Session {
                 Ok(inner)
             })
             .unwrap_or_else(|| self.open_typed_cursor(table_name, None, expected_table_type))
+    }
+
+    pub fn get_metadata_cursor(&self) -> Result<MetadataCursorGuard<'_>> {
+        let mut cursor_cache = self.cached_cursors.borrow_mut();
+        cursor_cache
+            .iter()
+            .position(|c| c.uri.table_name() == c"metadata:")
+            .map(|i| Ok(MetadataCursor::new(cursor_cache.remove(i), self)))
+            .unwrap_or_else(|| self.open_metadata_cursor())
+            .map(MetadataCursorGuard::new)
     }
 
     /// Return an `InnerCursor` to the cache for future re-use.

--- a/wt_mdb/src/session/stat_cursor.rs
+++ b/wt_mdb/src/session/stat_cursor.rs
@@ -62,7 +62,6 @@ impl Iterator for StatCursor<'_> {
 
 impl Drop for StatCursor<'_> {
     fn drop(&mut self) {
-        // TODO: print something if this returns an error.
         if let Err(e) = unsafe { wt_call!(self.ptr, close) } {
             error!("Failed to close statistics WT_CURSOR: {}", e);
         }


### PR DESCRIPTION
Using table metadata with json values will allow us to embed configuration data in the metadata index
instead of relying on "special" keys in the table. Metadata cursors and config parsing are necessary to
access this data in practice.

WT config strings are roughly compatible with JSON so we can continue to use JSON metadata using
this new mechanism.