### PR TITLE
Scaled non-uniform quantization (i8)

### DIFF
--- a/src/vectors/mod.rs
+++ b/src/vectors/mod.rs
@@ -3,7 +3,10 @@
 use std::{borrow::Cow, fmt::Debug, io, num::ParseIntError, ops::Deref, str::FromStr};
 
 use crate::vectors::{
-    binary::{AsymmetricHammingDistance, HammingDistance},
+    binary::{
+        AsymmetricBinaryQuantizedVectorCoder, AsymmetricHammingDistance,
+        BinaryQuantizedVectorCoder, HammingDistance,
+    },
     raw::{
         F32DotProductDistance, F32EuclideanDistance, F32QueryVectorDistance, RawF32VectorCoder,
         RawL2NormalizedF32VectorCoder,
@@ -15,8 +18,10 @@ mod raw;
 mod scaled_non_uniform;
 mod scaled_uniform;
 
-pub(crate) use binary::{AsymmetricBinaryQuantizedVectorCoder, BinaryQuantizedVectorCoder};
 use serde::{Deserialize, Serialize};
+
+// Re-export to scaled_non_uniform to vector accelerate f32 x quantized distance.
+use scaled_uniform::dot_unnormalized_i8_f32;
 
 /// Functions used for to compute the distance between two vectors.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]

--- a/src/vectors/mod.rs
+++ b/src/vectors/mod.rs
@@ -625,8 +625,7 @@ mod test {
         let splits = NonUniformQuantizedDimensions::try_from([2u16].as_slice()).unwrap();
         for (i, (a, b)) in test_float_vectors().into_iter().enumerate() {
             distance_compare(Dot, I8ScaledNonUniformQuantized(splits), i, &a, &b, 0.01);
-            // XXX figure out why
-            query_distance_compare(Dot, I8ScaledNonUniformQuantized(splits), i, &a, &b, 0.99);
+            query_distance_compare(Dot, I8ScaledNonUniformQuantized(splits), i, &a, &b, 0.01);
         }
     }
 

--- a/src/vectors/mod.rs
+++ b/src/vectors/mod.rs
@@ -627,10 +627,12 @@ mod test {
 
     #[test]
     fn i8_scaled_non_uniform_dot() {
-        let splits = NonUniformQuantizedDimensions::try_from([2u16].as_slice()).unwrap();
+        let format = I8ScaledNonUniformQuantized(
+            NonUniformQuantizedDimensions::try_from([2u16].as_slice()).unwrap(),
+        );
         for (i, (a, b)) in test_float_vectors().into_iter().enumerate() {
-            distance_compare(Dot, I8ScaledNonUniformQuantized(splits), i, &a, &b, 0.01);
-            query_distance_compare(Dot, I8ScaledNonUniformQuantized(splits), i, &a, &b, 0.01);
+            distance_compare(Dot, format, i, &a, &b, 0.01);
+            query_distance_compare(Dot, format, i, &a, &b, 0.01);
         }
     }
 

--- a/src/vectors/mod.rs
+++ b/src/vectors/mod.rs
@@ -44,12 +44,21 @@ impl FromStr for VectorSimilarity {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "euclidean" => Ok(VectorSimilarity::Euclidean),
+            "euclidean" | "l2" => Ok(VectorSimilarity::Euclidean),
             "dot" => Ok(VectorSimilarity::Dot),
             x => Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 format!("unknown similarity function {x}"),
             )),
+        }
+    }
+}
+
+impl std::fmt::Display for VectorSimilarity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Dot => write!(f, "dot"),
+            Self::Euclidean => write!(f, "l2"),
         }
     }
 }
@@ -283,7 +292,6 @@ impl std::fmt::Display for F32VectorCoding {
                 f,
                 "i8-scaled-non-uniform:{}",
                 splits
-                    .0
                     .iter()
                     .map(|s| s.to_string())
                     .collect::<Vec<_>>()

--- a/src/vectors/scaled_non_uniform.rs
+++ b/src/vectors/scaled_non_uniform.rs
@@ -1,0 +1,258 @@
+//! Scaled non-uniform coding divides the segment into several splits based on manually specified
+//! split points. Within each segment we compute the maximum absolute value across all dimensions
+//! and use this to produce an i8 value in [-127,127]. Each segment has its own stored scaling
+//! factor; we also store the squared l2 norm for adjusting the final distances to produces scores
+//! in the same ranges as float scoring. This may be useful for MRL representation vectors that are
+//! designed to be truncated at fix points, where later segments are "less important".
+//!
+//! Unlike some other quantization schemes this does not rely on anything computed across a sample
+//! of the data set -- no means or centroids, no quantiles. For transformer models which produce
+//! relatively well centered vectors this seems to be effective enough that we may discard the
+//! original f32 vectors.
+
+use std::{borrow::Cow, ops::Range};
+
+use crate::{
+    distance::{dot_f32, l2_normalize},
+    vectors::{F32VectorCoder, NonUniformQuantizedDimensions, QueryVectorDistance, VectorDistance},
+};
+
+fn compute_scale<const M: i8>(vector: &[f32]) -> (f32, f32) {
+    if let Some(max) = vector.iter().map(|d| d.abs()).max_by(|a, b| a.total_cmp(b)) {
+        (
+            (f64::from(M) / max as f64) as f32,
+            (max as f64 / f64::from(M)) as f32,
+        )
+    } else {
+        (0.0, 0.0)
+    }
+}
+
+fn split_dim_iterator<'a>(
+    splits: &'a [u16],
+    vector_len: usize,
+) -> impl Iterator<Item = Range<usize>> + 'a {
+    std::iter::once(0)
+        .chain(splits.iter().map(|s| *s as usize))
+        .zip(
+            splits
+                .iter()
+                .map(|s| *s as usize)
+                .chain(std::iter::once(vector_len)),
+        )
+        .map(|(s, e)| s..e)
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct I8VectorCoder(NonUniformQuantizedDimensions);
+
+impl I8VectorCoder {
+    pub fn new(splits: NonUniformQuantizedDimensions) -> Self {
+        Self(splits)
+    }
+
+    fn split_iterator<'a, 'b>(
+        &'b self,
+        vector: &'a [f32],
+    ) -> impl Iterator<Item = &'a [f32]> + use<'a, 'b> {
+        split_dim_iterator(&self.0, vector.len()).map(|r| &vector[r])
+    }
+}
+
+impl F32VectorCoder for I8VectorCoder {
+    fn encode_to(&self, vector: &[f32], out: &mut [u8]) {
+        let l2_norm = crate::distance::dot_f32(vector, vector).sqrt() as f32;
+        let scales = self
+            .split_iterator(vector)
+            .map(compute_scale::<{ i8::MAX }>)
+            .collect::<Vec<_>>();
+        out[0..4].copy_from_slice(&l2_norm.to_le_bytes());
+        let mut output_index = 4usize;
+        for inv_scale in scales.iter().map(|(_, s)| *s) {
+            out[output_index..(output_index + 4)].copy_from_slice(&inv_scale.to_le_bytes());
+            output_index += 4;
+        }
+        for (scale, v) in scales
+            .iter()
+            .map(|(s, _)| *s)
+            .zip(self.split_iterator(vector))
+        {
+            for (d, o) in v.iter().zip(out[output_index..].iter_mut()) {
+                *o = ((*d * scale).round() as i8).to_le_bytes()[0];
+            }
+            output_index += v.len();
+        }
+    }
+
+    fn byte_len(&self, dimensions: usize) -> usize {
+        // Store
+        dimensions + std::mem::size_of::<f32>() * (self.0.len() + 1)
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+struct I8Vector<'a, 'b> {
+    splits: &'a [u16],
+    raw_vector: &'b [u8],
+    vector_base: usize,
+}
+
+impl<'a, 'b> I8Vector<'a, 'b> {
+    fn new(splits: &'a [u16], raw_vector: &'b [u8]) -> Self {
+        let vector_base = std::mem::size_of::<f32>() * (splits.len() + 2);
+        Self {
+            splits,
+            raw_vector,
+            vector_base,
+        }
+    }
+
+    fn l2_norm_sq(&self) -> f64 {
+        self.l2_norm() * self.l2_norm()
+    }
+
+    fn l2_norm(&self) -> f64 {
+        f32::from_le_bytes(self.raw_vector[0..4].try_into().unwrap()).into()
+    }
+
+    fn segments(&self) -> impl Iterator<Item = (f32, &[i8])> {
+        let scale_it = self.raw_vector[std::mem::size_of::<f32>()..].chunks(4);
+        let vector = &self.raw_vector[self.vector_base..];
+        scale_it
+            .zip(split_dim_iterator(self.splits, vector.len()))
+            .map(|(s, r)| {
+                (
+                    f32::from_le_bytes(s.try_into().expect("4 bytes")),
+                    bytemuck::cast_slice(&vector[r]),
+                )
+            })
+    }
+
+    fn segment_dot_unnormalized(a: (f32, &[i8]), b: (f32, &[i8])) -> f64 {
+        a.1.iter()
+            .zip(b.1.iter())
+            .map(|(a, b)| *a as i32 * *b as i32)
+            .sum::<i32>() as f64
+            * a.0 as f64
+            * b.0 as f64
+    }
+
+    fn dot_unnormalized(&self, other: &Self) -> f64 {
+        self.segments()
+            .zip(other.segments())
+            .map(|(a, b)| Self::segment_dot_unnormalized(a, b))
+            .sum::<f64>()
+    }
+
+    fn dequantized_unnormalized_iter(&self) -> impl Iterator<Item = f32> + '_ {
+        self.segments()
+            .flat_map(|(scale, v)| v.iter().map(move |d| *d as f32 * scale))
+    }
+
+    fn dequantized_normalized_iter(&self) -> impl Iterator<Item = f32> + '_ {
+        let inv_norm = self.l2_norm().recip() as f32;
+        self.segments().flat_map(move |(s, v)| {
+            let scale = s * inv_norm;
+            v.iter().map(move |d| *d as f32 * scale)
+        })
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct I8DotProductDistance(NonUniformQuantizedDimensions);
+
+impl I8DotProductDistance {
+    pub fn new(splits: NonUniformQuantizedDimensions) -> Self {
+        Self(splits)
+    }
+}
+
+impl VectorDistance for I8DotProductDistance {
+    fn distance(&self, query: &[u8], doc: &[u8]) -> f64 {
+        let query = I8Vector::new(&self.0, query);
+        let doc = I8Vector::new(&self.0, doc);
+        let dot = query.dot_unnormalized(&doc) * query.l2_norm().recip() * doc.l2_norm().recip();
+        (-dot + 1.0) / 2.0
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct I8DotProductQueryDistance<'a> {
+    splits: NonUniformQuantizedDimensions,
+    query: Cow<'a, [f32]>,
+}
+
+impl<'a> I8DotProductQueryDistance<'a> {
+    pub fn new(splits: NonUniformQuantizedDimensions, query: &'a [f32]) -> Self {
+        Self {
+            splits,
+            query: l2_normalize(query),
+        }
+    }
+}
+
+impl QueryVectorDistance for I8DotProductQueryDistance<'_> {
+    fn distance(&self, vector: &[u8]) -> f64 {
+        // TODO: benchmark performing dot product of query and doc without scaling, then scaling
+        // afterward. This would avoid a multiplication per dimension.
+        let vector = I8Vector::new(&self.splits, vector);
+        let dot = self
+            .query
+            .iter()
+            .zip(vector.dequantized_normalized_iter())
+            .map(|(q, d)| *q * d)
+            .sum::<f32>() as f64
+            / vector.l2_norm();
+        (-dot + 1.0) / 2.0
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct I8EuclideanDistance(NonUniformQuantizedDimensions);
+
+impl I8EuclideanDistance {
+    pub fn new(splits: NonUniformQuantizedDimensions) -> Self {
+        Self(splits)
+    }
+}
+
+impl VectorDistance for I8EuclideanDistance {
+    fn distance(&self, query: &[u8], doc: &[u8]) -> f64 {
+        let query = I8Vector::new(&self.0, query);
+        let doc = I8Vector::new(&self.0, doc);
+        let dot = query.dot_unnormalized(&doc);
+        query.l2_norm_sq() + doc.l2_norm_sq() - (2.0 * dot)
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct I8EuclideanQueryDistance<'a> {
+    splits: NonUniformQuantizedDimensions,
+    query: &'a [f32],
+    l2_norm_sq: f64,
+}
+
+impl<'a> I8EuclideanQueryDistance<'a> {
+    pub fn new(splits: NonUniformQuantizedDimensions, query: &'a [f32]) -> Self {
+        Self {
+            splits,
+            query,
+            l2_norm_sq: dot_f32(query, query),
+        }
+    }
+}
+
+impl QueryVectorDistance for I8EuclideanQueryDistance<'_> {
+    fn distance(&self, vector: &[u8]) -> f64 {
+        // TODO: benchmark performing dot product of query and doc without scaling, then scaling
+        // afterward. This would avoid a multiplication per dimension.
+        let vector = I8Vector::new(&self.splits, vector);
+        let dot = self
+            .query
+            .iter()
+            .zip(vector.dequantized_unnormalized_iter())
+            .map(|(q, d)| *q * d)
+            .sum::<f32>() as f64;
+        self.l2_norm_sq + vector.l2_norm_sq() - (2.0 * dot)
+    }
+}

--- a/src/vectors/scaled_non_uniform.rs
+++ b/src/vectors/scaled_non_uniform.rs
@@ -86,7 +86,7 @@ impl F32VectorCoder for I8VectorCoder {
 
     fn byte_len(&self, dimensions: usize) -> usize {
         // Store
-        dimensions + std::mem::size_of::<f32>() * (self.0.len() + 1)
+        dimensions + std::mem::size_of::<f32>() * (self.0.len() + 2)
     }
 }
 

--- a/src/vectors/scaled_non_uniform.rs
+++ b/src/vectors/scaled_non_uniform.rs
@@ -88,6 +88,15 @@ impl F32VectorCoder for I8VectorCoder {
         // Store
         dimensions + std::mem::size_of::<f32>() * (self.0.len() + 2)
     }
+
+    fn decode(&self, encoded: &[u8]) -> Option<Vec<f32>> {
+        let v = I8Vector::new(&self.0, encoded);
+        Some(
+            v.segments()
+                .flat_map(|(scale, bytes)| bytes.iter().map(move |d| *d as f32 * scale))
+                .collect(),
+        )
+    }
 }
 
 #[derive(Debug, Copy, Clone)]

--- a/src/vectors/scaled_non_uniform.rs
+++ b/src/vectors/scaled_non_uniform.rs
@@ -156,7 +156,7 @@ impl<'a, 'b> I8Vector<'a, 'b> {
 
     fn dot_unnormalized_f32(&self, other: &[f32]) -> f64 {
         self.segments()
-            .zip(split_dim_iterator(&self.splits, other.len()).map(|r| &other[r]))
+            .zip(split_dim_iterator(self.splits, other.len()).map(|r| &other[r]))
             .map(|(q, f)| dot_unnormalized_i8_f32(q.1, q.0 as f64, f))
             .sum::<f64>()
     }

--- a/src/vectors/scaled_uniform.rs
+++ b/src/vectors/scaled_uniform.rs
@@ -53,15 +53,7 @@ impl F32VectorCoder for I8VectorCoder {
     }
 }
 
-// Computes unnormalized dot between `quantized` + `scale` x `float` vectors.
-pub(super) fn dot_unnormalized_i8_f32(quantized: &[i8], scale: f64, float: &[f32]) -> f64 {
-    if cfg!(target_arch = "aarch64") {
-        dot_unnormalized_i8_f32_aarch64(quantized, scale, float)
-    } else {
-        dot_unnormalized_i8_f32_scalar(quantized, scale, float)
-    }
-}
-
+#[allow(dead_code)]
 fn dot_unnormalized_i8_f32_scalar(quantized: &[i8], scale: f64, float: &[f32]) -> f64 {
     quantized
         .iter()
@@ -109,6 +101,18 @@ fn dot_unnormalized_i8_f32_aarch64(quantized: &[i8], scale: f64, float: &[f32]) 
         .map(|(s, o)| *s as f32 * *o)
         .sum::<f32>();
     sum as f64 * scale
+}
+
+// Computes unnormalized dot between `quantized` + `scale` x `float` vectors.
+#[cfg(target_arch = "aarch64")]
+pub(super) fn dot_unnormalized_i8_f32(quantized: &[i8], scale: f64, float: &[f32]) -> f64 {
+    dot_unnormalized_i8_f32_aarch64(quantized, scale, float)
+}
+
+// Computes unnormalized dot between `quantized` + `scale` x `float` vectors.
+#[cfg(not(target_arch = "aarch64"))]
+pub(super) fn dot_unnormalized_i8_f32(quantized: &[i8], scale: f64, float: &[f32]) -> f64 {
+    dot_unnormalized_i8_f32_scalar(quantized, scale, float)
 }
 
 #[derive(Debug, Copy, Clone)]

--- a/src/vectors/scaled_uniform.rs
+++ b/src/vectors/scaled_uniform.rs
@@ -53,8 +53,63 @@ impl F32VectorCoder for I8VectorCoder {
     }
 }
 
-// TODO: quantizer that is non-uniform for MRL vectors.
-// Bonus points if it can still be scored on the quantized rep instead of de-quantizing.
+// Computes unnormalized dot between `quantized` + `scale` x `float` vectors.
+pub(super) fn dot_unnormalized_i8_f32(quantized: &[i8], scale: f64, float: &[f32]) -> f64 {
+    if cfg!(target_arch = "aarch64") {
+        dot_unnormalized_i8_f32_aarch64(quantized, scale, float)
+    } else {
+        dot_unnormalized_i8_f32_scalar(quantized, scale, float)
+    }
+}
+
+fn dot_unnormalized_i8_f32_scalar(quantized: &[i8], scale: f64, float: &[f32]) -> f64 {
+    quantized
+        .iter()
+        .zip(float.iter())
+        .map(|(s, o)| *s as f32 * *o)
+        .sum::<f32>() as f64
+        * scale
+}
+
+#[cfg(target_arch = "aarch64")]
+fn dot_unnormalized_i8_f32_aarch64(quantized: &[i8], scale: f64, float: &[f32]) -> f64 {
+    let split = quantized.len() & !15;
+    let mut sum = unsafe {
+        use std::arch::aarch64::{
+            vaddvq_f32, vcvtq_f32_s32, vdupq_n_f32, vfmaq_f32, vget_low_s8, vget_low_s16,
+            vld1q_f32, vld1q_s8, vmovl_high_s8, vmovl_high_s16, vmovl_s8, vmovl_s16,
+        };
+
+        let mut dot = vdupq_n_f32(0.0);
+        for i in (0..split).step_by(16) {
+            let qv = {
+                let qb = vld1q_s8(quantized.as_ptr().add(i));
+                let qh = [vmovl_s8(vget_low_s8(qb)), vmovl_high_s8(qb)];
+                [
+                    vmovl_s16(vget_low_s16(qh[0])),
+                    vmovl_high_s16(qh[0]),
+                    vmovl_s16(vget_low_s16(qh[1])),
+                    vmovl_high_s16(qh[1]),
+                ]
+            };
+            #[allow(clippy::needless_range_loop)]
+            for j in 0..4 {
+                dot = vfmaq_f32(
+                    dot,
+                    vld1q_f32(float.as_ptr().add(i + j * 4)),
+                    vcvtq_f32_s32(qv[j]),
+                );
+            }
+        }
+        vaddvq_f32(dot)
+    };
+    sum += quantized[split..]
+        .iter()
+        .zip(float[split..].iter())
+        .map(|(s, o)| *s as f32 * *o)
+        .sum::<f32>();
+    sum as f64 * scale
+}
 
 #[derive(Debug, Copy, Clone)]
 struct I8Vector<'a>(&'a [u8]);
@@ -85,48 +140,8 @@ impl<'a> I8Vector<'a> {
             * self.scale()
     }
 
-    #[cfg(not(target_arch = "aarch64"))]
     fn dot_unnormalized_f32(&self, other: &[f32]) -> f64 {
-        self.dot_unnormalized_f32_scalar(other)
-    }
-
-    #[cfg(target_arch = "aarch64")]
-    fn dot_unnormalized_f32(&self, other: &[f32]) -> f64 {
-        let doc = self.vector();
-        let split = doc.len() & !15;
-        let mut sum = unsafe {
-            use std::arch::aarch64::{
-                vaddvq_f32, vcvtq_f32_s32, vdupq_n_f32, vfmaq_f32, vget_low_s16, vget_low_s8,
-                vld1q_f32, vld1q_s8, vmovl_high_s16, vmovl_high_s8, vmovl_s16, vmovl_s8,
-            };
-
-            let mut dot = vdupq_n_f32(0.0);
-            for i in (0..split).step_by(16) {
-                let docv = vld1q_s8(doc.as_ptr().add(i));
-                let docv_h = [vmovl_s8(vget_low_s8(docv)), vmovl_high_s8(docv)];
-                let docv_q = [
-                    vmovl_s16(vget_low_s16(docv_h[0])),
-                    vmovl_high_s16(docv_h[0]),
-                    vmovl_s16(vget_low_s16(docv_h[1])),
-                    vmovl_high_s16(docv_h[1]),
-                ];
-                #[allow(clippy::needless_range_loop)]
-                for j in 0..4 {
-                    dot = vfmaq_f32(
-                        dot,
-                        vld1q_f32(other.as_ptr().add(i + j * 4)),
-                        vcvtq_f32_s32(docv_q[j]),
-                    );
-                }
-            }
-            vaddvq_f32(dot)
-        };
-        sum += doc[split..]
-            .iter()
-            .zip(other[split..].iter())
-            .map(|(s, o)| *s as f32 * *o)
-            .sum::<f32>();
-        sum as f64 * self.scale()
+        dot_unnormalized_i8_f32(self.vector(), self.scale(), other)
     }
 
     fn scale(&self) -> f64 {
@@ -312,7 +327,7 @@ impl<'a> I4PackedVector<'a> {
     fn dot_unnormalized_f32(&self, other: &[f32]) -> f64 {
         use std::arch::aarch64::{
             vaddvq_f32, vand_s8, vcvtq_f32_s32, vdup_n_s8, vdupq_n_f32, vfmaq_f32, vget_low_s16,
-            vld1_u8, vld1q_f32, vmovl_high_s16, vmovl_s16, vmovl_s8, vreinterpret_s8_u8, vshr_n_u8,
+            vld1_u8, vld1q_f32, vmovl_high_s16, vmovl_s8, vmovl_s16, vreinterpret_s8_u8, vshr_n_u8,
             vsub_s8, vzip1_s8, vzip2_s8,
         };
 


### PR DESCRIPTION
Like scaled uniform quantization, but users annotate ranges of dimensions that each receive their own scaling value.

This is intended for use with MRL vectors where certain ranges are "more important" than others and may have a
larger range of values. Like scaled uniform we can compute distance between two quantized vectors directly without
de-quantizing each dimension, although we will de-quantize when scoring float x quantized representations.

Scaled uniform coding is a subset of this functionality, just an empty list of splits. For the voyage dbpedia dataset
I chose splits based on where truncation is suggested, but there appears to be reduction in quantization loss
if I use many more intervals so that is worth investigating in the future.

recall:
```
voyage-3.5 dbpedia; 1.9M vectors; split at 256,512,1024, num_candidates=128, rerank_budget=0, recall@10
f32: 0.967333 (-0.000000)
i8 uniform: 0.963755 (-0.003578)
i8 non-uniform (256,512,1024): 0.964226 (-0.003107)
```

benchmark results, M2 Mac:
```
i8-scaled-non-uniform:256,512/doc/dot
                        time:   [28.162 ns 28.208 ns 28.264 ns]

i8-scaled-non-uniform:256,512/query/dot
                        time:   [183.64 ns 184.23 ns 184.86 ns]

i8-scaled-non-uniform:256,512/doc/l2
                        time:   [26.922 ns 26.962 ns 27.010 ns]

i8-scaled-non-uniform:256,512/query/l2
                        time:   [178.39 ns 178.58 ns 178.83 ns]
```

quantization loss:
```
% ./target/release/qt --input-vectors=./testdata/voyage-3.5-dbpedia/train.fvecs --dimensions=2048 quantization-loss --format=i8-scaled-uniform                             
Vectors: 1892880
Sum of absolute error: 622113.194624 squared error: 206159.038875
Per vector absolute error: 0.328660 squared error: 0.108913
./target/release/qt --input-vectors=./testdata/voyage-3.5-dbpedia/train.fvecs --dimensions=2048 quantization-loss --format=i8-scaled-non-uniform:256,512,1024         
Vectors: 1892880
Sum of absolute error: 549972.589382 squared error: 160343.894659
Per vector absolute error: 0.290548 squared error: 0.084709
```