### PR TITLE
Normalized coding

### DIFF
--- a/et/src/spann/bulk_load.rs
+++ b/et/src/spann/bulk_load.rs
@@ -135,6 +135,8 @@ pub fn bulk_load(
         dimensions: args.dimensions,
         similarity: args.similarity,
         nav_format: args.head_quantizer,
+        // XXX expose via command line
+        rerank_format: args.similarity.default_vector_coding(),
         layout: args.layout,
         max_edges: args.max_edges,
         index_search_params: GraphSearchParams {

--- a/et/src/spann/bulk_load.rs
+++ b/et/src/spann/bulk_load.rs
@@ -31,20 +31,14 @@ pub struct BulkLoadArgs {
     /// Similarity function to use for vector scoring.
     #[arg(short, long, value_enum)]
     similarity: VectorSimilarity,
-    /// Quantizer to use for navigational vectors.
-    ///
-    /// This will also dictate the quantized scoring function used.
-    #[arg(short, long, value_enum)]
-    head_quantizer: F32VectorCoding,
+    /// Encoding used for navigational vectors in the head index.
+    #[arg(long, value_enum)]
+    head_nav_format: F32VectorCoding,
+    /// Encoding used for rerank vectors in the head index.
+    #[arg(long, value_enum, default_value = "raw")]
+    head_rerank_format: F32VectorCoding,
 
-    /// Physical layout used for graph.
-    ///
-    /// `split` puts raw vectors, nav vectors, and graph edges each in separate tables. If results
-    /// are being re-ranked this will require additional reads to complete.
-    ///
-    /// `raw_vector_in_graph` places raw vectors and graph edges in the same table. When a vertex
-    /// is visited the raw vector is read and saved for re-scoring. This minimizes the number of
-    /// reads performed and is likely better for indices with less traffic.
+    /// Physical layout used for the head graph.
     #[arg(long, value_enum, default_value = "split")]
     layout: GraphLayout,
 
@@ -134,9 +128,8 @@ pub fn bulk_load(
     let head_config = GraphConfig {
         dimensions: args.dimensions,
         similarity: args.similarity,
-        nav_format: args.head_quantizer,
-        // XXX expose via command line
-        rerank_format: args.similarity.default_vector_coding(),
+        nav_format: args.head_nav_format.adjust_raw_format(args.similarity),
+        rerank_format: args.head_rerank_format.adjust_raw_format(args.similarity),
         layout: args.layout,
         max_edges: args.max_edges,
         index_search_params: GraphSearchParams {

--- a/et/src/vamana/bulk_load.rs
+++ b/et/src/vamana/bulk_load.rs
@@ -86,6 +86,8 @@ pub fn bulk_load(
         dimensions: args.dimensions,
         similarity: args.similarity,
         nav_format: args.nav_format,
+        // XXX allow specifying this on the command line.
+        rerank_format: args.similarity.default_vector_coding(),
         layout: args.layout,
         max_edges: args.max_edges,
         index_search_params: GraphSearchParams {

--- a/et/src/vamana/bulk_load.rs
+++ b/et/src/vamana/bulk_load.rs
@@ -22,18 +22,16 @@ pub struct BulkLoadArgs {
     #[arg(short, long)]
     dimensions: NonZero<usize>,
     /// Similarity function to use for vector scoring.
-    #[arg(short, long, value_enum)]
+    #[arg(long, value_enum)]
     similarity: VectorSimilarity,
-    /// Quantizer to use for navigational vectors.
-    ///
-    /// This will also dictate the quantized scoring function used.
-    #[arg(short, long, value_enum)]
+    /// Vector coding to use for navigational vectors.
+    #[arg(long, value_enum)]
     nav_format: F32VectorCoding,
+    /// Vector coding to use for rerank vectors.
+    #[arg(long, value_enum, default_value = "raw")]
+    rerank_format: F32VectorCoding,
 
     /// Physical layout used for graph.
-    ///
-    /// `split` puts raw vectors, nav vectors, and graph edges each in separate tables. If results
-    /// are being re-ranked this will require additional reads to complete.
     #[arg(long, value_enum, default_value = "split")]
     layout: GraphLayout,
     /// If true, load all quantized vectors into a trivial memory store for bulk loading.
@@ -85,9 +83,8 @@ pub fn bulk_load(
     let config = GraphConfig {
         dimensions: args.dimensions,
         similarity: args.similarity,
-        nav_format: args.nav_format,
-        // XXX allow specifying this on the command line.
-        rerank_format: args.similarity.default_vector_coding(),
+        nav_format: args.nav_format.adjust_raw_format(args.similarity),
+        rerank_format: args.rerank_format.adjust_raw_format(args.similarity),
         layout: args.layout,
         max_edges: args.max_edges,
         index_search_params: GraphSearchParams {

--- a/et/src/vamana/init_index.rs
+++ b/et/src/vamana/init_index.rs
@@ -25,14 +25,7 @@ pub struct InitIndexArgs {
     nav_format: F32VectorCoding,
 
     /// Physical layout used for graph.
-    ///
-    /// `split` puts raw vectors, nav vectors, and graph edges each in separate tables. If results
-    /// are being re-ranked this will require additional reads to complete.
-    ///
-    /// `raw_vector_in_graph` places raw vectors and graph edges in the same table. When a vertex
-    /// is visited the raw vector is read and saved for re-scoring. This minimizes the number of
-    /// reads performed and is likely better for indices with less traffic.
-    #[arg(long, value_enum, default_value = "raw_vector_in_graph")]
+    #[arg(long, value_enum, default_value = "split")]
     layout: GraphLayout,
 
     /// Maximum number of edges for any vertex.
@@ -80,6 +73,8 @@ pub fn init_index(
             dimensions: args.dimensions,
             similarity: args.similarity,
             nav_format: args.nav_format,
+            // XXX expose via command line.
+            rerank_format: args.similarity.default_vector_coding(),
             layout: args.layout,
             max_edges: args.max_edges,
             index_search_params: GraphSearchParams {

--- a/et/src/vamana/init_index.rs
+++ b/et/src/vamana/init_index.rs
@@ -18,11 +18,12 @@ pub struct InitIndexArgs {
     /// Similarity function to use for vector scoring.
     #[arg(short, long, value_enum)]
     similarity: VectorSimilarity,
-    /// Quantizer to use for navigational vectors.
-    ///
-    /// This will also dictate the quantized scoring function used.
-    #[arg(short, long, value_enum)]
+    /// Vector coding to use for navigational vectors.
+    #[arg(long, value_enum)]
     nav_format: F32VectorCoding,
+    /// Vector coding to use for rerank vectors.
+    #[arg(long, value_enum, default_value = "raw")]
+    rerank_format: F32VectorCoding,
 
     /// Physical layout used for graph.
     #[arg(long, value_enum, default_value = "split")]
@@ -72,9 +73,8 @@ pub fn init_index(
         GraphConfig {
             dimensions: args.dimensions,
             similarity: args.similarity,
-            nav_format: args.nav_format,
-            // XXX expose via command line.
-            rerank_format: args.similarity.default_vector_coding(),
+            nav_format: args.nav_format.adjust_raw_format(args.similarity),
+            rerank_format: args.rerank_format.adjust_raw_format(args.similarity),
             layout: args.layout,
             max_edges: args.max_edges,
             index_search_params: GraphSearchParams {

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -288,7 +288,7 @@ where
         // centroid, we may update this if we find a closer point then reflect it back into entry_vertex.
         let apply_mu = {
             let session = self.connection.open_session()?;
-            let mut cursor = session.open_record_cursor(&self.index.raw_table_name())?;
+            let mut cursor = session.open_record_cursor(self.index.raw_table_name())?;
             let vector0 = cursor.seek_exact(0).unwrap()?;
             Mutex::new((0i64, self.distance_fn.distance(&self.centroid, &vector0)))
         };

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -69,6 +69,8 @@ pub struct Options {
 
 #[derive(Debug, Copy, Clone)]
 pub enum BulkLoadPhase {
+    // TODO: combine vector loading phases now that bulk_load APIs have been refactored to allow
+    // this in a useful/meaningful way.
     LoadNavVectors,
     LoadRawVectors,
     ClusterVectors,

--- a/src/crud.rs
+++ b/src/crud.rs
@@ -64,7 +64,6 @@ impl IndexMutator {
         assert_eq!(self.reader.config().dimensions.get(), vector.len());
 
         let distance_fn = self.reader.config().new_distance_function();
-        let vector = distance_fn.normalize(vector.into());
         let mut candidate_edges = self.searcher.search(&vector, &mut self.reader)?;
         let mut graph = self.reader.graph()?;
         let mut raw_vectors = self.reader.raw_vectors()?;

--- a/src/crud.rs
+++ b/src/crud.rs
@@ -71,7 +71,7 @@ impl IndexMutator {
         assert_eq!(self.reader.config().dimensions.get(), vector.len());
 
         let distance_fn = self.reader.config().new_distance_function();
-        let mut candidate_edges = self.searcher.search(&vector, &mut self.reader)?;
+        let mut candidate_edges = self.searcher.search(vector, &mut self.reader)?;
         let mut graph = self.reader.graph()?;
         let mut raw_vectors = self.reader.raw_vectors()?;
         if candidate_edges.is_empty() {

--- a/src/crud.rs
+++ b/src/crud.rs
@@ -85,7 +85,7 @@ impl IndexMutator {
             vertex_id,
             candidate_edges.iter().map(|n| n.vertex()).collect(),
             vector.as_ref(),
-            &self.reader.config().new_coder().encode(vector.as_ref()),
+            &self.reader.config().new_nav_coder().encode(vector.as_ref()),
         )?;
 
         let mut pruned_edges = vec![];
@@ -294,8 +294,8 @@ impl IndexMutator {
         nav_vector: &[u8],
     ) -> Result<()> {
         self.reader.graph()?.set(vertex_id, edges)?;
-        // TODO: make this a struct member.
-        let coder = self.reader.config().similarity.vector_coding().new_coder();
+        // XXX make this a struct member.
+        let coder = self.reader.config().rerank_format.new_coder();
         self.reader
             .raw_vectors()?
             .set(vertex_id, coder.encode(raw_vector))?;
@@ -384,7 +384,7 @@ mod tests {
                         dimensions: NonZero::new(2).unwrap(),
                         similarity: VectorSimilarity::Euclidean,
                         nav_format: F32VectorCoding::BinaryQuantized,
-                        // TODO: each test should be run in both layouts.
+                        rerank_format: F32VectorCoding::Raw,
                         layout: GraphLayout::Split,
                         max_edges: NonZero::new(4).unwrap(),
                         index_search_params: Self::search_params(),

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -10,8 +10,7 @@ use wt_mdb::{Error, Result};
 
 use crate::{
     vectors::{
-        new_query_vector_distance_f32, F32VectorCoder, F32VectorCoding, F32VectorDistance,
-        QueryVectorDistance, VectorDistance, VectorSimilarity,
+        F32VectorCoder, F32VectorCoding, F32VectorDistance, VectorDistance, VectorSimilarity,
     },
     Neighbor,
 };
@@ -104,14 +103,6 @@ impl GraphConfig {
     /// Return a new vector coder for the rerank vector format.
     pub fn new_rerank_coder(&self) -> Box<dyn F32VectorCoder> {
         self.rerank_format.new_coder()
-    }
-
-    /// Return a new query vector distance function for the query against the rerank vector format.
-    pub fn new_rerank_query_distance_function<'a>(
-        &self,
-        query: &'a [f32],
-    ) -> Box<dyn QueryVectorDistance + 'a> {
-        new_query_vector_distance_f32(query, self.similarity, self.rerank_format)
     }
 }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -55,14 +55,15 @@ impl FromStr for GraphLayout {
 }
 
 /// Configuration describing graph shape and construction. Used to read and mutate the graph.
-// XXX I need to adjust nav_format and rerank_format depending on the similarity function -- if the
-// format is raw i should reformat it as rawl2normalized for dot/angular distance. this probably
-// requires wrapping graph config.
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct GraphConfig {
     /// Number of vector dimensions.
     pub dimensions: NonZero<usize>,
     /// Function to use for vector distance computations.
+    ///
+    /// If using [`VectorSimilarity::Dot`] along with [`F32VectorCoding::Raw`], consider using
+    /// [`F32VectorCoding::RawL2Normalized`] instead unless you are certain that all input vectors
+    /// in the read and write path are _already_ l2 normalized.
     pub similarity: VectorSimilarity,
     /// Vector coding to use in the nav table.
     ///

--- a/src/search.rs
+++ b/src/search.rs
@@ -141,13 +141,9 @@ impl GraphSearcher {
         } else {
             None
         };
-        let rerank_query = rerank_query_rep.as_ref().map(|q| {
-            new_query_vector_distance_f32(
-                q,
-                reader.config().similarity,
-                reader.config().similarity.vector_coding(),
-            )
-        });
+        let rerank_query = rerank_query_rep
+            .as_ref()
+            .map(|q| reader.config().new_rerank_query_distance_function(q));
 
         self.search_graph_and_rerank(
             nav_query.as_ref(),
@@ -169,11 +165,7 @@ impl GraphSearcher {
             reader.config().nav_format,
         );
         let rerank_query = if self.params.num_rerank > 0 {
-            Some(new_query_vector_distance_f32(
-                query,
-                reader.config().similarity,
-                reader.config().similarity.vector_coding(),
-            ))
+            Some(reader.config().new_rerank_query_distance_function(query))
         } else {
             None
         };
@@ -442,6 +434,7 @@ mod test {
                 dimensions: NonZero::new(rep.first().map(|v| v.vector.len()).unwrap_or(1)).unwrap(),
                 similarity: VectorSimilarity::Euclidean,
                 nav_format: F32VectorCoding::BinaryQuantized,
+                rerank_format: F32VectorCoding::Raw,
                 layout: GraphLayout::Split,
                 max_edges,
                 index_search_params: GraphSearchParams {

--- a/src/spann.rs
+++ b/src/spann.rs
@@ -606,10 +606,12 @@ impl SpannSearcher {
             return Ok(results.into_sorted_vec());
         }
 
-        let query = reader
-            .head_reader
-            .config()
-            .new_rerank_query_distance_function(query);
+        // TODO: separate head rerank format from tail rerank format.
+        let query = new_query_vector_distance_f32(
+            query,
+            reader.head_reader.config().similarity,
+            reader.head_reader.config().rerank_format,
+        );
         let mut raw_cursor = reader
             .session()
             .open_record_cursor(&reader.index().table_names.raw_vectors)?;

--- a/src/spann.rs
+++ b/src/spann.rs
@@ -250,7 +250,7 @@ impl SessionIndexWriter {
     pub fn new(index: Arc<TableIndex>, session: Session) -> Self {
         let distance_fn = index.head.config().new_distance_function();
         let posting_coder = index.config.posting_coder.new_coder();
-        let raw_coder = index.head.config().similarity.vector_coding().new_coder();
+        let raw_coder = index.head.config().new_rerank_coder();
         let head_reader = SessionGraphVectorIndexReader::new(index.head.clone(), session);
         let head_searcher = GraphSearcher::new(index.config.head_search_params);
         Self {
@@ -606,11 +606,10 @@ impl SpannSearcher {
             return Ok(results.into_sorted_vec());
         }
 
-        let query = new_query_vector_distance_f32(
-            query,
-            reader.head_reader.config().similarity,
-            reader.head_reader.config().similarity.vector_coding(),
-        );
+        let query = reader
+            .head_reader
+            .config()
+            .new_rerank_query_distance_function(query);
         let mut raw_cursor = reader
             .session()
             .open_record_cursor(&reader.index().table_names.raw_vectors)?;

--- a/src/spann.rs
+++ b/src/spann.rs
@@ -240,6 +240,7 @@ pub struct SessionIndexWriter {
     index: Arc<TableIndex>,
     distance_fn: Box<dyn F32VectorDistance + 'static>,
     posting_coder: Box<dyn F32VectorCoder + 'static>,
+    raw_coder: Box<dyn F32VectorCoder + 'static>,
 
     head_reader: SessionGraphVectorIndexReader,
     head_searcher: GraphSearcher,
@@ -249,12 +250,14 @@ impl SessionIndexWriter {
     pub fn new(index: Arc<TableIndex>, session: Session) -> Self {
         let distance_fn = index.head.config().new_distance_function();
         let posting_coder = index.config.posting_coder.new_coder();
+        let raw_coder = index.head.config().similarity.vector_coding().new_coder();
         let head_reader = SessionGraphVectorIndexReader::new(index.head.clone(), session);
         let head_searcher = GraphSearcher::new(index.config.head_search_params);
         Self {
             index,
             distance_fn,
             posting_coder,
+            raw_coder,
             head_reader,
             head_searcher,
         }
@@ -265,7 +268,6 @@ impl SessionIndexWriter {
     }
 
     pub fn upsert(&mut self, record_id: i64, vector: &[f32]) -> Result<Vec<u32>> {
-        let vector = self.distance_fn.normalize(vector.into());
         let candidates = self
             .head_searcher
             .search(vector.as_ref(), &mut self.head_reader)?;
@@ -283,15 +285,8 @@ impl SessionIndexWriter {
         }
 
         let mut raw_vector_cursor = self.raw_vector_cursor()?;
-        let vector = self.distance_fn.normalize(vector);
         // TODO: factor out handling of high fidelity vector tables.
-        raw_vector_cursor.set(
-            record_id,
-            &vector
-                .iter()
-                .flat_map(|d| d.to_le_bytes())
-                .collect::<Vec<_>>(),
-        )?;
+        raw_vector_cursor.set(record_id, &self.raw_coder.encode(vector))?;
         centroid_cursor.set(
             record_id,
             &centroid_ids

--- a/src/spann/bulk.rs
+++ b/src/spann/bulk.rs
@@ -127,12 +127,7 @@ pub fn bulk_load_raw_vectors(
                 .app_metadata(&serde_json::to_string(&index.config).unwrap()),
         ),
     )?;
-    let coder = index
-        .head_config()
-        .config()
-        .similarity
-        .vector_coding()
-        .new_coder();
+    let coder = index.head_config().config().rerank_format.new_coder();
     let mut encoded =
         Vec::with_capacity(coder.byte_len(index.head_config().config().dimensions.get()));
     for (record_id, vector) in vectors.iter().enumerate().take(limit) {

--- a/src/vectors/mod.rs
+++ b/src/vectors/mod.rs
@@ -210,6 +210,19 @@ impl FromStr for F32VectorCoding {
     }
 }
 
+impl std::fmt::Display for F32VectorCoding {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Raw => write!(f, "raw"),
+            Self::RawL2Normalized => write!(f, "raw-l2-norm"),
+            Self::BinaryQuantized => write!(f, "binary"),
+            Self::NBitBinaryQuantized(n) => write!(f, "asymmetric_binary:{}", *n),
+            Self::I8NaiveQuantized => write!(f, "i8-naive"),
+            Self::I8ScaledUniformQuantized => write!(f, "i8-scaled-uniform"),
+        }
+    }
+}
+
 /// Encode an f32 vector into byte stream, possibly quantizing the vector in the process.
 pub trait F32VectorCoder: Send + Sync {
     /// Encode the input vector and return the encoded byte buffer.

--- a/src/vectors/mod.rs
+++ b/src/vectors/mod.rs
@@ -44,14 +44,6 @@ impl VectorSimilarity {
             Self::Dot => Box::new(F32DotProductDistance),
         }
     }
-
-    /// Returns the default [F32VectorCoding] to use for this similarity function.
-    pub fn default_vector_coding(&self) -> F32VectorCoding {
-        match self {
-            Self::Euclidean => F32VectorCoding::Raw,
-            Self::Dot => F32VectorCoding::RawL2Normalized,
-        }
-    }
 }
 
 impl FromStr for VectorSimilarity {
@@ -361,8 +353,8 @@ mod test {
     use super::scaled_uniform::{I8ScaledUniformDotProduct, I8ScaledUniformEuclidean};
     use crate::vectors::i8naive::I8NaiveDistance;
     use crate::vectors::{
-        F32VectorCoder, I8NaiveVectorCoder, I8ScaledUniformVectorCoder, VectorDistance,
-        VectorSimilarity,
+        F32VectorCoder, F32VectorCoding, I8NaiveVectorCoder, I8ScaledUniformVectorCoder,
+        VectorDistance, VectorSimilarity,
     };
 
     struct TestVector {
@@ -376,7 +368,11 @@ mod test {
             similarity: VectorSimilarity,
             coder: impl F32VectorCoder,
         ) -> Self {
-            let f32_coder = similarity.default_vector_coding().new_coder();
+            let f32_coder = match similarity {
+                VectorSimilarity::Dot => F32VectorCoding::RawL2Normalized,
+                VectorSimilarity::Euclidean => F32VectorCoding::Raw,
+            }
+            .new_coder();
             let rvec = f32_coder
                 .encode(&rvec)
                 .chunks(4)

--- a/src/vectors/mod.rs
+++ b/src/vectors/mod.rs
@@ -198,7 +198,7 @@ impl FromStr for F32VectorCoding {
             }
             "i8-naive" => Ok(Self::I8NaiveQuantized),
             "i8-scaled-uniform" => Ok(Self::I8ScaledUniformQuantized),
-            _ => Err(input_err(format!("unknown quantizer function {s}"))),
+            _ => Err(input_err(format!("unknown vector coding function {s}"))),
         }
     }
 }

--- a/src/vectors/mod.rs
+++ b/src/vectors/mod.rs
@@ -46,7 +46,7 @@ impl VectorSimilarity {
     }
 
     /// Returns the default [F32VectorCoding] to use for this similarity function.
-    pub fn vector_coding(&self) -> F32VectorCoding {
+    pub fn default_vector_coding(&self) -> F32VectorCoding {
         match self {
             Self::Euclidean => F32VectorCoding::Raw,
             Self::Dot => F32VectorCoding::RawL2Normalized,
@@ -368,7 +368,7 @@ mod test {
             similarity: VectorSimilarity,
             coder: impl F32VectorCoder,
         ) -> Self {
-            let f32_coder = similarity.vector_coding().new_coder();
+            let f32_coder = similarity.default_vector_coding().new_coder();
             let rvec = f32_coder
                 .encode(&rvec)
                 .chunks(4)

--- a/src/vectors/mod.rs
+++ b/src/vectors/mod.rs
@@ -98,7 +98,7 @@ pub trait F32VectorDistance: VectorDistance {
 ///
 /// Raw vectors are stored little endian but the remaining formats are all lossy in some way with
 /// varying degrees of compression and fidelity in distance computation.
-#[derive(Debug, Copy, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub enum F32VectorCoding {
     /// Little-endian f32 values encoded as bytes.
     #[default]
@@ -173,6 +173,14 @@ impl F32VectorCoding {
     /// same coding. Only encodings that are symmetrical can be used for vectors stored on disk.
     pub fn is_symmetric(&self) -> bool {
         !matches!(self, Self::NBitBinaryQuantized(_))
+    }
+
+    /// Adjust raw format to normalize for angular ismilarity.
+    pub fn adjust_raw_format(&self, similarity: VectorSimilarity) -> Self {
+        match (self, similarity) {
+            (Self::Raw, VectorSimilarity::Dot) => Self::RawL2Normalized,
+            (_, _) => *self,
+        }
     }
 }
 

--- a/src/vectors/raw.rs
+++ b/src/vectors/raw.rs
@@ -103,14 +103,6 @@ impl F32VectorDistance for F32DotProductDistance {
         // Assuming values are normalized, this will produce a distance in [0,1]
         (-dot_f32(a, b) + 1.0) / 2.0
     }
-
-    fn normalize<'a>(&self, mut vector: Cow<'a, [f32]>) -> Cow<'a, [f32]> {
-        let norm = dot_f32(&vector, &vector).sqrt() as f32;
-        for d in vector.to_mut().iter_mut() {
-            *d /= norm;
-        }
-        vector
-    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/wt.rs
+++ b/src/wt.rs
@@ -183,6 +183,8 @@ pub struct TableGraphVectorIndex {
     config: GraphConfig,
 }
 
+// TODO: collapse raw and nav tables if the formats are the same.
+// TODO: embed configuration in metadata.
 impl TableGraphVectorIndex {
     /// Create a new `TableGraphVectorIndex` from the relevant db tables, extracting
     /// immutable graph metadata that can be used across operations.


### PR DESCRIPTION
Allow specifying a `rerank` format that is inserted into the raw vectors table. This allows us to replace the "raw"
vectors with high fidelity quantized vectors for space savings and faster reranking.