### PR TITLE
Add microbenchmarks for distance functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,13 @@ tracing = "0.1.41"
 wt_mdb = { path = "./wt_mdb" }
 
 [dev-dependencies]
+criterion = "0.7.0"
+rand_xoshiro = "0.7.0"
 tempfile = "3.20.0"
+
+[[bench]]
+name = "distance"
+harness = false
 
 [workspace]
 members = ["et", "pt", "wt_mdb", "wt_sys"]

--- a/benches/distance.rs
+++ b/benches/distance.rs
@@ -1,0 +1,58 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use easy_tiger::vectors::{F32VectorCoding, VectorSimilarity};
+use rand::{Rng, SeedableRng};
+
+fn generate_test_vectors(dim: usize) -> (Vec<f32>, Vec<f32>) {
+    let mut rng = rand_xoshiro::Xoroshiro128PlusPlus::seed_from_u64(0x455A_5469676572);
+    let a = (&mut rng)
+        .random_iter::<f32>()
+        .by_ref()
+        .take(dim)
+        .collect::<Vec<_>>();
+    let b = (&mut rng)
+        .random_iter::<f32>()
+        .take(dim)
+        .collect::<Vec<_>>();
+    (a, b)
+}
+
+fn benchmark_distance(
+    name: &'static str,
+    x: &[f32],
+    y: &[f32],
+    coding: F32VectorCoding,
+    similarity: VectorSimilarity,
+    c: &mut Criterion,
+) {
+    let coder = coding.new_coder();
+    let x = coder.encode(x);
+    let y = coder.encode(y);
+    let dist = coding.new_symmetric_vector_distance(similarity).unwrap();
+    c.bench_function(name, |b| {
+        b.iter(|| std::hint::black_box(dist.distance(&x, &y)))
+    });
+}
+
+pub fn float32_benchmarks(c: &mut Criterion) {
+    let (a, b) = generate_test_vectors(1024);
+
+    benchmark_distance(
+        "f32/dot",
+        &a,
+        &b,
+        F32VectorCoding::RawL2Normalized,
+        VectorSimilarity::Dot,
+        c,
+    );
+    benchmark_distance(
+        "f32/l2",
+        &a,
+        &b,
+        F32VectorCoding::Raw,
+        VectorSimilarity::Euclidean,
+        c,
+    );
+}
+
+criterion_group!(benches, float32_benchmarks);
+criterion_main!(benches);

--- a/benches/distance.rs
+++ b/benches/distance.rs
@@ -105,5 +105,62 @@ pub fn i8_scaled_uniform_benchmarks(c: &mut Criterion) {
     );
 }
 
-criterion_group!(benches, float32_benchmarks, i8_scaled_uniform_benchmarks);
+pub fn i4_scaled_uniform_benchmarks(c: &mut Criterion) {
+    let (x, y) = generate_test_vectors(1024);
+
+    benchmark_distance(
+        "i4-scaled-uniform/doc/dot",
+        &x,
+        &y,
+        F32VectorCoding::I4ScaledUniformQuantized,
+        VectorSimilarity::Dot,
+        c,
+    );
+    benchmark_distance(
+        "i4-scaled-uniform/doc/l2",
+        &x,
+        &y,
+        F32VectorCoding::I4ScaledUniformQuantized,
+        VectorSimilarity::Euclidean,
+        c,
+    );
+
+    benchmark_query_distance(
+        "i4-scaled-uniform/query/dot",
+        &x,
+        &y,
+        F32VectorCoding::I4ScaledUniformQuantized,
+        VectorSimilarity::Dot,
+        c,
+    );
+    benchmark_query_distance(
+        "i4-scaled-uniform/query/l2",
+        &x,
+        &y,
+        F32VectorCoding::I4ScaledUniformQuantized,
+        VectorSimilarity::Euclidean,
+        c,
+    );
+}
+
+pub fn u1_benchmarks(c: &mut Criterion) {
+    let (x, y) = generate_test_vectors(1024);
+
+    benchmark_distance(
+        "u1/hamming",
+        &x,
+        &y,
+        F32VectorCoding::BinaryQuantized,
+        VectorSimilarity::Dot, // doesn't really matter here
+        c,
+    );
+}
+
+criterion_group!(
+    benches,
+    float32_benchmarks,
+    i8_scaled_uniform_benchmarks,
+    i4_scaled_uniform_benchmarks,
+    u1_benchmarks,
+);
 criterion_main!(benches);

--- a/src/distance.rs
+++ b/src/distance.rs
@@ -2,6 +2,7 @@
 
 use std::borrow::Cow;
 
+#[inline(always)]
 #[cfg(target_arch = "aarch64")]
 unsafe fn load_f32x4_le(p: *const u8) -> core::arch::aarch64::float32x4_t {
     use core::arch::aarch64;


### PR DESCRIPTION
This covers f32, bit (u1), i8 scaled uniform and i4 scaled uniform.

The benchmark generates two "random" 1024d vectors using a fixed seed, encodes the vectors, and performs distance
computations. In cases where the vector coding has a special `QueryVectorDistance` functions that directly compare
an f32 vector and a quantized vector, add benchmarks for those too.

In real world applications using graph-based indices these numbers are not going to be very helpful, the cost is likely
to be dominated by memory latency resulting from random reads.

Results on an M4 Mac:
```
f32/dot                 time:   [145.72 ns 146.07 ns 146.43 ns]
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) low mild
  4 (4.00%) high severe

f32/l2                  time:   [151.67 ns 152.12 ns 152.59 ns]
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild

i8-scaled-uniform/doc/dot
                        time:   [15.314 ns 15.340 ns 15.371 ns]
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

i8-scaled-uniform/doc/l2
                        time:   [14.289 ns 14.301 ns 14.317 ns]
Found 13 outliers among 100 measurements (13.00%)
  2 (2.00%) low mild
  5 (5.00%) high mild
  6 (6.00%) high severe

i8-scaled-uniform/query/dot
                        time:   [468.04 ns 469.62 ns 471.61 ns]
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe

i8-scaled-uniform/query/l2
                        time:   [466.24 ns 467.56 ns 469.69 ns]
Found 10 outliers among 100 measurements (10.00%)
  3 (3.00%) high mild
  7 (7.00%) high severe

i4-scaled-uniform/doc/dot
                        time:   [33.867 ns 33.906 ns 33.951 ns]
Found 9 outliers among 100 measurements (9.00%)
  2 (2.00%) low mild
  3 (3.00%) high mild
  4 (4.00%) high severe

i4-scaled-uniform/doc/l2
                        time:   [33.559 ns 33.609 ns 33.665 ns]
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low severe
  4 (4.00%) low mild
  3 (3.00%) high mild

i4-scaled-uniform/query/dot
                        time:   [345.23 ns 345.57 ns 346.05 ns]
Found 12 outliers among 100 measurements (12.00%)
  1 (1.00%) low severe
  4 (4.00%) low mild
  2 (2.00%) high mild
  5 (5.00%) high severe

i4-scaled-uniform/query/l2
                        time:   [345.00 ns 345.29 ns 345.65 ns]
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) low mild
  6 (6.00%) high mild
  3 (3.00%) high severe

u1/hamming              time:   [5.2979 ns 5.3353 ns 5.3766 ns]
Found 7 outliers among 100 measurements (7.00%)
  7 (7.00%) high mild
```