### PR TITLE
Packed `i4` scaled uniform quantization

### DIFF
--- a/src/vectors/mod.rs
+++ b/src/vectors/mod.rs
@@ -213,7 +213,6 @@ impl FromStr for F32VectorCoding {
             "i8-naive" => Ok(Self::I8NaiveQuantized),
             "i8-scaled-uniform" => Ok(Self::I8ScaledUniformQuantized),
             "i4-scaled-uniform" => Ok(Self::I4ScaledUniformQuantized),
-            _ => Err(input_err(format!("unknown quantizer function {s}"))),
             _ => Err(input_err(format!("unknown vector coding {s}"))),
         }
     }

--- a/src/vectors/mod.rs
+++ b/src/vectors/mod.rs
@@ -507,7 +507,7 @@ mod test {
     fn i4_scaled_dot() {
         // TODO: randomly generate a bunch of vectors for this test.
         distance_compare_threshold(
-            F32DotProductDistance,
+            VectorSimilarity::Dot,
             I4PackedVectorCoder,
             I4PackedDotProductDistance,
             vec![-1.0f32, 2.5, 0.7, -1.7],
@@ -519,7 +519,7 @@ mod test {
     #[test]
     fn i4_scaled_l2() {
         distance_compare_threshold(
-            F32EuclideanDistance,
+            VectorSimilarity::Euclidean,
             I4PackedVectorCoder,
             I4PackedEuclideanDistance,
             vec![-1.0f32, 2.5, 0.7, -1.7],

--- a/src/vectors/scaled_uniform.rs
+++ b/src/vectors/scaled_uniform.rs
@@ -14,22 +14,24 @@ use crate::{
     vectors::{F32VectorCoder, QueryVectorDistance, VectorDistance},
 };
 
+fn compute_scale<const M: i8>(vector: &[f32]) -> (f32, f32) {
+    if let Some(max) = vector.iter().map(|d| d.abs()).max_by(|a, b| a.total_cmp(b)) {
+        (
+            (f64::from(M) / max as f64) as f32,
+            (max as f64 / f64::from(M)) as f32,
+        )
+    } else {
+        (0.0, 0.0)
+    }
+}
+
 #[derive(Debug, Copy, Clone)]
 pub struct I8ScaledUniformVectorCoder;
 
 impl F32VectorCoder for I8ScaledUniformVectorCoder {
     fn encode_to(&self, vector: &[f32], out: &mut [u8]) {
         let l2_norm = crate::distance::dot_f32(vector, vector).sqrt() as f32;
-        let (scale, inv_scale) =
-            if let Some(max) = vector.iter().map(|d| d.abs()).max_by(|a, b| a.total_cmp(b)) {
-                (
-                    (f64::from(i8::MAX) / max as f64) as f32,
-                    (max as f64 / f64::from(i8::MAX)) as f32,
-                )
-            } else {
-                (0.0, 0.0)
-            };
-
+        let (scale, inv_scale) = compute_scale::<{ i8::MAX }>(vector);
         out[0..4].copy_from_slice(&inv_scale.to_le_bytes());
         out[4..8].copy_from_slice(&l2_norm.to_le_bytes());
         for (d, o) in vector.iter().zip(out[8..].iter_mut()) {
@@ -164,5 +166,151 @@ impl QueryVectorDistance for I8ScaledUniformEuclideanQueryDistance<'_> {
             .map(|(q, d)| *q * d)
             .sum::<f32>() as f64;
         self.1 + vector.l2_norm_sq() - (2.0 * dot)
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct I4PackedVectorCoder;
+
+impl F32VectorCoder for I4PackedVectorCoder {
+    fn encode_to(&self, vector: &[f32], out: &mut [u8]) {
+        let l2_norm = crate::distance::dot_f32(vector, vector).sqrt() as f32;
+        let (scale, inv_scale) = compute_scale::<7>(vector);
+        out[0..4].copy_from_slice(&inv_scale.to_le_bytes());
+        out[4..8].copy_from_slice(&l2_norm.to_le_bytes());
+        // Encode two at a time and pack them together in a single byte. Use offset binary coding
+        // to avoid problems with sign extension happening or not happening when intended.
+        for (c, o) in vector.chunks(2).zip(out[8..].iter_mut()) {
+            let lo = (c[0] * scale).round() as i8;
+            let hi = (c.get(1).unwrap_or(&0.0) * scale).round() as i8;
+            *o = ((lo + 7) as u8) | (((hi + 7) as u8) << 4)
+        }
+    }
+
+    fn byte_len(&self, dimensions: usize) -> usize {
+        dimensions.div_ceil(2) + std::mem::size_of::<f32>() * 2
+    }
+}
+
+struct I4PackedVector<'a>(&'a [u8]);
+
+impl<'a> I4PackedVector<'a> {
+    fn new(vector: &'a [u8]) -> Option<Self> {
+        if vector.len() <= std::mem::size_of::<f32>() * 2 {
+            None
+        } else {
+            Some(Self(vector))
+        }
+    }
+
+    fn scale(&self) -> f64 {
+        f32::from_le_bytes(self.0[0..4].try_into().expect("4 bytes")).into()
+    }
+
+    fn l2_norm(&self) -> f64 {
+        f32::from_le_bytes(self.0[4..8].try_into().expect("4 bytes")).into()
+    }
+
+    fn l2_norm_sq(&self) -> f64 {
+        self.l2_norm() * self.l2_norm()
+    }
+
+    fn dimensions(&self) -> &[u8] {
+        &self.0[8..]
+    }
+
+    fn unpack(x: u8) -> [i8; 2] {
+        [((x & 0xf) as i8) - 7, ((x >> 4) as i8) - 7]
+    }
+
+    fn dot_unnormalized(&self, other: &Self) -> f64 {
+        self.dimensions()
+            .iter()
+            .zip(other.dimensions().iter())
+            .map(|(q, d)| {
+                let q = Self::unpack(*q);
+                let d = Self::unpack(*d);
+                (q[0] * d[0] + q[1] * d[1]) as i32
+            })
+            .sum::<i32>() as f64
+            * self.scale()
+            * other.scale()
+    }
+
+    fn dot_unnormalized_f32(&self, other: &[f32]) -> f64 {
+        let mut dim_it = self.dimensions().iter();
+        let mut other_it = other.chunks_exact(2);
+        let mut dot = dim_it
+            .by_ref()
+            .zip(other_it.by_ref())
+            .map(|(d, c)| {
+                let d = Self::unpack(*d);
+                d[0] as f32 * c[0] + d[1] as f32 * c[1]
+            })
+            .sum::<f32>();
+        dot += dim_it
+            .zip(other_it.remainder())
+            .map(|(d, o)| (*d - 15) as f32 * *o)
+            .sum::<f32>();
+        // NB: other.scale() is implicitly 1.
+        dot as f64 * self.scale()
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct I4PackedDotProductDistance;
+
+impl VectorDistance for I4PackedDotProductDistance {
+    fn distance(&self, query: &[u8], doc: &[u8]) -> f64 {
+        let query = I4PackedVector::new(query).expect("valid format");
+        let doc = I4PackedVector::new(doc).expect("valid format");
+        let dot = query.dot_unnormalized(&doc) * query.l2_norm().recip() * doc.l2_norm().recip();
+        (-dot + 1.0) / 2.0
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct I4PackedDotProductQueryDistance<'a>(Cow<'a, [f32]>);
+
+impl<'a> I4PackedDotProductQueryDistance<'a> {
+    pub fn new(query: &'a [f32]) -> Self {
+        Self(l2_normalize(query))
+    }
+}
+
+impl QueryVectorDistance for I4PackedDotProductQueryDistance<'_> {
+    fn distance(&self, vector: &[u8]) -> f64 {
+        let vector = I4PackedVector::new(vector).expect("valid format");
+        let dot = vector.dot_unnormalized_f32(self.0.as_ref()) * vector.l2_norm().recip();
+        (-dot + 1.0) / 2.0
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct I4PackedEuclideanDistance;
+
+impl VectorDistance for I4PackedEuclideanDistance {
+    fn distance(&self, query: &[u8], doc: &[u8]) -> f64 {
+        let query = I4PackedVector::new(query).expect("valid format");
+        let doc = I4PackedVector::new(doc).expect("valid format");
+        let dot = query.dot_unnormalized(&doc);
+        query.l2_norm_sq() + doc.l2_norm_sq() - (2.0 * dot)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct I4PackedEuclideanQueryDistance<'a>(&'a [f32]);
+
+impl<'a> I4PackedEuclideanQueryDistance<'a> {
+    pub fn new(query: &'a [f32]) -> Self {
+        Self(query)
+    }
+}
+
+impl QueryVectorDistance for I4PackedEuclideanQueryDistance<'_> {
+    fn distance(&self, vector: &[u8]) -> f64 {
+        let vector = I4PackedVector::new(vector).expect("valid format");
+        let dot = vector.dot_unnormalized_f32(self.0.as_ref());
+        vector.l2_norm_sq() - (2.0 * dot)
     }
 }

--- a/src/vectors/scaled_uniform.rs
+++ b/src/vectors/scaled_uniform.rs
@@ -301,11 +301,11 @@ impl VectorDistance for I4PackedEuclideanDistance {
 }
 
 #[derive(Debug, Clone)]
-pub struct I4PackedEuclideanQueryDistance<'a>(&'a [f32]);
+pub struct I4PackedEuclideanQueryDistance<'a>(&'a [f32], f64);
 
 impl<'a> I4PackedEuclideanQueryDistance<'a> {
     pub fn new(query: &'a [f32]) -> Self {
-        Self(query)
+        Self(query, dot_f32(query, query).sqrt())
     }
 }
 
@@ -313,7 +313,7 @@ impl QueryVectorDistance for I4PackedEuclideanQueryDistance<'_> {
     fn distance(&self, vector: &[u8]) -> f64 {
         let vector = I4PackedVector::new(vector).expect("valid format");
         let dot = vector.dot_unnormalized_f32(self.0.as_ref());
-        // XXX i need to add query l2 norm here.
-        vector.l2_norm_sq() - (2.0 * dot)
+        // XXX I need to write a test for this first.
+        self.1 + vector.l2_norm_sq() - (2.0 * dot)
     }
 }

--- a/src/vectors/scaled_uniform.rs
+++ b/src/vectors/scaled_uniform.rs
@@ -251,7 +251,7 @@ impl<'a> I4PackedVector<'a> {
             .sum::<f32>();
         dot += dim_it
             .zip(other_it.remainder())
-            .map(|(d, o)| (*d - 15) as f32 * *o)
+            .map(|(d, o)| (*d - 7) as f32 * *o)
             .sum::<f32>();
         // NB: other.scale() is implicitly 1.
         dot as f64 * self.scale()

--- a/src/vectors/scaled_uniform.rs
+++ b/src/vectors/scaled_uniform.rs
@@ -305,7 +305,7 @@ pub struct I4PackedEuclideanQueryDistance<'a>(&'a [f32], f64);
 
 impl<'a> I4PackedEuclideanQueryDistance<'a> {
     pub fn new(query: &'a [f32]) -> Self {
-        Self(query, dot_f32(query, query).sqrt())
+        Self(query, dot_f32(query, query))
     }
 }
 
@@ -313,7 +313,6 @@ impl QueryVectorDistance for I4PackedEuclideanQueryDistance<'_> {
     fn distance(&self, vector: &[u8]) -> f64 {
         let vector = I4PackedVector::new(vector).expect("valid format");
         let dot = vector.dot_unnormalized_f32(self.0.as_ref());
-        // XXX I need to write a test for this first.
         self.1 + vector.l2_norm_sq() - (2.0 * dot)
     }
 }

--- a/src/vectors/scaled_uniform.rs
+++ b/src/vectors/scaled_uniform.rs
@@ -103,10 +103,6 @@ impl VectorDistance for I8ScaledUniformDotProduct {
     fn distance(&self, query: &[u8], doc: &[u8]) -> f64 {
         let query = I8ScaledUniformVector::from(query);
         let doc = I8ScaledUniformVector::from(doc);
-        // XXX _horrid_ recall. why???
-        // experiment: randomly generate a bunch of vectors and normalize them.
-        // pick 1 and compute both l2 distance and angular distance, then compare the order. they
-        // should be the same if both are normalized.
         let dot = query.dot_unnormalized(&doc) * query.l2_norm().recip() * doc.l2_norm().recip();
         (-dot + 1.0) / 2.0
     }
@@ -126,7 +122,6 @@ impl QueryVectorDistance for I8ScaledUniformDotProductQueryDistance<'_> {
         // TODO: benchmark performing dot product of query and doc without scaling, then scaling
         // afterward. This would avoid a multiplication per dimension.
         let vector = I8ScaledUniformVector::from(vector);
-        // XXX _horrid_ recall
         let dot = self
             .0
             .iter()
@@ -272,8 +267,6 @@ impl VectorDistance for I4PackedDotProductDistance {
         let query = I4PackedVector::new(query).expect("valid format");
         let doc = I4PackedVector::new(doc).expect("valid format");
         let dot = query.dot_unnormalized(&doc) * query.l2_norm().recip() * doc.l2_norm().recip();
-        // XXX something about this is hella broken, because recall is _awful_.
-        assert!(-1.0 <= dot && dot <= 1.0, "dot={}", dot);
         (-dot + 1.0) / 2.0
     }
 }

--- a/src/vectors/scaled_uniform.rs
+++ b/src/vectors/scaled_uniform.rs
@@ -129,7 +129,6 @@ impl QueryVectorDistance for I8ScaledUniformDotProductQueryDistance<'_> {
             .map(|(q, d)| *q * d)
             .sum::<f32>() as f64
             / vector.l2_norm();
-        assert!(-1.0 <= dot && dot <= 1.0, "dot={}", dot);
         (-dot + 1.0) / 2.0
     }
 }


### PR DESCRIPTION
This utilizes the same scaling/shaping behavior is `i8-scaled-uniform` but quantizes to 4 bit values and packs two
dimension per byte, halving the amount of required storage. This comes at a 3-4% recall hit.

During packing values are offset binary encoded to ease unpacking -- we can mask and subtract to get sign extension
on negative values. This adds a couple of instructions on core decoding.