### PR TITLE
Add a `QueryVectorDistance` trait

### DIFF
--- a/src/distance.rs
+++ b/src/distance.rs
@@ -4,7 +4,7 @@ use std::{borrow::Cow, io, str::FromStr};
 
 use serde::{Deserialize, Serialize};
 
-/// Distance function for quantized vectors.
+/// Distance function for coded vectors.
 ///
 /// This trait is object-safe; it may be instantiated at runtime based on
 /// data that appears in a file or other backing store.
@@ -33,6 +33,12 @@ pub trait F32VectorDistance: VectorDistance {
     fn normalize<'a>(&self, vector: Cow<'a, [f32]>) -> Cow<'a, [f32]> {
         vector
     }
+}
+
+/// Compute the distance between a fixed vector provided at creation time and other vectors.
+/// This is often useful in query flows where everything references a specific point.
+pub trait QueryVectorDistance: Send + Sync {
+    fn distance(&self, vector: &[u8]) -> f64;
 }
 
 /// Functions used for computing a similarity score for high fidelity vectors.
@@ -250,6 +256,7 @@ pub(crate) fn hamming(q: &[u8], d: &[u8]) -> f64 {
 
 #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
 unsafe fn load_f32x4_le(p: *const u8) -> core::arch::aarch64::float32x4_t {
+    // XXX use cfg!(target+endian = "big") and byte swap
     core::arch::aarch64::vld1q_f32(p as *const f32)
 }
 

--- a/src/distance.rs
+++ b/src/distance.rs
@@ -252,7 +252,6 @@ impl QueryVectorDistance for I8ScaledUniformDotProductQueryDistance<'_> {
     fn distance(&self, vector: &[u8]) -> f64 {
         // TODO: benchmark performing dot product of query and doc without scaling, then scaling
         // afterward. This would avoid a multiplication per dimension.
-        // XXX
         let vector = I8ScaledUniformVector::from(vector);
         let dot = self
             .0
@@ -288,6 +287,8 @@ impl<'a> I8ScaledUniformEuclideanQueryDistance<'a> {
 
 impl QueryVectorDistance for I8ScaledUniformEuclideanQueryDistance<'_> {
     fn distance(&self, vector: &[u8]) -> f64 {
+        // TODO: benchmark performing dot product of query and doc without scaling, then scaling
+        // afterward. This would avoid a multiplication per dimension.
         let vector = I8ScaledUniformVector::from(vector);
         let dot = self
             .0
@@ -455,8 +456,6 @@ mod test {
             qdist,
         );
     }
-
-    // XXX i get recall of 0 when using the asymmetric functions so clearly i fucked up _something_.
 
     #[test]
     fn i8_shaped_dot() {

--- a/src/distance.rs
+++ b/src/distance.rs
@@ -207,7 +207,7 @@ impl I8ScaledUniformVector<'_> {
         f32::from_le_bytes(self.0[0..4].try_into().unwrap()).into()
     }
 
-    fn l1_norm(&self) -> f64 {
+    fn l2_norm_sq(&self) -> f64 {
         self.l2_norm() * self.l2_norm()
     }
 
@@ -271,7 +271,7 @@ impl VectorDistance for I8ScaledUniformEuclidean {
         let query = I8ScaledUniformVector::from(query);
         let doc = I8ScaledUniformVector::from(doc);
         let dot = query.dot_unnormalized(&doc);
-        query.l1_norm() + doc.l1_norm() - (2.0 * dot)
+        query.l2_norm_sq() + doc.l2_norm_sq() - (2.0 * dot)
     }
 }
 
@@ -280,8 +280,8 @@ pub struct I8ScaledUniformEuclideanQueryDistance<'a>(&'a [f32], f64);
 
 impl<'a> I8ScaledUniformEuclideanQueryDistance<'a> {
     pub fn new(query: &'a [f32]) -> Self {
-        let l1_norm = dot_f32(query, query);
-        Self(query, l1_norm)
+        let l2_norm_sq = dot_f32(query, query);
+        Self(query, l2_norm_sq)
     }
 }
 
@@ -296,7 +296,7 @@ impl QueryVectorDistance for I8ScaledUniformEuclideanQueryDistance<'_> {
             .zip(vector.dequantized_unnormalized_iter())
             .map(|(q, d)| *q * d)
             .sum::<f32>() as f64;
-        self.1 + vector.l1_norm() - (2.0 * dot)
+        self.1 + vector.l2_norm_sq() - (2.0 * dot)
     }
 }
 

--- a/src/distance.rs
+++ b/src/distance.rs
@@ -306,10 +306,14 @@ pub(crate) fn hamming(q: &[u8], d: &[u8]) -> f64 {
     u8::hamming(q, d).expect("same dimensionality")
 }
 
-#[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+#[cfg(all(target_arch = "aarch64"))]
 unsafe fn load_f32x4_le(p: *const u8) -> core::arch::aarch64::float32x4_t {
-    // XXX use cfg!(target_endian = "big") and byte swap
-    core::arch::aarch64::vld1q_f32(p as *const f32)
+    use core::arch::aarch64;
+    if cfg!(target_endian = "big") {
+        aarch64::vreinterpretq_f32_u8(aarch64::vrev32q_u8(aarch64::vld1q_u8(p)))
+    } else {
+        aarch64::vld1q_f32(p as *const f32)
+    }
 }
 
 #[cfg(not(target_arch = "aarch64"))]

--- a/src/distance.rs
+++ b/src/distance.rs
@@ -305,7 +305,7 @@ pub(crate) fn hamming(q: &[u8], d: &[u8]) -> f64 {
     u8::hamming(q, d).expect("same dimensionality")
 }
 
-#[cfg(all(target_arch = "aarch64"))]
+#[cfg(target_arch = "aarch64")]
 unsafe fn load_f32x4_le(p: *const u8) -> core::arch::aarch64::float32x4_t {
     use core::arch::aarch64;
     if cfg!(target_endian = "big") {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod graph_clustering;
 pub mod input;
 pub mod kmeans;
 pub mod quantization;
+pub mod query_distance;
 pub mod search;
 pub mod spann;
 pub mod wt;

--- a/src/query_distance.rs
+++ b/src/query_distance.rs
@@ -107,9 +107,9 @@ pub fn new_query_vector_distance_f32<'a>(
     }
 }
 
-/// Create a new [QueryVectorDistance] that accepts a pre-quantized query.
+/// Create a new [QueryVectorDistance] for indexing that _requires_ symmetrical distance computation.
 // TODO: ideally we would indicate the on-disk target format (today specified as Option<VectorQuantizer>)
-pub fn new_query_vector_distance_quantized<'a>(
+pub fn new_query_vector_distance_indexing<'a>(
     query: &'a [u8],
     similarity: VectorSimilarity,
     quantizer: Option<VectorQuantizer>,
@@ -127,10 +127,7 @@ pub fn new_query_vector_distance_quantized<'a>(
             query,
         )),
         (_, Some(VectorQuantizer::AsymmetricBinary { n: _ })) => Box::new(
-            // XXX this is probably all wrong if you use AsymmetricBinary during indexing.
-            // i may just delete this because i don't think it's all that useful.
-            // maybe it should just be named "for indexing" and use HammingDistance?
-            GenericQueryVectorDistance::from_quantized(AsymmetricHammingDistance, query),
+            GenericQueryVectorDistance::from_quantized(HammingDistance, query),
         ),
         (_, Some(VectorQuantizer::I8Naive)) => Box::new(
             GenericQueryVectorDistance::from_quantized(I8NaiveDistance(similarity), query),

--- a/src/query_distance.rs
+++ b/src/query_distance.rs
@@ -1,0 +1,69 @@
+//! Abstractions for computing the distance between a fixed query vector and other vectors.
+//!
+//! This abstraction is particularly useful in query paths where we are computing the distance to
+//! a query and allows us to hide details about the packing of quantized vectors or implement
+//! asymmetric scoring schemes.
+
+use crate::{
+    distance::{
+        F32DotProductDistance, F32EuclideanDistance, HammingDistance, I8NaiveDistance,
+        VectorDistance, VectorSimilarity,
+    },
+    quantization::VectorQuantizer,
+};
+
+// XXX I actually have two separate problems: one is that I have no mechanism for replacing the
+// format of the "raw" vectors, which overlaps with quantization (except the default is lossless),
+// the second is that implementing scoring in this kind of scheme is annoying. Should I focus on
+// the former? Seems moree productive.
+
+// XXX format/quantization and distance are closely interrelated and it probably doesn't make
+// sense for the formatting code to live in a different place from the distance code. i might need
+// both to get anything done.
+
+/// Compute the distance between a fixed vector provided at creation time and other vectors.
+/// This is often useful in query flows where everything references a specific point.
+pub trait QueryVectorDistance: Send + Sync {
+    fn distance(&self, vector: &[u8]) -> f64;
+}
+
+#[derive(Debug, Copy, Clone)]
+struct GenericQueryVectorDistance<'a, D> {
+    distance_fn: D,
+    query: &'a [u8],
+}
+
+impl<'a, D: VectorDistance> QueryVectorDistance for GenericQueryVectorDistance<'a, D> {
+    fn distance(&self, vector: &[u8]) -> f64 {
+        self.distance_fn.distance(self.query, vector)
+    }
+}
+
+/// Create a new [QueryVectorDistance] given a query, similarity function, and quantizer.
+pub fn new_query_vector_distance<'a>(
+    query: &'a [u8],
+    similarity: VectorSimilarity,
+    quantizer: Option<VectorQuantizer>,
+) -> Box<dyn QueryVectorDistance + 'a> {
+    match (similarity, quantizer) {
+        (VectorSimilarity::Dot, None) => Box::new(GenericQueryVectorDistance {
+            distance_fn: F32DotProductDistance,
+            query,
+        }),
+        (VectorSimilarity::Euclidean, None) => Box::new(GenericQueryVectorDistance {
+            distance_fn: F32EuclideanDistance,
+            query,
+        }),
+        (_, Some(VectorQuantizer::Binary)) => Box::new(GenericQueryVectorDistance {
+            distance_fn: HammingDistance,
+            query,
+        }),
+        // TODO: this should be implemented by some other means and GenericQueryVectorDistance
+        // should be called "SymmetricQueryVectorDistance"
+        (_, Some(VectorQuantizer::AsymmetricBinary { n: _ })) => unimplemented!(),
+        (_, Some(VectorQuantizer::I8Naive)) => Box::new(GenericQueryVectorDistance {
+            distance_fn: I8NaiveDistance(similarity),
+            query,
+        }),
+    }
+}

--- a/src/query_distance.rs
+++ b/src/query_distance.rs
@@ -18,15 +18,6 @@ use crate::{
     },
 };
 
-// XXX I actually have two separate problems: one is that I have no mechanism for replacing the
-// format of the "raw" vectors, which overlaps with quantization (except the default is lossless),
-// the second is that implementing scoring in this kind of scheme is annoying. Should I focus on
-// the former? Seems moree productive.
-
-// XXX format/quantization and distance are closely interrelated and it probably doesn't make
-// sense for the formatting code to live in a different place from the distance code. i might need
-// both to get anything done.
-
 /// Compute the distance between a fixed vector provided at creation time and other vectors.
 /// This is often useful in query flows where everything references a specific point.
 pub trait QueryVectorDistance: Send + Sync {

--- a/src/search.rs
+++ b/src/search.rs
@@ -157,8 +157,7 @@ impl GraphSearcher {
             return Ok(self.candidates.iter().map(|c| c.neighbor).collect());
         }
 
-        let distance_fn = reader.config().new_distance_function();
-        let query = distance_fn.normalize(query.into());
+        let query = new_query_vector_distance_f32(query, reader.config().similarity, None);
         let mut raw_vectors = reader.raw_vectors()?;
         let rescored = self
             .candidates
@@ -169,12 +168,7 @@ impl GraphSearcher {
                 raw_vectors
                     .get_raw_vector(vertex)
                     .expect("row exists")
-                    .map(|rv| {
-                        Neighbor::new(
-                            vertex,
-                            distance_fn.distance(bytemuck::cast_slice(&query), &rv),
-                        )
-                    })
+                    .map(|rv| Neighbor::new(vertex, query.distance(&rv)))
             })
             .collect::<Result<Vec<_>>>();
         rescored.map(|mut r| {

--- a/src/search.rs
+++ b/src/search.rs
@@ -11,7 +11,7 @@ use crate::{
         RawVectorStore,
     },
     query_distance::{
-        new_query_vector_distance_f32, new_query_vector_distance_quantized, QueryVectorDistance,
+        new_query_vector_distance_f32, new_query_vector_distance_indexing, QueryVectorDistance,
     },
     Neighbor,
 };
@@ -130,7 +130,7 @@ impl GraphSearcher {
                 .get_nav_vector(vertex_id)
                 .unwrap_or(Err(Error::not_found_error()))?
                 .to_vec();
-            let nav_query = new_query_vector_distance_quantized(
+            let nav_query = new_query_vector_distance_indexing(
                 &nav_query,
                 reader.config().similarity,
                 Some(reader.config().quantizer),


### PR DESCRIPTION
This trait binds a query and a distance function. This abstracts the format of the query away from search code
that is performing distance scoring, making it easier to replace the vector format in the table or build asymmetric
distance functions that use two different vector representations to balance size and fidelity.

Provide a query distance function for f32 x i8scaled-uniform, which is worth about 0.1% in recall benchmarks,
leaving the gap between f32 and i8su at ~2.7%.