### PR TITLE
Unify vector representation in scoring around byte arrays

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,6 @@ name = "easy_tiger"
 version = "0.1.0"
 edition = "2021"
 
-[features]
-default = ["simsimd"]
-simsimd = ["dep:simsimd"]
-
 [dependencies]
 bytemuck = "1.23.0"
 crossbeam-skiplist = "0.1.3"
@@ -16,7 +12,7 @@ rand = "0.9.1"
 rayon = "1.10.0"
 serde = { version = "1.0.215", features = ["serde_derive"] }
 serde_json = "1.0.132"
-simsimd = { version = "6.4.4", optional = true }
+simsimd = { version = "6.5.0" }
 stable_deref_trait = "1.2.0"
 thread_local = "1.1.8"
 tracing = "0.1.41"

--- a/et/Cargo.toml
+++ b/et/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+bytemuck = "1.23.1"
 clap = { version = "4.5.20", features = ["derive"] }
 easy_tiger = { path = "../" }
 histogram = "0.11.3"

--- a/et/src/exhaustive_search.rs
+++ b/et/src/exhaustive_search.rs
@@ -72,7 +72,7 @@ pub fn exhaustive_search(
         results.par_iter_mut().enumerate().for_each(|(i, r)| {
             let n = Neighbor::new(
                 record.key(),
-                distance_fn.distance(&index_vector, &query_vectors[i]),
+                distance_fn.distance_f32(&index_vector, &query_vectors[i]),
             );
             if r.len() <= k || n < r[k] {
                 r.push(n);

--- a/et/src/vamana/lookup.rs
+++ b/et/src/vamana/lookup.rs
@@ -21,10 +21,7 @@ pub struct LookupArgs {
 pub fn lookup(connection: Arc<Connection>, index_name: &str, args: LookupArgs) -> io::Result<()> {
     let index = TableGraphVectorIndex::from_db(&connection, index_name)?;
     let session = connection.open_session()?;
-    let mut graph = CursorGraph::new(
-        *index.config(),
-        session.get_record_cursor(index.graph_table_name())?,
-    );
+    let mut graph = CursorGraph::new(session.get_record_cursor(index.graph_table_name())?);
     match graph.get_vertex(args.id) {
         None => {
             println!("Not found!");

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -338,8 +338,7 @@ where
                 self.insert_in_flight_edges(v, in_flight.iter().map(|e| *e), &mut edges);
                 assert!(
                     !edges.iter().any(|n| n.vertex() == v as i64),
-                    "Candidate edges for vertex {} contains self-edge.",
-                    v
+                    "Candidate edges for vertex {v} contains self-edge."
                 );
 
                 // TODO: consider using quantized scores here to avoid reading f32 vectors when

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -242,7 +242,7 @@ where
         });
         self.centroid = self
             .distance_fn
-            .normalize_vector(
+            .normalize(
                 sum.into_iter()
                     .map(|s| (s / self.limit as f64) as f32)
                     .collect::<Vec<_>>()
@@ -262,7 +262,7 @@ where
                 .enumerate()
                 .take(self.limit)
                 .map(|(i, v)| {
-                    let normalized = self.distance_fn.normalize_vector(v.into());
+                    let normalized = self.distance_fn.normalize(v.into());
                     let value = encode_raw_vector(&normalized);
                     progress(1);
                     Record::new(i as i64, value)
@@ -295,7 +295,7 @@ where
         let apply_mu = Mutex::new((
             0i64,
             self.distance_fn
-                .distance(&self.get_vector(0), &self.centroid),
+                .distance_f32(&self.get_vector(0), &self.centroid),
         ));
         self.entry_vertex.store(0, atomic::Ordering::SeqCst);
 
@@ -346,7 +346,7 @@ where
                 // reranking is turned off.
                 let centroid_distance = self
                     .distance_fn
-                    .distance(&self.get_vector(v), &self.centroid);
+                    .distance_f32(&self.get_vector(v), &self.centroid);
 
                 // Add each edge to this vertex and a reciprocal edge to make the graph
                 // undirected. If an edge does not fit on either vertex, save it for later.
@@ -503,7 +503,7 @@ where
             let n = Neighbor::new(
                 in_flight_vertex as i64,
                 self.distance_fn
-                    .distance(&vertex_vector, &self.get_vector(in_flight_vertex)),
+                    .distance_f32(&vertex_vector, &self.get_vector(in_flight_vertex)),
             );
             // If the queue is full and n is worse than all other edges, skip.
             if edges.len() >= limit && n >= *edges.last().unwrap() {
@@ -594,8 +594,7 @@ where
     }
 
     fn get_vector(&self, index: usize) -> Cow<'_, [f32]> {
-        self.distance_fn
-            .normalize_vector(self.vectors[index].into())
+        self.distance_fn.normalize(self.vectors[index].into())
     }
 }
 

--- a/src/crud.rs
+++ b/src/crud.rs
@@ -67,7 +67,7 @@ impl IndexMutator {
         assert_eq!(self.reader.config().dimensions.get(), vector.len());
 
         let distance_fn = self.reader.config().new_distance_function();
-        let vector = distance_fn.normalize_vector(vector.into());
+        let vector = distance_fn.normalize(vector.into());
         let mut candidate_edges = self.searcher.search(&vector, &mut self.reader)?;
         let mut graph = self.reader.graph()?;
         let mut raw_vectors = self.reader.raw_vectors()?;
@@ -147,7 +147,7 @@ impl IndexMutator {
                     raw_vectors
                         .get_raw_vector(*e)
                         .unwrap_or(Err(Error::not_found_error()))
-                        .map(|dst| Neighbor::new(*e, distance_fn.distance(&src_vector, &dst)))
+                        .map(|dst| Neighbor::new(*e, distance_fn.distance_f32(&src_vector, &dst)))
                 })
                 .collect::<Result<Vec<Neighbor>>>()?;
             neighbors.sort();
@@ -223,7 +223,7 @@ impl IndexMutator {
         if graph.entry_point().unwrap()? == vertex_id {
             let mut neighbors = vertex_data
                 .iter()
-                .map(|(id, vec, _)| Neighbor::new(*id, distance_fn.distance(&vector, vec)))
+                .map(|(id, vec, _)| Neighbor::new(*id, distance_fn.distance_f32(&vector, vec)))
                 .collect::<Vec<_>>();
             neighbors.sort();
             if let Some(ep_neighbor) = neighbors.first() {
@@ -257,7 +257,7 @@ impl IndexMutator {
                     .skip(src + 1)
                     .filter_map(|(dst, (dst_vertex, dst_vector, _))| {
                         if !src_edges.contains(dst_vertex) {
-                            Some((src, dst, distance_fn.distance(src_vector, dst_vector)))
+                            Some((src, dst, distance_fn.distance_f32(src_vector, dst_vector)))
                         } else {
                             None
                         }

--- a/src/crud.rs
+++ b/src/crud.rs
@@ -147,7 +147,7 @@ impl IndexMutator {
                     raw_vectors
                         .get_raw_vector(*e)
                         .unwrap_or(Err(Error::not_found_error()))
-                        .map(|dst| Neighbor::new(*e, distance_fn.distance_f32(&src_vector, &dst)))
+                        .map(|dst| Neighbor::new(*e, distance_fn.distance(&src_vector, &dst)))
                 })
                 .collect::<Result<Vec<Neighbor>>>()?;
             neighbors.sort();
@@ -223,7 +223,7 @@ impl IndexMutator {
         if graph.entry_point().unwrap()? == vertex_id {
             let mut neighbors = vertex_data
                 .iter()
-                .map(|(id, vec, _)| Neighbor::new(*id, distance_fn.distance_f32(&vector, vec)))
+                .map(|(id, vec, _)| Neighbor::new(*id, distance_fn.distance(&vector, vec)))
                 .collect::<Vec<_>>();
             neighbors.sort();
             if let Some(ep_neighbor) = neighbors.first() {
@@ -241,9 +241,10 @@ impl IndexMutator {
         Ok(())
     }
 
+    // XXX relax distance fn constraint here.
     fn cross_link_peer_vertices(
         &self,
-        vertex_data: &mut [(i64, Vec<f32>, Vec<i64>)],
+        vertex_data: &mut [(i64, Vec<u8>, Vec<i64>)],
         distance_fn: &dyn F32VectorDistance,
     ) -> Result<()> {
         // Score all pairs of vectors among the passed vertices.
@@ -257,7 +258,7 @@ impl IndexMutator {
                     .skip(src + 1)
                     .filter_map(|(dst, (dst_vertex, dst_vector, _))| {
                         if !src_edges.contains(dst_vertex) {
-                            Some((src, dst, distance_fn.distance_f32(src_vector, dst_vector)))
+                            Some((src, dst, distance_fn.distance(src_vector, dst_vector)))
                         } else {
                             None
                         }

--- a/src/distance.rs
+++ b/src/distance.rs
@@ -69,7 +69,7 @@ impl FromStr for VectorSimilarity {
             "dot" => Ok(VectorSimilarity::Dot),
             x => Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
-                format!("unknown similarity fuction {}", x),
+                format!("unknown similarity fuction {x}"),
             )),
         }
     }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -274,7 +274,7 @@ impl EdgeSetDistanceComputer {
             Self::Raw {
                 distance_fn,
                 vectors,
-            } => distance_fn.distance(&vectors[i], &vectors[j]),
+            } => distance_fn.distance_f32(&vectors[i], &vectors[j]),
             Self::Nav {
                 distance_fn,
                 vectors,

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -46,7 +46,7 @@ impl FromStr for GraphLayout {
             "split" => Ok(Self::Split),
             _ => Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
-                format!("Unknown graph layout {}", s),
+                format!("Unknown graph layout {s}"),
             )),
         }
     }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -129,7 +129,6 @@ pub trait GraphVertex {
 }
 
 /// Vector store for raw vectors used to produce the highest fidelity scores.
-// XXX collapse this and NavVectorStore
 pub trait RawVectorStore {
     /// Get the raw vector for the given vertex.
     fn get_raw_vector(&mut self, vertex_id: i64) -> Option<Result<Cow<'_, [u8]>>>;

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use wt_mdb::{Error, Result};
 
 use crate::{
-    distance::{F32VectorDistance, QuantizedVectorDistance, VectorSimilarity},
+    distance::{F32VectorDistance, VectorDistance, VectorSimilarity},
     quantization::{Quantizer, VectorQuantizer},
     Neighbor,
 };
@@ -75,7 +75,7 @@ impl GraphConfig {
     }
 
     /// Return a distance function for quantized navigational vectors in the index.
-    pub fn new_nav_distance_function(&self) -> Box<dyn QuantizedVectorDistance> {
+    pub fn new_nav_distance_function(&self) -> Box<dyn VectorDistance> {
         self.quantizer.new_distance_function(&self.similarity)
     }
 }
@@ -228,7 +228,7 @@ pub enum EdgeSetDistanceComputer {
         vectors: Vec<Vec<f32>>,
     },
     Nav {
-        distance_fn: Box<dyn QuantizedVectorDistance>,
+        distance_fn: Box<dyn VectorDistance>,
         // TODO: flat representation of the vectors instead of nesting.
         vectors: Vec<Vec<u8>>,
     },

--- a/src/input.rs
+++ b/src/input.rs
@@ -50,8 +50,7 @@ where
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 format!(
-                    "input vector data not aligned to element width {}",
-                    elem_width
+                    "input vector data not aligned to element width {elem_width}"
                 ),
             ));
         }

--- a/src/kmeans.rs
+++ b/src/kmeans.rs
@@ -325,8 +325,8 @@ fn bp_vectors<V: VectorStore<Elem = f32> + Send + Sync>(
         bp_update_centroid(&left_vectors, &mut centroids[0]);
         bp_update_centroid(&right_vectors, &mut centroids[1]);
         distances.par_iter_mut().enumerate().for_each(|(i, d)| {
-            let ldist = crate::distance::l2sq(&dataset[i], &centroids[0]);
-            let rdist = crate::distance::l2sq(&dataset[i], &centroids[1]);
+            let ldist = crate::distance::l2sq_f32(&dataset[i], &centroids[0]);
+            let rdist = crate::distance::l2sq_f32(&dataset[i], &centroids[1]);
             *d = (i, ldist, rdist, ldist - rdist)
         });
         distances.sort_unstable_by(|a, b| a.3.total_cmp(&b.3).then_with(|| a.0.cmp(&b.0)));
@@ -366,10 +366,10 @@ fn bp_vectors<V: VectorStore<Elem = f32> + Send + Sync>(
 
     let mut assignments = vec![(0, 0.0); dataset.len()];
     for i in left_vectors.into_subset().into_iter() {
-        assignments[i] = (0, crate::distance::l2sq(&centroids[0], &dataset[i]));
+        assignments[i] = (0, crate::distance::l2sq_f32(&centroids[0], &dataset[i]));
     }
     for i in right_vectors.into_subset().into_iter() {
-        assignments[i] = (1, crate::distance::l2sq(&centroids[1], &dataset[i]));
+        assignments[i] = (1, crate::distance::l2sq_f32(&centroids[1], &dataset[i]));
     }
 
     if converged {

--- a/src/quantization.rs
+++ b/src/quantization.rs
@@ -86,11 +86,11 @@ impl FromStr for VectorQuantizer {
                     .and_then(|b| if (1..=8).contains(&b) { Some(b) } else { None })
                     .map(|n| Self::AsymmetricBinary { n })
                     .ok_or_else(|| {
-                        input_err(format!("invalid asymmetric_binary bits {}", bits_str))
+                        input_err(format!("invalid asymmetric_binary bits {bits_str}"))
                     })
             }
             "i8naive" => Ok(Self::I8Naive),
-            _ => Err(input_err(format!("unknown quantizer function {}", s))),
+            _ => Err(input_err(format!("unknown quantizer function {s}"))),
         }
     }
 }

--- a/src/quantization.rs
+++ b/src/quantization.rs
@@ -249,7 +249,7 @@ pub struct I8NaiveQuantizer;
 
 impl Quantizer for I8NaiveQuantizer {
     fn for_doc(&self, vector: &[f32]) -> Vec<u8> {
-        let norm = crate::distance::dot(vector, vector).sqrt() as f32;
+        let norm = crate::distance::dot_f32(vector, vector).sqrt() as f32;
         let mut normalized_vector = vector.to_vec();
         for d in normalized_vector.iter_mut() {
             *d /= norm;

--- a/src/search.rs
+++ b/src/search.rs
@@ -531,7 +531,7 @@ mod test {
         fn get_raw_vector(&mut self, vertex_id: i64) -> Option<Result<Cow<'_, [u8]>>> {
             if vertex_id >= 0 && (vertex_id as usize) < self.0.data.len() {
                 Some(Ok(bytemuck::cast_slice(
-                    &*self.0.data[vertex_id as usize].vector,
+                    &self.0.data[vertex_id as usize].vector,
                 )
                 .into()))
             } else {

--- a/src/spann.rs
+++ b/src/spann.rs
@@ -346,7 +346,7 @@ impl SessionIndexWriter {
 
         let mut centroid_ids: Vec<u32> = Vec::with_capacity(replica_count);
         let mut centroids = VecVectorStore::with_capacity(
-            self.head_reader.index().config().dimensions.get(),
+            self.head_reader.index().config().dimensions.get() * 4,
             replica_count,
         );
         for candidate in candidates {
@@ -359,7 +359,7 @@ impl SessionIndexWriter {
                 .expect("returned vector should exist")?;
             if !centroids
                 .iter()
-                .any(|c| self.distance_fn.distance_f32(c, &v) < candidate.distance())
+                .any(|c| self.distance_fn.distance(c, &v) < candidate.distance())
             {
                 centroid_ids.push(
                     candidate

--- a/src/spann.rs
+++ b/src/spann.rs
@@ -23,7 +23,7 @@ use wt_mdb::{
 };
 
 use crate::{
-    distance::{F32VectorDistance, QuantizedVectorDistance},
+    distance::{F32VectorDistance, VectorDistance},
     graph::{GraphConfig, GraphSearchParams, GraphVectorIndexReader, RawVectorStore},
     input::{VecVectorStore, VectorStore},
     quantization::{Quantizer, VectorQuantizer},
@@ -413,7 +413,7 @@ struct PostingIter<'a, 'b, 'c, 'd> {
     cursor: IndexCursorGuard<'a>,
     seen: &'b mut HashSet<i64>,
     query: &'c [u8],
-    distance_fn: &'d dyn QuantizedVectorDistance,
+    distance_fn: &'d dyn VectorDistance,
 
     read: usize,
 }
@@ -424,7 +424,7 @@ impl<'a, 'b, 'c, 'd> PostingIter<'a, 'b, 'c, 'd> {
         centroid_id: u32,
         seen: &'b mut HashSet<i64>,
         query: &'c [u8],
-        distance_fn: &'d dyn QuantizedVectorDistance,
+        distance_fn: &'d dyn VectorDistance,
     ) -> Result<Self> {
         // I _think_ wt copies bounds so we should be cool with temporaries here.
         let mut cursor = reader

--- a/src/spann.rs
+++ b/src/spann.rs
@@ -55,9 +55,9 @@ struct TableNames {
 impl TableNames {
     fn from_index_name(index_name: &str) -> Self {
         TableNames {
-            postings: format!("{}.postings", index_name),
-            centroids: format!("{}.centroids", index_name),
-            raw_vectors: format!("{}.raw_vectors", index_name),
+            postings: format!("{index_name}.postings"),
+            centroids: format!("{index_name}.centroids"),
+            raw_vectors: format!("{index_name}.raw_vectors"),
         }
     }
 
@@ -187,7 +187,7 @@ impl TableIndex {
     }
 
     fn head_name(index_name: &str) -> String {
-        format!("{}.head", index_name)
+        format!("{index_name}.head")
     }
 }
 

--- a/src/spann.rs
+++ b/src/spann.rs
@@ -262,7 +262,7 @@ impl SessionIndexWriter {
     }
 
     pub fn upsert(&mut self, record_id: i64, vector: &[f32]) -> Result<Vec<u32>> {
-        let vector = self.distance_fn.normalize_vector(vector.into());
+        let vector = self.distance_fn.normalize(vector.into());
         let candidates = self
             .head_searcher
             .search(vector.as_ref(), &mut self.head_reader)?;
@@ -275,7 +275,7 @@ impl SessionIndexWriter {
         }
 
         let mut raw_vector_cursor = self.raw_vector_cursor()?;
-        let vector = self.distance_fn.normalize_vector(vector);
+        let vector = self.distance_fn.normalize(vector);
         // TODO: factor out handling of high fidelity vector tables.
         raw_vector_cursor.set(&Record::new(
             record_id,
@@ -359,7 +359,7 @@ impl SessionIndexWriter {
                 .expect("returned vector should exist")?;
             if !centroids
                 .iter()
-                .any(|c| self.distance_fn.distance(c, &v) < candidate.distance())
+                .any(|c| self.distance_fn.distance_f32(c, &v) < candidate.distance())
             {
                 centroid_ids.push(
                     candidate
@@ -651,7 +651,7 @@ impl SpannSearcher {
                     });
                 Ok(Neighbor::new(
                     n.vertex(),
-                    distance_fn.distance(query, &raw_vector),
+                    distance_fn.distance_f32(query, &raw_vector),
                 ))
             })
             .collect::<Result<Vec<_>>>()?;

--- a/src/wt.rs
+++ b/src/wt.rs
@@ -223,9 +223,9 @@ impl TableGraphVectorIndex {
     /// Generate the names of the tables used for `index_name`.
     pub fn generate_table_names(index_name: &str) -> [String; 3] {
         [
-            format!("{}.graph", index_name),
-            format!("{}.raw_vectors", index_name),
-            format!("{}.nav_vectors", index_name),
+            format!("{index_name}.graph"),
+            format!("{index_name}.raw_vectors"),
+            format!("{index_name}.nav_vectors"),
         ]
     }
 

--- a/wt_mdb/src/lib.rs
+++ b/wt_mdb/src/lib.rs
@@ -107,8 +107,8 @@ impl From<NonZero<i32>> for Error {
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::WiredTiger(w) => write!(f, "WT {}", w),
-            Self::Errno(p) => write!(f, "errno {}", p),
+            Self::WiredTiger(w) => write!(f, "WT {w}"),
+            Self::Errno(p) => write!(f, "errno {p}"),
         }
     }
 }

--- a/wt_mdb/src/options.rs
+++ b/wt_mdb/src/options.rs
@@ -84,7 +84,7 @@ impl Statistics {
     pub(crate) fn to_config_string_clause(&self) -> Option<String> {
         match self {
             Self::None => None,
-            opt => Some(format!("statistics=({})", opt)),
+            opt => Some(format!("statistics=({opt})")),
         }
     }
 }
@@ -117,7 +117,7 @@ impl FromStr for Statistics {
             "none" => Ok(Self::None),
             "fast" => Ok(Self::Fast),
             "all" => Ok(Self::All),
-            _ => Err(format!("Unknown statistics type {}", s)),
+            _ => Err(format!("Unknown statistics type {s}")),
         }
     }
 }
@@ -288,7 +288,7 @@ impl From<BeginTransactionOptionsBuilder> for BeginTransactionOptions {
         Self(
             value
                 .name
-                .map(|n| CString::new(format!("name={}", n)).expect("name has no nulls")),
+                .map(|n| CString::new(format!("name={n}")).expect("name has no nulls")),
         )
     }
 }
@@ -324,7 +324,7 @@ impl From<CommitTransactionOptionsBuilder> for CommitTransactionOptions {
         Self(
             value
                 .operation_timeout_ms
-                .map(|t| CString::new(format!("operation_timeout_ms={}", t)).expect("no nulls")),
+                .map(|t| CString::new(format!("operation_timeout_ms={t}")).expect("no nulls")),
         )
     }
 }
@@ -360,7 +360,7 @@ impl From<RollbackTransactionOptionsBuilder> for RollbackTransactionOptions {
         Self(
             value
                 .operation_timeout_ms
-                .map(|t| CString::new(format!("operation_timeout_ms={}", t)).expect("no nulls")),
+                .map(|t| CString::new(format!("operation_timeout_ms={t}")).expect("no nulls")),
         )
     }
 }

--- a/wt_mdb/src/session/mod.rs
+++ b/wt_mdb/src/session/mod.rs
@@ -51,7 +51,7 @@ impl Deref for TableUri {
 
 impl From<&str> for TableUri {
     fn from(value: &str) -> Self {
-        Self(CString::new(format!("table:{}", value)).expect("no nulls in table name"))
+        Self(CString::new(format!("table:{value}")).expect("no nulls in table name"))
     }
 }
 
@@ -294,7 +294,7 @@ impl Session {
         table: Option<&str>,
     ) -> Result<StatCursor<'_>> {
         let table_stats_uri = table.map(|t| {
-            CString::new(format!("statistics:table:{}", t)).expect("no nulls in table name")
+            CString::new(format!("statistics:table:{t}")).expect("no nulls in table name")
         });
         let uri = table_stats_uri.as_deref().unwrap_or(c"statistics:");
         let options = level

--- a/wt_sys/build.rs
+++ b/wt_sys/build.rs
@@ -12,7 +12,7 @@ fn build_wt() -> PathBuf {
         // We have quasi-vendored WT and won't change upstream source to handle errors from new compiler versions.
         .cflag("-Wno-everything")
         // CMake crate is not doing this correctly for whatever reason.
-        .build_arg(format!("-j{}", jobs))
+        .build_arg(format!("-j{jobs}"))
         .build_target("wiredtiger_static")
         .build();
     PathBuf::from_iter([build_path, PathBuf::from("build")])


### PR DESCRIPTION
The observation here is that most vector scoring functions will use SIMD instructions that allow unaligned loads,
so we can use `[u8]` as the rep instead of `[f32]` since we don't _really_ have to worry about alignment, and
simplifies code for loading float vectors from WT which does not guarantee alignment of returned pointers.

This opens a path to using the vamana code with a quantized representation of the "raw" vectors.

Remove the simsimd feature, it's kind of moot since we won't be using simsimd as heavily because simsimd accepts
slices and slices must be aligned. I think this is only a feature of the rust API but none of the docs indicate anything
about alignment in the C API either.