### PR TITLE
Add an `i16` scaled uniform quantization scheme

### DIFF
--- a/benches/distance.rs
+++ b/benches/distance.rs
@@ -73,6 +73,10 @@ pub fn float16_benchmarks(c: &mut Criterion) {
     query_and_doc_benchmarks(c, F32VectorCoding::F16);
 }
 
+pub fn i16_scaled_uniform_benchmarks(c: &mut Criterion) {
+    query_and_doc_benchmarks(c, F32VectorCoding::I16ScaledUniformQuantized);
+}
+
 pub fn i8_scaled_uniform_benchmarks(c: &mut Criterion) {
     query_and_doc_benchmarks(c, F32VectorCoding::I8ScaledUniformQuantized);
 }
@@ -127,6 +131,7 @@ criterion_group!(
     benches,
     float32_benchmarks,
     float16_benchmarks,
+    i16_scaled_uniform_benchmarks,
     i8_scaled_uniform_benchmarks,
     i4_scaled_uniform_benchmarks,
     i8_scaled_non_uniform_benchmarks,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.88.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.88.0"
+components = ["rustfmt", "clippy"]

--- a/src/vectors/mod.rs
+++ b/src/vectors/mod.rs
@@ -167,7 +167,12 @@ pub enum F32VectorCoding {
     ///
     /// This uses 1 byte per 2 dimensions and 8 additional bytes for a scaling factor and l2 norm.
     I4ScaledUniformQuantized,
-    // XXX docos
+    /// Quantize into an i16 value shaped to the input vector.
+    ///
+    /// This uses the contents of the vector to try to reduce quantization error but no data from
+    /// other vectors in the data set.
+    ///
+    /// This uses 2 bytes per dimension and 8 additional bytes for a scaling factor and l2 norm.
     I16ScaledUniformQuantized,
     /// Quantize into an i4 value shaped to the input vector, where we choose different scaling
     /// factors for different segments of the dimension space.


### PR DESCRIPTION
This is like `i8` but scaled to 16 bits, with much lower quantization and distance loss than `i8`. It should behave at least
as well as `f16` according to loss metrics.

This is faster than `i4` and `i8` to score against `f32` vectors, probably mostly owing to fewer widening instructions, but
is not as fast to perform fully quantized scoring -- fewer elements per vector and no `SDOT` path.

This could be the basis for a split representation codec -- metadata and the high byte are used for navigation, but can
be merged with the low byte for higher precision when re-ranking.