### PR TITLE
Unify vector interfaces in graph handling

### DIFF
--- a/et/src/exhaustive_search.rs
+++ b/et/src/exhaustive_search.rs
@@ -52,7 +52,7 @@ pub fn exhaustive_search(
     let distance_fn = index.config().new_distance_function();
 
     let session = connection.open_session()?;
-    let mut cursor = session.open_record_cursor(index.raw_table_name())?;
+    let mut cursor = session.open_record_cursor(index.rerank_table_name())?;
     let mut limit = std::cmp::max(cursor.largest_key().unwrap().unwrap() + 1, 0) as usize;
     limit = limit.min(args.record_limit.unwrap_or(usize::MAX));
     cursor.set_bounds(0..)?;

--- a/et/src/vamana/init_index.rs
+++ b/et/src/vamana/init_index.rs
@@ -69,7 +69,6 @@ pub fn init_index(
 
     TableGraphVectorIndex::init_index(
         &connection,
-        None,
         GraphConfig {
             dimensions: args.dimensions,
             similarity: args.similarity,

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -461,7 +461,8 @@ where
         reader: &mut BulkLoadGraphVectorIndexReader<'_, '_, D>,
         edges: &mut Vec<Neighbor>,
     ) -> Result<()> {
-        // XXX should this move into search_for_insert???
+        // TODO: consider moving this to search_for_insert() where it makes more sense to consider
+        // the additional vectors and there's more control over how it is done.
         if self.index.config().index_search_params.num_rerank > 0 {
             self.insert_in_flight_edges_from(
                 vertex_id,

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -346,7 +346,7 @@ where
                     // reranking is turned off.
                     let mut raw_vectors = reader.raw_vectors()?;
                     self.distance_fn
-                        .distance(&self.centroid, &raw_vectors.get(v as i64).unwrap()?)
+                        .distance(&self.centroid, raw_vectors.get(v as i64).unwrap()?)
                 };
 
                 // Add each edge to this vertex and a reciprocal edge to make the graph
@@ -531,7 +531,7 @@ where
             let in_flight_vertex_vector = vector_store.get(in_flight_vertex as i64).unwrap()?;
             let n = Neighbor::new(
                 in_flight_vertex as i64,
-                vertex_dist_fn.distance(&in_flight_vertex_vector),
+                vertex_dist_fn.distance(in_flight_vertex_vector),
             );
             // If the queue is full and n is worse than all other edges, skip.
             if edges.len() >= limit && n >= *edges.last().unwrap() {

--- a/src/crud.rs
+++ b/src/crud.rs
@@ -153,7 +153,7 @@ impl IndexMutator {
                     raw_vectors
                         .get(*e)
                         .unwrap_or(Err(Error::not_found_error()))
-                        .map(|dst| Neighbor::new(*e, distance_fn.distance(&src_vector, &dst)))
+                        .map(|dst| Neighbor::new(*e, distance_fn.distance(&src_vector, dst)))
                 })
                 .collect::<Result<Vec<Neighbor>>>()?;
             neighbors.sort();

--- a/src/crud.rs
+++ b/src/crud.rs
@@ -73,7 +73,7 @@ impl IndexMutator {
         let distance_fn = self.reader.config().new_distance_function();
         let mut candidate_edges = self.searcher.search(vector, &mut self.reader)?;
         let mut graph = self.reader.graph()?;
-        let mut raw_vectors = self.reader.raw_vectors()?;
+        let mut rerank_vectors = self.reader.rerank_vectors()?;
         if candidate_edges.is_empty() {
             // Proceed through the rest of the function so that the inserts happen.
             // This is mostly as a noop because there are no edges.
@@ -99,14 +99,14 @@ impl IndexMutator {
             .nav_vectors()?
             .set(vertex_id, self.nav_coder.encode(vector))?;
         self.reader
-            .raw_vectors()?
+            .rerank_vectors()?
             .set(vertex_id, self.rerank_coder.encode(vector))?;
 
         let mut pruned_edges = vec![];
         for src_vertex_id in candidate_edges.into_iter().map(|n| n.vertex()) {
             self.insert_edge(
                 &mut graph,
-                &mut raw_vectors,
+                &mut rerank_vectors,
                 distance_fn.as_ref(),
                 src_vertex_id,
                 vertex_id,
@@ -178,22 +178,21 @@ impl IndexMutator {
     pub fn delete(&mut self, vertex_id: i64) -> Result<()> {
         let distance_fn = self.reader.config().new_distance_function();
         let mut graph = self.reader.graph()?;
-        let mut raw_vectors = self.reader.raw_vectors()?;
+        let mut rerank_vectors = self.reader.rerank_vectors()?;
 
         let (vector, edges) = graph
             .get_vertex(vertex_id)
             .unwrap_or(Err(Error::not_found_error()))
             .map(|v| {
-                let raw_vector = raw_vectors
+                rerank_vectors
                     .get(vertex_id)
                     .expect("row exists")
-                    .map(|v| v.to_vec());
-                raw_vector.map(|rv| (rv, v.edges().collect::<Vec<_>>()))
+                    .map(|vec| (vec.to_vec(), v.edges().collect::<Vec<_>>()))
             })??;
 
         // TODO: unified graph index writer trait to handles removal and other mutations.
         graph.remove(vertex_id)?;
-        raw_vectors.remove(vertex_id)?;
+        rerank_vectors.remove(vertex_id)?;
         self.reader.nav_vectors()?.remove(vertex_id)?;
 
         // Cache information about each vertex linked to vertex_id.
@@ -205,11 +204,11 @@ impl IndexMutator {
                     .get_vertex(e)
                     .unwrap_or(Err(Error::not_found_error()))
                     .map(|v| {
-                        let raw_vector = raw_vectors
+                        let rerank_vector = rerank_vectors
                             .get(e)
                             .expect("row exists")
                             .map(|rv| rv.to_vec());
-                        raw_vector.map(|rv| {
+                        rerank_vector.map(|rv| {
                             (
                                 e,
                                 rv,

--- a/src/crud.rs
+++ b/src/crud.rs
@@ -376,7 +376,6 @@ mod tests {
             let index = Arc::new(
                 TableGraphVectorIndex::init_index(
                     &conn,
-                    None,
                     GraphConfig {
                         dimensions: NonZero::new(2).unwrap(),
                         similarity: VectorSimilarity::Euclidean,

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -159,9 +159,7 @@ pub trait GraphVectorStore {
     fn format(&self) -> F32VectorCoding;
 
     /// Return the contents of the vector at vertex, or `None` if the vertex is unknown.
-    // XXX this is actually unsafe for wt implementations! We use seek_exact_unsafe() and the
-    // pointer backing the slice is invalidated if the transaction is rolled back. Consider
-    // removing this method entirely?
+    // TODO: consider removing this method as it is _unsafe_ in the event of a rollback.
     fn get(&mut self, vertex_id: i64) -> Option<Result<&[u8]>>;
 
     // TODO: extract many vectors into VecVectorStore.

--- a/src/search.rs
+++ b/src/search.rs
@@ -201,7 +201,7 @@ impl GraphSearcher {
                 .unwrap_or(Err(Error::not_found_error()))?;
             self.candidates.add_unvisited(Neighbor::new(
                 entry_point,
-                nav_query.distance(&entry_vector),
+                nav_query.distance(entry_vector),
             ));
             self.seen.insert(entry_point);
         }
@@ -224,7 +224,7 @@ impl GraphSearcher {
                 }
                 let vec = nav.get(edge).unwrap_or(Err(Error::not_found_error()))?;
                 self.candidates
-                    .add_unvisited(Neighbor::new(edge, nav_query.distance(&vec)));
+                    .add_unvisited(Neighbor::new(edge, nav_query.distance(vec)));
             }
         }
 
@@ -243,7 +243,7 @@ impl GraphSearcher {
                 raw_vectors
                     .get(vertex)
                     .expect("row exists")
-                    .map(|rv| Neighbor::new(vertex, rerank_query.distance(&rv)))
+                    .map(|rv| Neighbor::new(vertex, rerank_query.distance(rv)))
             })
             .collect::<Result<Vec<_>>>();
         rescored.map(|mut r| {

--- a/src/spann.rs
+++ b/src/spann.rs
@@ -391,7 +391,7 @@ fn select_centroids(
             .expect("returned vector should exist")?;
         if !centroids
             .iter()
-            .any(|c| distance_fn.distance(c, &v) < candidate.distance())
+            .any(|c| distance_fn.distance(c, v) < candidate.distance())
         {
             centroid_ids.push(
                 candidate
@@ -399,7 +399,7 @@ fn select_centroids(
                     .try_into()
                     .expect("centroid_ids <= u32::MAX"),
             );
-            centroids.push(&v);
+            centroids.push(v);
         }
     }
     Ok(centroid_ids)

--- a/src/spann.rs
+++ b/src/spann.rs
@@ -376,7 +376,7 @@ fn select_centroids(
     replica_count: usize,
 ) -> Result<Vec<u32>> {
     assert!(!candidates.is_empty());
-    let mut raw_vectors = head_reader.raw_vectors()?;
+    let mut raw_vectors = head_reader.rerank_vectors()?;
 
     let mut centroid_ids: Vec<u32> = Vec::with_capacity(replica_count);
     let mut centroids =

--- a/src/spann.rs
+++ b/src/spann.rs
@@ -135,7 +135,6 @@ impl TableIndex {
     ) -> io::Result<Self> {
         let head = Arc::new(TableGraphVectorIndex::init_index(
             connection,
-            None,
             head_config,
             &Self::head_name(index_name),
         )?);

--- a/src/spann.rs
+++ b/src/spann.rs
@@ -23,7 +23,7 @@ use wt_mdb::{
 };
 
 use crate::{
-    graph::{GraphConfig, GraphSearchParams, GraphVectorIndexReader, RawVectorStore},
+    graph::{GraphConfig, GraphSearchParams, GraphVectorIndexReader, GraphVectorStore},
     input::{VecVectorStore, VectorStore},
     search::{GraphSearchStats, GraphSearcher},
     vectors::{
@@ -387,7 +387,7 @@ fn select_centroids(
         }
 
         let v = raw_vectors
-            .get_raw_vector(candidate.vertex())
+            .get(candidate.vertex())
             .expect("returned vector should exist")?;
         if !centroids
             .iter()

--- a/src/wt.rs
+++ b/src/wt.rs
@@ -174,6 +174,7 @@ impl GraphVectorStore for CursorVectorStore<'_> {
 #[derive(Clone)]
 pub struct TableGraphVectorIndex {
     graph_table_name: String,
+    // XXX rerank
     raw_table_name: String,
     nav_table_name: String,
     config: GraphConfig,
@@ -305,11 +306,11 @@ impl GraphVectorIndexReader for SessionGraphVectorIndexReader {
         = CursorGraph<'a>
     where
         Self: 'a;
-    type RawVectorStore<'a>
+    type NavVectorStore<'a>
         = CursorVectorStore<'a>
     where
         Self: 'a;
-    type NavVectorStore<'a>
+    type RerankVectorStore<'a>
         = CursorVectorStore<'a>
     where
         Self: 'a;
@@ -325,19 +326,19 @@ impl GraphVectorIndexReader for SessionGraphVectorIndexReader {
         ))
     }
 
-    fn raw_vectors(&self) -> Result<Self::RawVectorStore<'_>> {
-        Ok(CursorVectorStore::new(
-            self.session
-                .get_record_cursor(self.index.raw_table_name())?,
-            self.index.config().rerank_format,
-        ))
-    }
-
     fn nav_vectors(&self) -> Result<Self::NavVectorStore<'_>> {
         Ok(CursorVectorStore::new(
             self.session
                 .get_record_cursor(self.index.nav_table_name())?,
             self.index.config().nav_format,
+        ))
+    }
+
+    fn rerank_vectors(&self) -> Result<Self::RerankVectorStore<'_>> {
+        Ok(CursorVectorStore::new(
+            self.session
+                .get_record_cursor(self.index.raw_table_name())?,
+            self.index.config().rerank_format,
         ))
     }
 }

--- a/src/wt.rs
+++ b/src/wt.rs
@@ -21,6 +21,7 @@ use crate::{
 /// Key in the graph table containing the entry point.
 pub const ENTRY_POINT_KEY: i64 = -1;
 /// Key in the graph table containing configuration.
+// XXX replace with app_metadata.
 pub const CONFIG_KEY: i64 = -2;
 
 fn read_app_metadata_internal(session: &Session, table_name: &str) -> Result<String> {

--- a/src/wt.rs
+++ b/src/wt.rs
@@ -4,7 +4,7 @@
 //! is recommeded that callers begin a transaction before performing their search or mutation
 //! and commit or rollback the transaction when they are done.
 
-use std::{borrow::Cow, ffi::CString, io, sync::Arc};
+use std::{ffi::CString, io, sync::Arc};
 
 use rustix::io::Errno;
 use wt_mdb::{
@@ -14,9 +14,7 @@ use wt_mdb::{
 };
 
 use crate::{
-    graph::{
-        Graph, GraphConfig, GraphVectorIndexReader, GraphVectorStore, GraphVertex, RawVectorStore,
-    },
+    graph::{Graph, GraphConfig, GraphVectorIndexReader, GraphVectorStore, GraphVertex},
     vectors::F32VectorCoding,
 };
 
@@ -167,12 +165,6 @@ impl GraphVectorStore for CursorVectorStore<'_> {
 
     fn get(&mut self, vertex_id: i64) -> Option<Result<&[u8]>> {
         Some(unsafe { self.0.seek_exact_unsafe(vertex_id)? })
-    }
-}
-
-impl RawVectorStore for CursorVectorStore<'_> {
-    fn get_raw_vector(&mut self, vertex_id: i64) -> Option<Result<Cow<'_, [u8]>>> {
-        self.get(vertex_id).map(|r| r.map(|v| v.into()))
     }
 }
 


### PR DESCRIPTION
This makes it easier to treat nav and rerank vectors as interchangeable, so that in the future may we go down to
just one vector table when high fidelity vectors are available.

Replace "raw" with "rerank" in most spots.

Use `app_metadata` to store configuration information instead of a special key.