### PR TITLE
Add f16 vector format using the half crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 bytemuck = "1.23.0"
 crossbeam-skiplist = "0.1.3"
+half = "2.6.0"
 leb128 = "0.2.5"
 memmap2 = { version = "0.9.5", features = ["stable_deref_trait"] }
 rand = "0.9.1"

--- a/benches/distance.rs
+++ b/benches/distance.rs
@@ -55,7 +55,7 @@ pub fn float32_benchmarks(c: &mut Criterion) {
         "f32/dot",
         &a,
         &b,
-        F32VectorCoding::Raw,
+        F32VectorCoding::F32,
         VectorSimilarity::Dot,
         c,
     );
@@ -63,7 +63,7 @@ pub fn float32_benchmarks(c: &mut Criterion) {
         "f32/l2",
         &a,
         &b,
-        F32VectorCoding::Raw,
+        F32VectorCoding::F32,
         VectorSimilarity::Euclidean,
         c,
     );

--- a/benches/distance.rs
+++ b/benches/distance.rs
@@ -55,7 +55,7 @@ pub fn float32_benchmarks(c: &mut Criterion) {
         "f32/dot",
         &a,
         &b,
-        F32VectorCoding::RawL2Normalized,
+        F32VectorCoding::Raw,
         VectorSimilarity::Dot,
         c,
     );

--- a/benches/distance.rs
+++ b/benches/distance.rs
@@ -26,7 +26,7 @@ fn benchmark_distance(
     similarity: VectorSimilarity,
     c: &mut Criterion,
 ) {
-    let coder = coding.new_coder();
+    let coder = coding.new_coder(similarity);
     let x = coder.encode(x);
     let y = coder.encode(y);
     let dist = coding.new_symmetric_vector_distance(similarity).unwrap();
@@ -43,7 +43,7 @@ fn benchmark_query_distance(
     similarity: VectorSimilarity,
     c: &mut Criterion,
 ) {
-    let y = coding.new_coder().encode(y);
+    let y = coding.new_coder(similarity).encode(y);
     let dist = new_query_vector_distance_f32(x, similarity, coding);
     c.bench_function(name, |b| b.iter(|| std::hint::black_box(dist.distance(&y))));
 }

--- a/benches/distance.rs
+++ b/benches/distance.rs
@@ -1,6 +1,6 @@
-use criterion::{Criterion, criterion_group, criterion_main};
+use criterion::{criterion_group, criterion_main, Criterion};
 use easy_tiger::vectors::{
-    F32VectorCoding, NonUniformQuantizedDimensions, VectorSimilarity, new_query_vector_distance_f32,
+    new_query_vector_distance_f32, F32VectorCoding, NonUniformQuantizedDimensions, VectorSimilarity,
 };
 use rand::{Rng, SeedableRng};
 
@@ -69,87 +69,27 @@ pub fn float32_benchmarks(c: &mut Criterion) {
     );
 }
 
+pub fn float16_benchmarks(c: &mut Criterion) {
+    query_and_doc_benchmarks(c, F32VectorCoding::F16);
+}
+
 pub fn i8_scaled_uniform_benchmarks(c: &mut Criterion) {
-    let (x, y) = generate_test_vectors(1024);
-
-    benchmark_distance(
-        "i8-scaled-uniform/doc/dot",
-        &x,
-        &y,
-        F32VectorCoding::I8ScaledUniformQuantized,
-        VectorSimilarity::Dot,
-        c,
-    );
-    benchmark_distance(
-        "i8-scaled-uniform/doc/l2",
-        &x,
-        &y,
-        F32VectorCoding::I8ScaledUniformQuantized,
-        VectorSimilarity::Euclidean,
-        c,
-    );
-
-    benchmark_query_distance(
-        "i8-scaled-uniform/query/dot",
-        &x,
-        &y,
-        F32VectorCoding::I8ScaledUniformQuantized,
-        VectorSimilarity::Dot,
-        c,
-    );
-    benchmark_query_distance(
-        "i8-scaled-uniform/query/l2",
-        &x,
-        &y,
-        F32VectorCoding::I8ScaledUniformQuantized,
-        VectorSimilarity::Euclidean,
-        c,
-    );
+    query_and_doc_benchmarks(c, F32VectorCoding::I8ScaledUniformQuantized);
 }
 
 pub fn i4_scaled_uniform_benchmarks(c: &mut Criterion) {
-    let (x, y) = generate_test_vectors(1024);
-
-    benchmark_distance(
-        "i4-scaled-uniform/doc/dot",
-        &x,
-        &y,
-        F32VectorCoding::I4ScaledUniformQuantized,
-        VectorSimilarity::Dot,
-        c,
-    );
-    benchmark_distance(
-        "i4-scaled-uniform/doc/l2",
-        &x,
-        &y,
-        F32VectorCoding::I4ScaledUniformQuantized,
-        VectorSimilarity::Euclidean,
-        c,
-    );
-
-    benchmark_query_distance(
-        "i4-scaled-uniform/query/dot",
-        &x,
-        &y,
-        F32VectorCoding::I4ScaledUniformQuantized,
-        VectorSimilarity::Dot,
-        c,
-    );
-    benchmark_query_distance(
-        "i4-scaled-uniform/query/l2",
-        &x,
-        &y,
-        F32VectorCoding::I4ScaledUniformQuantized,
-        VectorSimilarity::Euclidean,
-        c,
-    );
+    query_and_doc_benchmarks(c, F32VectorCoding::I4ScaledUniformQuantized);
 }
 
 pub fn i8_scaled_non_uniform_benchmarks(c: &mut Criterion) {
-    let (x, y) = generate_test_vectors(1024);
     let format = F32VectorCoding::I8ScaledNonUniformQuantized(
         NonUniformQuantizedDimensions::try_from([256, 512].as_slice()).unwrap(),
     );
+    query_and_doc_benchmarks(c, format);
+}
+
+fn query_and_doc_benchmarks(c: &mut Criterion, format: F32VectorCoding) {
+    let (x, y) = generate_test_vectors(1024);
     for similarity in [VectorSimilarity::Dot, VectorSimilarity::Euclidean] {
         benchmark_distance(
             &format!("{format}/doc/{similarity}"),
@@ -186,6 +126,7 @@ pub fn u1_benchmarks(c: &mut Criterion) {
 criterion_group!(
     benches,
     float32_benchmarks,
+    float16_benchmarks,
     i8_scaled_uniform_benchmarks,
     i4_scaled_uniform_benchmarks,
     i8_scaled_non_uniform_benchmarks,

--- a/et/src/spann/bulk_load.rs
+++ b/et/src/spann/bulk_load.rs
@@ -128,8 +128,8 @@ pub fn bulk_load(
     let head_config = GraphConfig {
         dimensions: args.dimensions,
         similarity: args.similarity,
-        nav_format: args.head_nav_format.adjust_raw_format(args.similarity),
-        rerank_format: args.head_rerank_format.adjust_raw_format(args.similarity),
+        nav_format: args.head_nav_format,
+        rerank_format: args.head_rerank_format,
         layout: args.layout,
         max_edges: args.max_edges,
         index_search_params: GraphSearchParams {

--- a/et/src/vamana/bulk_load.rs
+++ b/et/src/vamana/bulk_load.rs
@@ -83,8 +83,8 @@ pub fn bulk_load(
     let config = GraphConfig {
         dimensions: args.dimensions,
         similarity: args.similarity,
-        nav_format: args.nav_format.adjust_raw_format(args.similarity),
-        rerank_format: args.rerank_format.adjust_raw_format(args.similarity),
+        nav_format: args.nav_format,
+        rerank_format: args.rerank_format,
         layout: args.layout,
         max_edges: args.max_edges,
         index_search_params: GraphSearchParams {

--- a/et/src/vamana/init_index.rs
+++ b/et/src/vamana/init_index.rs
@@ -72,8 +72,8 @@ pub fn init_index(
         GraphConfig {
             dimensions: args.dimensions,
             similarity: args.similarity,
-            nav_format: args.nav_format.adjust_raw_format(args.similarity),
-            rerank_format: args.rerank_format.adjust_raw_format(args.similarity),
+            nav_format: args.nav_format,
+            rerank_format: args.rerank_format,
             layout: args.layout,
             max_edges: args.max_edges,
             index_search_params: GraphSearchParams {

--- a/qt/src/main.rs
+++ b/qt/src/main.rs
@@ -138,7 +138,7 @@ fn distance_loss(
                 new_query_vector_distance_f32(
                     &query_vectors[i],
                     args.similarity,
-                    F32VectorCoding::Raw.adjust_raw_format(args.similarity),
+                    F32VectorCoding::Raw,
                 ),
                 new_query_vector_distance_f32(&query_vectors[i], args.similarity, args.format),
                 quantized_query_vectors.as_ref().map(|v| {
@@ -174,7 +174,6 @@ fn distance_loss(
             |a, b| (a.0 + b.0, a.1 + b.1, a.2 + b.2),
         );
 
-    // XXX error seems like a lot over 10k, but it's actually over 10k * num_queries.
     println!(
         "Vectors: {} mean abs error: {} mean square error: {}",
         count,

--- a/qt/src/main.rs
+++ b/qt/src/main.rs
@@ -138,7 +138,7 @@ fn distance_loss(
                 new_query_vector_distance_f32(
                     &query_vectors[i],
                     args.similarity,
-                    F32VectorCoding::Raw,
+                    F32VectorCoding::F32,
                 ),
                 new_query_vector_distance_f32(&query_vectors[i], args.similarity, args.format),
                 quantized_query_vectors.as_ref().map(|v| {

--- a/qt/src/main.rs
+++ b/qt/src/main.rs
@@ -58,6 +58,7 @@ fn quantization_loss(
     );
     let (abs_error, sq_error) = (0..vectors.len())
         .into_par_iter()
+        .progress_count(vectors.len() as u64)
         .map(|i| {
             let v = &vectors[i];
             let encoded = coder.encode(v);

--- a/qt/src/main.rs
+++ b/qt/src/main.rs
@@ -51,7 +51,9 @@ fn quantization_loss(
     args: QuantizationLossArgs,
     vectors: &(impl VectorStore<Elem = f32> + Send + Sync),
 ) -> io::Result<()> {
-    let coder = args.format.new_coder();
+    // Assume Euclidean. It might be best to make this configurable as some encodings might perform
+    // better when the inputs are l2 normalized.
+    let coder = args.format.new_coder(VectorSimilarity::Euclidean);
     assert!(
         coder.decode(&coder.encode(&vectors[0])).is_some(),
         "specified vector format doesn't support decoding"
@@ -115,7 +117,7 @@ fn distance_loss(
         NonZero::new(vectors.elem_stride()).unwrap(),
     )?;
 
-    let coder = args.format.new_coder();
+    let coder = args.format.new_coder(args.similarity);
     let quantized_query_vectors = if args.quantize_query {
         let mut qvecs = VecVectorStore::with_capacity(
             coder.byte_len(query_vectors.elem_stride()),

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -204,7 +204,7 @@ where
         let mut nav_cursor =
             session.new_bulk_load_cursor::<i64, Vec<u8>>(self.index.nav_table_name(), None)?;
 
-        let rerank_coder = self.index.config().rerank_format.new_coder();
+        let rerank_coder = self.index.config().new_rerank_coder();
         let mut rerank_vector = vec![0u8; rerank_coder.byte_len(dim)];
         let mut rerank_cursor =
             session.new_bulk_load_cursor::<i64, Vec<u8>>(self.index.rerank_table_name(), None)?;
@@ -236,12 +236,7 @@ where
             .into_iter()
             .map(|s| (s / self.limit as f64) as f32)
             .collect::<Vec<_>>();
-        self.centroid = self
-            .index
-            .config()
-            .rerank_format
-            .new_coder()
-            .encode(&centroid);
+        self.centroid = self.index.config().new_rerank_coder().encode(&centroid);
         Ok(())
     }
 

--- a/src/crud.rs
+++ b/src/crud.rs
@@ -380,7 +380,7 @@ mod tests {
                         dimensions: NonZero::new(2).unwrap(),
                         similarity: VectorSimilarity::Euclidean,
                         nav_format: F32VectorCoding::BinaryQuantized,
-                        rerank_format: F32VectorCoding::Raw,
+                        rerank_format: F32VectorCoding::F32,
                         layout: GraphLayout::Split,
                         max_edges: NonZero::new(4).unwrap(),
                         index_search_params: Self::search_params(),

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -90,7 +90,7 @@ impl GraphConfig {
 
     /// Return a new vector coder for the nav vector format.
     pub fn new_nav_coder(&self) -> Box<dyn F32VectorCoder> {
-        self.nav_format.new_coder()
+        self.nav_format.new_coder(self.similarity)
     }
 
     /// Return a distance function for quantized navigational vectors in the index.
@@ -101,7 +101,7 @@ impl GraphConfig {
 
     /// Return a new vector coder for the rerank vector format.
     pub fn new_rerank_coder(&self) -> Box<dyn F32VectorCoder> {
-        self.rerank_format.new_coder()
+        self.rerank_format.new_coder(self.similarity)
     }
 }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -432,7 +432,7 @@ mod test {
                 dimensions: NonZero::new(rep.first().map(|v| v.vector.len()).unwrap_or(1)).unwrap(),
                 similarity: VectorSimilarity::Euclidean,
                 nav_format: F32VectorCoding::BinaryQuantized,
-                rerank_format: F32VectorCoding::Raw,
+                rerank_format: F32VectorCoding::F32,
                 layout: GraphLayout::Split,
                 max_edges,
                 index_search_params: GraphSearchParams {

--- a/src/search.rs
+++ b/src/search.rs
@@ -411,7 +411,7 @@ mod test {
             T: IntoIterator<Item = V>,
             V: Into<Vec<f32>>,
         {
-            let coder = F32VectorCoding::BinaryQuantized.new_coder();
+            let coder = F32VectorCoding::BinaryQuantized.new_coder(VectorSimilarity::Euclidean);
             let mut rep = iter
                 .into_iter()
                 .map(|x| {

--- a/src/spann.rs
+++ b/src/spann.rs
@@ -248,7 +248,10 @@ pub struct SessionIndexWriter {
 impl SessionIndexWriter {
     pub fn new(index: Arc<TableIndex>, session: Session) -> Self {
         let distance_fn = index.head.config().new_distance_function();
-        let posting_coder = index.config.posting_coder.new_coder();
+        let posting_coder = index
+            .config
+            .posting_coder
+            .new_coder(index.head.config().similarity);
         let raw_coder = index.head.config().new_rerank_coder();
         let head_reader = SessionGraphVectorIndexReader::new(index.head.clone(), session);
         let head_searcher = GraphSearcher::new(index.config.head_search_params);

--- a/src/spann/bulk.rs
+++ b/src/spann/bulk.rs
@@ -96,7 +96,10 @@ pub fn bulk_load_postings(
         .collect();
     posting_keys.par_sort_unstable();
 
-    let coder = index.config().posting_coder.new_coder();
+    let coder = index
+        .config()
+        .posting_coder
+        .new_coder(index.head_config().config().similarity);
     let mut bulk_cursor = session.new_bulk_load_cursor::<PostingKey, Vec<u8>>(
         &index.table_names.postings,
         Some(
@@ -127,7 +130,7 @@ pub fn bulk_load_raw_vectors(
                 .app_metadata(&serde_json::to_string(&index.config).unwrap()),
         ),
     )?;
-    let coder = index.head_config().config().rerank_format.new_coder();
+    let coder = index.head_config().config().new_rerank_coder();
     let mut encoded =
         Vec::with_capacity(coder.byte_len(index.head_config().config().dimensions.get()));
     for (record_id, vector) in vectors.iter().enumerate().take(limit) {

--- a/src/vectors/float16.rs
+++ b/src/vectors/float16.rs
@@ -9,15 +9,15 @@ use crate::{
 };
 
 #[derive(Debug, Copy, Clone)]
-pub struct F16VectorCoder(bool);
+pub struct VectorCoder(bool);
 
-impl F16VectorCoder {
+impl VectorCoder {
     pub fn new(similarity: VectorSimilarity) -> Self {
         Self(similarity.l2_normalize())
     }
 }
 
-impl F32VectorCoder for F16VectorCoder {
+impl F32VectorCoder for VectorCoder {
     fn encode_to(&self, vector: &[f32], out: &mut [u8]) {
         let encode_it = vector.iter().zip(out.chunks_mut(2));
         if self.0 {
@@ -55,9 +55,9 @@ fn f16_iter(raw: &[u8]) -> impl ExactSizeIterator<Item = f16> + '_ {
 }
 
 #[derive(Debug, Copy, Clone)]
-pub struct F16DotProductDistance;
+pub struct DotProductDistance;
 
-impl VectorDistance for F16DotProductDistance {
+impl VectorDistance for DotProductDistance {
     fn distance(&self, query: &[u8], doc: &[u8]) -> f64 {
         // TODO: vector accelerate this when necessary bits stabilize (or use C).
         let dot = f16_iter(query)
@@ -69,15 +69,15 @@ impl VectorDistance for F16DotProductDistance {
 }
 
 #[derive(Debug, Clone)]
-pub struct F16DotProductQueryDistance<'a>(Cow<'a, [f32]>);
+pub struct DotProductQueryDistance<'a>(Cow<'a, [f32]>);
 
-impl<'a> F16DotProductQueryDistance<'a> {
+impl<'a> DotProductQueryDistance<'a> {
     pub fn new(query: &'a [f32]) -> Self {
         Self(l2_normalize(query))
     }
 }
 
-impl QueryVectorDistance for F16DotProductQueryDistance<'_> {
+impl QueryVectorDistance for DotProductQueryDistance<'_> {
     fn distance(&self, vector: &[u8]) -> f64 {
         // TODO: vector accelerate this when necessary bits stabilize (or use C).
         let dot = self
@@ -91,9 +91,9 @@ impl QueryVectorDistance for F16DotProductQueryDistance<'_> {
 }
 
 #[derive(Debug, Copy, Clone)]
-pub struct F16EuclideanDistance;
+pub struct EuclideanDistance;
 
-impl VectorDistance for F16EuclideanDistance {
+impl VectorDistance for EuclideanDistance {
     fn distance(&self, query: &[u8], doc: &[u8]) -> f64 {
         // TODO: vector accelerate this when necessary bits stabilize (or use C).
         f16_iter(query)
@@ -107,15 +107,15 @@ impl VectorDistance for F16EuclideanDistance {
 }
 
 #[derive(Debug, Clone)]
-pub struct F16EuclideanQueryDistance<'a>(&'a [f32]);
+pub struct EuclideanQueryDistance<'a>(&'a [f32]);
 
-impl<'a> F16EuclideanQueryDistance<'a> {
+impl<'a> EuclideanQueryDistance<'a> {
     pub fn new(query: &'a [f32]) -> Self {
         Self(query)
     }
 }
 
-impl QueryVectorDistance for F16EuclideanQueryDistance<'_> {
+impl QueryVectorDistance for EuclideanQueryDistance<'_> {
     fn distance(&self, vector: &[u8]) -> f64 {
         // TODO: vector accelerate this when necessary bits stabilize (or use C).
         self.0

--- a/src/vectors/float16.rs
+++ b/src/vectors/float16.rs
@@ -1,6 +1,11 @@
+use std::borrow::Cow;
+
 use half::f16;
 
-use crate::vectors::{F32VectorCoder, VectorDistance};
+use crate::{
+    distance::l2_normalize,
+    vectors::{F32VectorCoder, QueryVectorDistance, VectorDistance},
+};
 
 // XXX creators should be forced to provide a similarity so I can normalize for dot.
 #[derive(Debug, Copy, Clone)]
@@ -37,11 +42,37 @@ pub struct F16DotProductDistance;
 
 impl VectorDistance for F16DotProductDistance {
     fn distance(&self, query: &[u8], doc: &[u8]) -> f64 {
-        f16_iter(query)
+        // XXX lol this makes f32 dot product look _cheap_. 35x more accurate than i8-su qxq
+        // in all native f16 math it is less accurate than i8 _and_ 3x more expensive.
+        let dot = f16_iter(query)
             .zip(f16_iter(doc))
             .map(|(q, d)| q * d)
             .sum::<f16>()
-            .to_f64()
+            .to_f64();
+        (-dot + 1.0) / 2.0
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct F16DotProductQueryDistance<'a>(Cow<'a, [f32]>);
+
+impl<'a> F16DotProductQueryDistance<'a> {
+    pub fn new(query: &'a [f32]) -> Self {
+        Self(l2_normalize(query))
+    }
+}
+
+impl QueryVectorDistance for F16DotProductQueryDistance<'_> {
+    fn distance(&self, vector: &[u8]) -> f64 {
+        // XXX just as stupidly expensive as f16xf16 dot product, but now 50x more accurate than
+        // i8-su qxq and 35x more accurate than f32xq
+        let dot = self
+            .0
+            .iter()
+            .zip(vector.chunks_exact(2))
+            .map(|(s, o)| *s * f16::from_le_bytes(o.try_into().unwrap()).to_f32())
+            .sum::<f32>() as f64;
+        (-dot + 1.0) / 2.0
     }
 }
 
@@ -53,11 +84,32 @@ impl VectorDistance for F16EuclideanDistance {
         f16_iter(query)
             .zip(f16_iter(doc))
             .map(|(q, d)| {
-                let diff = q - d;
+                let diff = q.to_f32() - d.to_f32();
                 diff * diff
             })
-            .sum::<f16>()
-            .to_f64()
+            .sum::<f32>() as f64
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct F16EuclideanQueryDistance<'a>(&'a [f32]);
+
+impl<'a> F16EuclideanQueryDistance<'a> {
+    pub fn new(query: &'a [f32]) -> Self {
+        Self(query)
+    }
+}
+
+impl QueryVectorDistance for F16EuclideanQueryDistance<'_> {
+    fn distance(&self, vector: &[u8]) -> f64 {
+        self.0
+            .iter()
+            .zip(vector.chunks_exact(2))
+            .map(|(s, o)| {
+                let diff = *s * f16::from_le_bytes(o.try_into().unwrap()).to_f32();
+                diff * diff
+            })
+            .sum::<f32>() as f64
     }
 }
 

--- a/src/vectors/float16.rs
+++ b/src/vectors/float16.rs
@@ -8,7 +8,6 @@ use crate::{
     vectors::{F32VectorCoder, QueryVectorDistance, VectorDistance, VectorSimilarity},
 };
 
-// XXX creators should be forced to provide a similarity so I can normalize for dot.
 #[derive(Debug, Copy, Clone)]
 pub struct F16VectorCoder(bool);
 

--- a/src/vectors/float16.rs
+++ b/src/vectors/float16.rs
@@ -46,9 +46,8 @@ impl VectorDistance for F16DotProductDistance {
         // in all native f16 math it is less accurate than i8 _and_ 3x more expensive.
         let dot = f16_iter(query)
             .zip(f16_iter(doc))
-            .map(|(q, d)| q * d)
-            .sum::<f16>()
-            .to_f64();
+            .map(|(q, d)| q.to_f32() * d.to_f32())
+            .sum::<f32>() as f64;
         (-dot + 1.0) / 2.0
     }
 }

--- a/src/vectors/float16.rs
+++ b/src/vectors/float16.rs
@@ -1,0 +1,27 @@
+use half::f16;
+
+use crate::vectors::F32VectorCoder;
+
+#[derive(Debug, Copy, Clone)]
+pub struct F16VectorCoder;
+
+impl F32VectorCoder for F16VectorCoder {
+    fn encode_to(&self, vector: &[f32], out: &mut [u8]) {
+        for (d, o) in vector.iter().zip(out.chunks_mut(2)) {
+            o.copy_from_slice(&f16::from_f32(*d).to_le_bytes());
+        }
+    }
+
+    fn byte_len(&self, dimensions: usize) -> usize {
+        dimensions * 2
+    }
+
+    fn decode(&self, encoded: &[u8]) -> Option<Vec<f32>> {
+        Some(
+            encoded
+                .chunks(2)
+                .map(|h| f16::from_le_bytes(h.try_into().unwrap()).to_f32())
+                .collect(),
+        )
+    }
+}

--- a/src/vectors/mod.rs
+++ b/src/vectors/mod.rs
@@ -7,10 +7,7 @@ use crate::vectors::{
         AsymmetricBinaryQuantizedVectorCoder, AsymmetricHammingDistance,
         BinaryQuantizedVectorCoder, HammingDistance,
     },
-    raw::{
-        F32DotProductDistance, F32EuclideanDistance, F32QueryVectorDistance, RawF32VectorCoder,
-        RawL2NormalizedF32VectorCoder,
-    },
+    raw::{F32DotProductDistance, F32EuclideanDistance, F32QueryVectorDistance, RawF32VectorCoder},
 };
 
 mod binary;
@@ -141,15 +138,12 @@ impl TryFrom<&[u16]> for NonUniformQuantizedDimensions {
 /// varying degrees of compression and fidelity in distance computation.
 #[derive(Debug, Copy, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub enum F32VectorCoding {
-    /// Little-endian f32 values encoded as bytes.
+    /// Little-endian f32 values.
     ///
     /// Depending on the similarity function this may be normalied or transformed in some other way
     /// so users should not rely on the value being identical.
     #[default]
     Raw, // XXX name should be F32
-    /// Little-endian f32 values encoded as bytes, but l2 normalized first.
-    /// The resulting unit vectors can be used to cheaply compute angular distance.
-    RawL2Normalized,
     /// Little-endian IEEE f16 encoding.
     F16,
     /// Single bit (sign bit) per dimension.
@@ -192,7 +186,6 @@ impl F32VectorCoding {
     pub fn new_coder(&self, similarity: VectorSimilarity) -> Box<dyn F32VectorCoder> {
         match self {
             Self::Raw => Box::new(RawF32VectorCoder::new(similarity)),
-            Self::RawL2Normalized => Box::new(RawL2NormalizedF32VectorCoder),
             Self::F16 => Box::new(float16::F16VectorCoder::new(similarity)),
             Self::BinaryQuantized => Box::new(BinaryQuantizedVectorCoder),
             Self::NBitBinaryQuantized(n) => Box::new(AsymmetricBinaryQuantizedVectorCoder::new(*n)),
@@ -212,11 +205,7 @@ impl F32VectorCoding {
     ) -> Option<Box<dyn VectorDistance>> {
         match (self, similarity) {
             (Self::Raw, VectorSimilarity::Dot) => Some(Box::new(F32DotProductDistance)),
-            (Self::RawL2Normalized, VectorSimilarity::Dot) => Some(Box::new(F32DotProductDistance)),
             (Self::Raw, VectorSimilarity::Euclidean) => Some(Box::new(F32EuclideanDistance)),
-            (Self::RawL2Normalized, VectorSimilarity::Euclidean) => {
-                Some(Box::new(F32EuclideanDistance))
-            }
             (Self::BinaryQuantized, _) => Some(Box::new(HammingDistance)),
             (Self::NBitBinaryQuantized(_), _) => None,
             (Self::I8ScaledUniformQuantized, VectorSimilarity::Dot) => {
@@ -249,14 +238,6 @@ impl F32VectorCoding {
     pub fn is_symmetric(&self) -> bool {
         !matches!(self, Self::NBitBinaryQuantized(_))
     }
-
-    /// Adjust raw format to normalize for angular similarity.
-    pub fn adjust_raw_format(&self, similarity: VectorSimilarity) -> Self {
-        match (self, similarity) {
-            (Self::Raw, VectorSimilarity::Dot) => Self::RawL2Normalized,
-            (_, _) => *self,
-        }
-    }
 }
 
 impl FromStr for F32VectorCoding {
@@ -265,8 +246,7 @@ impl FromStr for F32VectorCoding {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let input_err = |s| io::Error::new(io::ErrorKind::InvalidInput, s);
         match s {
-            "raw" => Ok(Self::Raw),
-            "raw-l2-norm" => Ok(Self::RawL2Normalized),
+            "raw" | "raw-l2-norm" => Ok(Self::Raw),
             "f16" => Ok(Self::F16),
             "binary" => Ok(Self::BinaryQuantized),
             ab if ab.starts_with("asymmetric_binary:") => {
@@ -305,7 +285,6 @@ impl std::fmt::Display for F32VectorCoding {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Raw => write!(f, "raw"),
-            Self::RawL2Normalized => write!(f, "raw-l2-norm"),
             Self::F16 => write!(f, "f16"),
             Self::BinaryQuantized => write!(f, "binary"),
             Self::NBitBinaryQuantized(n) => write!(f, "asymmetric_binary:{}", *n),
@@ -391,20 +370,16 @@ pub fn new_query_vector_distance_f32<'a>(
 ) -> Box<dyn QueryVectorDistance + 'a> {
     use VectorSimilarity::{Dot, Euclidean};
     match (similarity, coding) {
-        (Dot, F32VectorCoding::Raw) | (Dot, F32VectorCoding::RawL2Normalized) => {
-            Box::new(F32QueryVectorDistance::new(
-                F32DotProductDistance,
-                query,
-                matches!(coding, F32VectorCoding::RawL2Normalized),
-            ))
-        }
-        (Euclidean, F32VectorCoding::Raw) | (Euclidean, F32VectorCoding::RawL2Normalized) => {
-            Box::new(F32QueryVectorDistance::new(
-                F32EuclideanDistance,
-                query,
-                matches!(coding, F32VectorCoding::RawL2Normalized),
-            ))
-        }
+        (Dot, F32VectorCoding::Raw) => Box::new(F32QueryVectorDistance::new(
+            F32DotProductDistance,
+            query,
+            true,
+        )),
+        (Euclidean, F32VectorCoding::Raw) => Box::new(F32QueryVectorDistance::new(
+            F32EuclideanDistance,
+            query,
+            false,
+        )),
         (_, F32VectorCoding::BinaryQuantized) => Box::new(QuantizedQueryVectorDistance::from_f32(
             HammingDistance,
             query,
@@ -450,15 +425,13 @@ pub fn new_query_vector_distance_indexing<'a>(
 ) -> Box<dyn QueryVectorDistance + 'a> {
     use VectorSimilarity::{Dot, Euclidean};
     match (similarity, coding) {
-        (Dot, F32VectorCoding::Raw) | (Dot, F32VectorCoding::RawL2Normalized) => Box::new(
-            QuantizedQueryVectorDistance::from_quantized(F32DotProductDistance, query),
+        (Dot, F32VectorCoding::Raw) => Box::new(QuantizedQueryVectorDistance::from_quantized(
+            F32DotProductDistance,
+            query,
+        )),
+        (Euclidean, F32VectorCoding::Raw) => Box::new(
+            QuantizedQueryVectorDistance::from_quantized(F32EuclideanDistance, query),
         ),
-        (Euclidean, F32VectorCoding::Raw) | (Euclidean, F32VectorCoding::RawL2Normalized) => {
-            Box::new(QuantizedQueryVectorDistance::from_quantized(
-                F32EuclideanDistance,
-                query,
-            ))
-        }
         (_, F32VectorCoding::BinaryQuantized) => Box::new(
             QuantizedQueryVectorDistance::from_quantized(HammingDistance, query),
         ),
@@ -529,12 +502,7 @@ mod test {
             similarity: VectorSimilarity,
             coder: &(impl F32VectorCoder + ?Sized),
         ) -> Self {
-            // XXX remove me!
-            let f32_coder = match similarity {
-                VectorSimilarity::Dot => F32VectorCoding::RawL2Normalized,
-                VectorSimilarity::Euclidean => F32VectorCoding::Raw,
-            }
-            .new_coder(similarity);
+            let f32_coder = F32VectorCoding::Raw.new_coder(similarity);
             let rvec = f32_coder
                 .encode(vec)
                 .chunks(4)

--- a/src/vectors/mod.rs
+++ b/src/vectors/mod.rs
@@ -611,9 +611,25 @@ mod test {
     }
 
     use F32VectorCoding::{
-        I4ScaledUniformQuantized, I8ScaledNonUniformQuantized, I8ScaledUniformQuantized,
+        I4ScaledUniformQuantized, I8ScaledNonUniformQuantized, I8ScaledUniformQuantized, F16,
     };
     use VectorSimilarity::{Dot, Euclidean};
+
+    #[test]
+    fn f16_dot() {
+        for (i, (a, b)) in test_float_vectors().into_iter().enumerate() {
+            distance_compare(Dot, F16, i, &a, &b, 0.001);
+            query_distance_compare(Dot, F16, i, &a, &b, 0.001);
+        }
+    }
+
+    #[test]
+    fn f16_l2() {
+        for (i, (a, b)) in test_float_vectors().into_iter().enumerate() {
+            distance_compare(Euclidean, F16, i, &a, &b, 0.001);
+            query_distance_compare(Euclidean, F16, i, &a, &b, 0.001);
+        }
+    }
 
     #[test]
     fn i8_scaled_dot() {
@@ -668,6 +684,4 @@ mod test {
             query_distance_compare(Euclidean, format, i, &a, &b, 0.01);
         }
     }
-
-    // XXX add tests for f16.
 }

--- a/src/vectors/mod.rs
+++ b/src/vectors/mod.rs
@@ -137,7 +137,7 @@ impl TryFrom<&[u16]> for NonUniformQuantizedDimensions {
 pub enum F32VectorCoding {
     /// Little-endian f32 values.
     ///
-    /// Depending on the similarity function this may be normalied or transformed in some other way
+    /// Depending on the similarity function this may be normalized or transformed in some other way
     /// so users should not rely on the value being identical.
     #[default]
     F32,

--- a/src/vectors/mod.rs
+++ b/src/vectors/mod.rs
@@ -181,7 +181,8 @@ pub enum F32VectorCoding {
 
 impl F32VectorCoding {
     /// Create a new coder for this format.
-    pub fn new_coder(&self) -> Box<dyn F32VectorCoder> {
+    #[allow(unused_variables)] // XXX
+    pub fn new_coder(&self, similarity: VectorSimilarity) -> Box<dyn F32VectorCoder> {
         match self {
             Self::Raw => Box::new(RawF32VectorCoder),
             Self::RawL2Normalized => Box::new(RawL2NormalizedF32VectorCoder),
@@ -337,7 +338,8 @@ pub trait F32VectorCoder: Send + Sync {
     ///
     /// This is not supported for all codecs, and in cases where the format is packed may
     /// return more dimensions than originally specified.
-    fn decode(&self, _encoded: &[u8]) -> Option<Vec<f32>> {
+    #[allow(unused_variables)]
+    fn decode(&self, encoded: &[u8]) -> Option<Vec<f32>> {
         None
     }
 }
@@ -520,11 +522,12 @@ mod test {
             similarity: VectorSimilarity,
             coder: &(impl F32VectorCoder + ?Sized),
         ) -> Self {
+            // XXX remove me!
             let f32_coder = match similarity {
                 VectorSimilarity::Dot => F32VectorCoding::RawL2Normalized,
                 VectorSimilarity::Euclidean => F32VectorCoding::Raw,
             }
-            .new_coder();
+            .new_coder(similarity);
             let rvec = f32_coder
                 .encode(vec)
                 .chunks(4)
@@ -557,7 +560,7 @@ mod test {
         b: &[f32],
         threshold: f64,
     ) {
-        let coder = format.new_coder();
+        let coder = format.new_coder(similarity);
         let a = TestVector::new(a, similarity, coder.as_ref());
         let b = TestVector::new(b, similarity, coder.as_ref());
 
@@ -580,7 +583,7 @@ mod test {
         b: &[f32],
         threshold: f64,
     ) {
-        let coder = format.new_coder();
+        let coder = format.new_coder(similarity);
         let a = TestVector::new(a, similarity, coder.as_ref());
         let b = TestVector::new(b, similarity, coder.as_ref());
 

--- a/src/vectors/raw.rs
+++ b/src/vectors/raw.rs
@@ -49,59 +49,9 @@ impl F32VectorCoder for RawF32VectorCoder {
         }
     }
 
-    fn encode(&self, vector: &[f32]) -> Vec<u8> {
-        vector.iter().flat_map(|d| d.to_le_bytes()).collect()
-    }
-
     fn decode(&self, encoded: &[u8]) -> Option<Vec<f32>> {
         // NB: if the input value was l2 normalized we can't recreate that value -- we've already
         // discarded the norm.
-        let f32_len = std::mem::size_of::<f32>();
-        assert!(encoded.len() % f32_len == 0);
-        Some(
-            encoded
-                .chunks(f32_len)
-                .map(|c| f32::from_le_bytes(c.try_into().unwrap()))
-                .collect(),
-        )
-    }
-}
-
-#[derive(Debug, Copy, Clone)]
-pub struct RawL2NormalizedF32VectorCoder;
-
-impl RawL2NormalizedF32VectorCoder {
-    fn scale(v: &[f32]) -> f32 {
-        let l2_norm = SpatialSimilarity::dot(v, v).unwrap().sqrt() as f32;
-        l2_norm.recip()
-    }
-}
-
-impl F32VectorCoder for RawL2NormalizedF32VectorCoder {
-    fn byte_len(&self, dimensions: usize) -> usize {
-        dimensions * std::mem::size_of::<f32>()
-    }
-
-    fn encode_to(&self, vector: &[f32], out: &mut [u8]) {
-        assert!(out.len() >= std::mem::size_of_val(vector));
-        let scale = Self::scale(vector);
-        for (d, o) in vector
-            .iter()
-            .zip(out.chunks_mut(std::mem::size_of::<f32>()))
-        {
-            o.copy_from_slice(&(*d * scale).to_le_bytes());
-        }
-    }
-
-    fn encode(&self, vector: &[f32]) -> Vec<u8> {
-        let scale = Self::scale(vector);
-        vector
-            .iter()
-            .flat_map(|d| (*d * scale).to_le_bytes())
-            .collect()
-    }
-
-    fn decode(&self, encoded: &[u8]) -> Option<Vec<f32>> {
         let f32_len = std::mem::size_of::<f32>();
         assert!(encoded.len() % f32_len == 0);
         Some(


### PR DESCRIPTION
`f16` coding has near-zero quantization loss, and near zero distance loss so long as values are converted to `f32`
before computing the distance.

All of the SIMD infrastructure for `f16` is not stabilized so performance is quite poor, ~600ns to compute distance
across 1024 dimensions on an M4 Mac, ~4-5x the cost of doing so on f32 vectors. The compiler generated code
uses inline assembly without loop unrolling and absolutely no SIMD for this. This is fixable by using C, I just don't feel
like doing that right now.

Refactor so that creating the coder accepts a similarity and in the case of f32 and f16 codings, chooses to normalize
the vector during encoding. This replaces the special raw-l2-norm format and a bunch of adjustments around that.