### PR TITLE
Extend `pt` to compute distance loss

### DIFF
--- a/qt/Cargo.toml
+++ b/qt/Cargo.toml
@@ -8,3 +8,5 @@ easy_tiger = { path = "../" }
 clap = { version = "4.5.42", features = ["derive"] }
 memmap2 = { version = "0.9.7", features = ["stable_deref_trait"] }
 rayon = "1.10.0"
+indicatif = { version = "0.18.0", features = ["rayon"] }
+bytemuck = "1.23.1"


### PR DESCRIPTION
This compares float distance for a given similarity function with quantized comparison. This allows comparing
f32 x quantized (if available) or quantized x quantized.

Some things I learned:
* f32xi8 scoring is ~40% better on loss than i8xi8. f32xi4 is the same.
* i8->i4 is 12x increase in loss
* non-uniform at MRL is 12% better on loss than i8-uniform