### PR TITLE
Introduce a uniform scaled i8 quantizer

### DIFF
--- a/et/src/vamana/bulk_load.rs
+++ b/et/src/vamana/bulk_load.rs
@@ -35,11 +35,7 @@ pub struct BulkLoadArgs {
     ///
     /// `split` puts raw vectors, nav vectors, and graph edges each in separate tables. If results
     /// are being re-ranked this will require additional reads to complete.
-    ///
-    /// `raw_vector_in_graph` places raw vectors and graph edges in the same table. When a vertex
-    /// is visited the raw vector is read and saved for re-scoring. This minimizes the number of
-    /// reads performed and is likely better for indices with less traffic.
-    #[arg(long, value_enum, default_value = "raw_vector_in_graph")]
+    #[arg(long, value_enum, default_value = "split")]
     layout: GraphLayout,
     /// If true, load all quantized vectors into a trivial memory store for bulk loading.
     /// This can be significantly faster than reading these values from WiredTiger.

--- a/et/src/vamana/bulk_load.rs
+++ b/et/src/vamana/bulk_load.rs
@@ -39,7 +39,7 @@ pub struct BulkLoadArgs {
     layout: GraphLayout,
     /// If true, load all quantized vectors into a trivial memory store for bulk loading.
     /// This can be significantly faster than reading these values from WiredTiger.
-    #[arg(long, default_value_t = false)]
+    #[arg(long, default_value_t = true)]
     memory_quantized_vectors: bool,
     /// If true, load all the raw vectors into WiredTiger for bulk loading.
     /// This can be faster for dot similarity as the vectors are normalized just once.

--- a/src/distance.rs
+++ b/src/distance.rs
@@ -176,7 +176,6 @@ impl VectorDistance for I8NaiveDistance {
     }
 }
 
-// XXX repr should be [u8] with methods to pull the data.
 #[derive(Debug, Copy, Clone)]
 struct I8NonUniformNaiveVector<'a>(&'a [u8]);
 
@@ -192,17 +191,15 @@ impl I8NonUniformNaiveVector<'_> {
     }
 
     fn scale(&self) -> f64 {
-        // XXX scale should be stored precomputed this way
-        f32::from_le_bytes(self.0[0..4].try_into().unwrap()) as f64 / i8::MAX as f64
+        f32::from_le_bytes(self.0[0..4].try_into().unwrap()).into()
     }
 
     fn l1_norm(&self) -> f64 {
-        // XXX store l2 norm instead.
-        f32::from_le_bytes(self.0[4..8].try_into().unwrap()).into()
+        self.l2_norm() * self.l2_norm()
     }
 
     fn l2_norm(&self) -> f64 {
-        self.l1_norm().sqrt()
+        f32::from_le_bytes(self.0[4..8].try_into().unwrap()).into()
     }
 
     fn vector(&self) -> &[i8] {

--- a/src/quantization.rs
+++ b/src/quantization.rs
@@ -279,6 +279,8 @@ impl Quantizer for I8NaiveQuantizer {
 /// The maximum magnitude of any dimension is used to set the range for quantization into an i8
 /// value and is recorded in the packed vector. While quantization is uniform within the vector it
 /// is non-uniform across vectors so we must de-quantize values in order to score them.
+// XXX the name sucks. it's not really non-uniform i can score it pretty consistently. i could also
+// score it piecewise pretty consistently!
 #[derive(Debug, Copy, Clone)]
 pub struct I8NonUniformNaiveQuantizer;
 

--- a/src/quantization.rs
+++ b/src/quantization.rs
@@ -2,7 +2,7 @@
 //!
 //! Graph navigation during search uses these quantized vectors.
 
-use std::{i8, io, str::FromStr};
+use std::{io, str::FromStr};
 
 use serde::{Deserialize, Serialize};
 
@@ -323,3 +323,4 @@ impl Quantizer for I8NonUniformNaiveQuantizer {
 }
 
 // TODO: quantizer that is non-uniform for MRL vectors.
+// Bonus points if it can still be scored on the quantized rep instead of de-quantizing.


### PR DESCRIPTION
This quantizer uses the maximum absolute value across all dimensions to scale each dimension. The scale and
l2 norm are stored along with the quantized vector to allow computing l2 and dot product distances in a way that
is compatible with f32 l2 and dot distances on the quantized representation.

In a test where this is used for nav vectors, we can get 0.980560 recall with re-ranking of the full candidate set and
0.97705 recall without -- a difference of 0.35%. This could replace f32 in the raw vector table if the infrastructure
supported it.

Like i8naive and unlike lucene's u7 scalar this quantizer does not sample or measure the data set, meaning that changes
to the input vector set do not affect quantization.

Future work:
* A non-uniform scaled quantizer. In Matryoshka vector representations some dimensions are more important than others and we could vary the scaling factor across sets of dimensions to increase fidelity.
* Score f32 x quantized to improve recall. This requires significant work to inject scorers in the query flow.
* Replace f32 vectors in the "raw" vector table to reduce the cost of re-ranking.