### PR TITLE
Add a real bulk upload path to SPANN

### DIFF
--- a/et/src/spann/bulk_load.rs
+++ b/et/src/spann/bulk_load.rs
@@ -217,7 +217,7 @@ pub fn bulk_load(
     }
 
     let centroid_assignments = {
-        let progress = progress_bar(limit, "assign centroids");
+        let progress = progress_bar(limit, "tail assign centroids");
         assign_to_centroids(index.as_ref(), &connection, &f32_vectors, limit, |i| {
             progress.inc(i)
         })?
@@ -225,14 +225,14 @@ pub fn bulk_load(
 
     let session = connection.open_session()?;
     {
-        let progress = progress_bar(limit, "load centroids");
+        let progress = progress_bar(limit, "tail load centroids");
         bulk_load_centroids(index.as_ref(), &session, &centroid_assignments, |i| {
             progress.inc(i)
         })?;
     }
 
     {
-        let progress = progress_bar(limit, "load postings");
+        let progress = progress_bar(limit, "tail load postings");
         bulk_load_postings(
             index.as_ref(),
             &session,

--- a/et/src/spann/bulk_load.rs
+++ b/et/src/spann/bulk_load.rs
@@ -217,6 +217,9 @@ pub fn bulk_load(
 
     // TODO: consider writing a dedicated bulk loader. The bulk loader should at least do the raw
     // vectors to avoid writing to the checkpoint.
+    // XXX this also results in poor locality - splitting a centroid might result in data in two
+    // different locations. options are to either assign then bulk load in (centroid,record_id)
+    // order _or_ to write a collection for each centroid (too many files)
     let (inserted, assignment_stats) = {
         let tl_writer: ThreadLocal<RefCell<SessionIndexWriter>> = ThreadLocal::new();
         let progress = progress_bar(limit, "postings index");

--- a/src/spann.rs
+++ b/src/spann.rs
@@ -383,7 +383,7 @@ fn select_centroids(
 
     let mut centroid_ids: Vec<u32> = Vec::with_capacity(replica_count);
     let mut centroids =
-        VecVectorStore::with_capacity(head_reader.config().dimensions.get(), replica_count);
+        VecVectorStore::with_capacity(head_reader.config().dimensions.get() * 4, replica_count);
     for candidate in candidates {
         if centroid_ids.len() >= replica_count {
             break;

--- a/src/spann.rs
+++ b/src/spann.rs
@@ -211,7 +211,7 @@ impl PostingKey {
 }
 
 impl Formatted for PostingKey {
-    const FORMAT: FormatString = FormatString::new(c"iq");
+    const FORMAT: FormatString = FormatString::new(c"Iq");
 
     type Ref<'a> = Self;
 

--- a/src/spann.rs
+++ b/src/spann.rs
@@ -3,7 +3,7 @@
 //! This implemented by clustering the input dataset and building a graph-based index over the
 //! select centroids. This index is used to build and navigate a posting index.
 
-mod bulk;
+pub mod bulk;
 
 use std::{
     collections::{BinaryHeap, HashSet},

--- a/src/spann/bulk.rs
+++ b/src/spann/bulk.rs
@@ -1,0 +1,90 @@
+use std::{cell::RefCell, ops::DerefMut, sync::Arc};
+
+use crate::{
+    input::VectorStore,
+    search::GraphSearcher,
+    spann::{select_centroids, PostingKey, TableIndex},
+    wt::SessionGraphVectorIndexReader,
+};
+use rayon::prelude::*;
+use thread_local::ThreadLocal;
+use wt_mdb::{Connection, Result, Session};
+
+/// Assign all the vectors to one or more centroids in the head index. This performs the same search
+/// and pruning as [`super::SessionIndexWriter`] does.
+pub fn assign_to_centroids(
+    index: &TableIndex,
+    connection: &Arc<Connection>,
+    vectors: &(impl VectorStore<Elem = f32> + Send + Sync),
+    limit: Option<usize>,
+    progress: &(impl Fn(u64) + Send + Sync),
+) -> Result<Vec<Vec<u32>>> {
+    let tl_head_reader = ThreadLocal::new();
+    let tl_searcher = ThreadLocal::new();
+    let distance_fn = index.head_config().config().new_distance_function();
+    (0..limit.unwrap_or(vectors.len()))
+        .into_par_iter()
+        .map(|i| {
+            let mut head_reader = tl_head_reader
+                .get_or_try(|| {
+                    Ok::<_, wt_mdb::Error>(RefCell::new(SessionGraphVectorIndexReader::new(
+                        Arc::clone(&index.head),
+                        connection.open_session()?,
+                    )))
+                })?
+                .borrow_mut();
+            let mut searcher = tl_searcher
+                .get_or(|| RefCell::new(GraphSearcher::new(index.config().head_search_params)))
+                .borrow_mut();
+            let candidates = searcher.search(&vectors[i], head_reader.deref_mut())?;
+            let selected = select_centroids(
+                head_reader.deref_mut(),
+                candidates,
+                distance_fn.as_ref(),
+                index.config().replica_count,
+            );
+            progress(1);
+            selected
+        })
+        .collect::<Result<Vec<_>>>()
+}
+
+// XXX need to upload record -> centroid information
+
+/// Compute the sorted list of [`super::PostingKey`]s from centroid assignments.
+pub fn compute_posting_keys(assignments: Vec<Vec<u32>>) -> Vec<PostingKey> {
+    let mut keys: Vec<PostingKey> = assignments
+        .into_par_iter()
+        .enumerate()
+        .flat_map_iter(|(i, a)| {
+            a.into_iter().map(move |c| PostingKey {
+                centroid_id: c,
+                record_id: i as i64,
+            })
+        })
+        .collect();
+    keys.par_sort_unstable();
+    keys
+}
+
+// XXX move assignment stats computation here.
+
+/// Bulk load entries for each of the posting keys into the database.
+///
+/// This runs in a single thread, reading the vector for each posting, quantizing it, and uploading
+/// it into a table. Bulk upload ensures that all posting entries belonging to each centroid appear
+/// contiguously on disk, whereas iterative insertion may "split up" a centroid as it splits leaf
+/// pages. Bulk uploading also avoids checkpointing.
+///
+/// REQUIRES: `posting_keys.is_sorted()``
+pub fn bulk_load_postings<V: VectorStore<Elem = f32> + Send + Sync>(
+    index: &TableIndex,
+    session: &Session,
+    posting_keys: Vec<PostingKey>,
+    vectors: &V,
+    limit: Option<usize>,
+) -> Result<()> {
+    let quantizer = index.config().quantizer.new_quantizer();
+    // XXX I can't bulk load an index table FML.
+    todo!()
+}

--- a/wt_mdb/src/options.rs
+++ b/wt_mdb/src/options.rs
@@ -221,7 +221,7 @@ impl From<CreateOptionsBuilder> for CreateOptions {
             format!("value_format={}", value.value_format.format_str()),
         ];
         if let Some(metadata) = value.app_metadata {
-            parts.push(metadata);
+            parts.push(format!("app_metadata={metadata}"));
         }
         Self(CString::new(parts.join(",")).expect("no nulls"))
     }

--- a/wt_mdb/src/session/typed_cursor.rs
+++ b/wt_mdb/src/session/typed_cursor.rs
@@ -75,7 +75,7 @@ impl<'a, K: Formatted, V: Formatted> TypedCursor<'a, K, V> {
         }
     }
 
-    pub fn session(&self) -> &Session {
+    pub fn session(&self) -> &'a Session {
         self.session
     }
 


### PR DESCRIPTION
This loads the posting keys in order which should hopefully improve the efficacy of buffer cache since everything
for a centroid should be written contiguously after a bulk load.