### PR TITLE
Add a tool to compute recall against a ground truth set

### DIFF
--- a/qt/Cargo.toml
+++ b/qt/Cargo.toml
@@ -10,3 +10,4 @@ memmap2 = { version = "0.9.7", features = ["stable_deref_trait"] }
 rayon = "1.10.0"
 indicatif = { version = "0.18.0", features = ["rayon"] }
 bytemuck = "1.23.1"
+crossbeam-utils = "0.8.21"

--- a/qt/src/main.rs
+++ b/qt/src/main.rs
@@ -4,11 +4,13 @@ use std::{
     io::{self},
     num::NonZero,
     path::PathBuf,
-    sync::Arc,
+    sync::{Arc, Mutex, atomic::AtomicU64},
 };
 
 use clap::{Args, Parser, Subcommand};
+use crossbeam_utils::CachePadded;
 use easy_tiger::{
+    Neighbor,
     input::{DerefVectorStore, VectorStore},
     vectors::{
         F32VectorCoding, VectorSimilarity, new_query_vector_distance_f32,
@@ -39,6 +41,8 @@ enum Command {
     QuantizationLoss(QuantizationLossArgs),
     /// Compute precision loss in distance computation resulting from vector quantization.
     DistanceLoss(DistanceLossArgs),
+    /// Compute recall against a ground truth set using quantized vectors.
+    QuantizationRecall(QuantizationRecallArgs),
 }
 
 #[derive(Args)]
@@ -195,6 +199,7 @@ fn distance_loss(
 
     let (count, error_sum, error_sq_sum) = (0..doc_limit)
         .into_par_iter()
+        .progress_count(doc_limit as u64)
         .flat_map(|d| {
             let mut doc_f32 = Cow::from(&vectors[d]);
             if let Some(center) = center.as_ref() {
@@ -207,7 +212,6 @@ fn distance_loss(
                 .into_par_iter()
                 .map(move |q| (q, d, Arc::clone(&doc)))
         })
-        .progress_count((query_scorers.len() * doc_limit) as u64)
         .map(|(q, d, doc)| {
             let (f32_dist, qdist) = &query_scorers[q];
             let diff = f32_dist
@@ -230,6 +234,153 @@ fn distance_loss(
     Ok(())
 }
 
+#[derive(Args)]
+pub struct QuantizationRecallArgs {
+    /// List of little-endian float32 queries.
+    #[arg(long)]
+    query_vectors: PathBuf,
+    /// Neighbors list to use as ground truth for each query.
+    #[arg(long)]
+    neighbors: PathBuf,
+    /// Number of neighbors per-query.
+    #[arg(long, default_value_t = NonZero::new(100).unwrap())]
+    neighbors_len: NonZero<usize>,
+    /// If true, quantize the query before scoring.
+    ///
+    /// Some format implement f32 x quantized scoring which is more accurate but slower.
+    #[arg(long, default_value_t = false)]
+    quantize_query: bool,
+    /// If set, only process this many input queries.
+    #[arg(long)]
+    query_limit: Option<usize>,
+
+    /// Vector coding to test.
+    #[arg(long)]
+    format: F32VectorCoding,
+    /// Similarity function to use.
+    #[arg(long)]
+    similarity: VectorSimilarity,
+
+    /// Number of results to compare.
+    #[arg(long)]
+    recall_k: NonZero<usize>,
+    /// If specified, consider any in the top rerank_budget as matches.
+    ///
+    /// This mimics the behavior of re-ranking with exact vectors.
+    #[arg(long)]
+    rerank_budget: Option<NonZero<usize>>,
+
+    #[arg(long)]
+    doc_limit: Option<usize>,
+}
+
+fn quantization_recall(
+    args: QuantizationRecallArgs,
+    vectors: &(impl VectorStore<Elem = f32> + Send + Sync),
+) -> io::Result<()> {
+    let query_vectors: DerefVectorStore<f32, Mmap> = DerefVectorStore::new(
+        unsafe { Mmap::map(&File::open(args.query_vectors)?)? },
+        NonZero::new(vectors.elem_stride()).unwrap(),
+    )?;
+    let neighbors: DerefVectorStore<u32, Mmap> = DerefVectorStore::new(
+        unsafe { Mmap::map(&File::open(args.neighbors)?)? },
+        args.neighbors_len,
+    )?;
+    let query_limit = args
+        .query_limit
+        .unwrap_or(query_vectors.len())
+        .min(query_vectors.len());
+
+    let coder = args.format.new_coder(args.similarity);
+    let query_scorers = (0..query_limit)
+        .into_par_iter()
+        .map(|i| {
+            let qdist = if args.quantize_query {
+                new_query_vector_distance_indexing(
+                    coder.encode(&query_vectors[i]),
+                    args.similarity,
+                    args.format,
+                )
+            } else {
+                new_query_vector_distance_f32(
+                    query_vectors[i].to_vec(),
+                    args.similarity,
+                    args.format,
+                )
+            };
+            qdist
+        })
+        .collect::<Vec<_>>();
+
+    // Keep the top neighbors, along with a maximum distance. The distance is read atomically as
+    // to filter non-competitive results; competitive results are added to the neighbor list and
+    // periodically pruned to update the competitive value.
+    struct TopNeighbors {
+        rep: CachePadded<Mutex<Vec<Neighbor>>>,
+        threshold: CachePadded<AtomicU64>,
+    }
+    impl TopNeighbors {
+        fn new(n: usize) -> Self {
+            Self {
+                rep: CachePadded::new(Mutex::new(Vec::with_capacity(n * 2))),
+                threshold: CachePadded::new(AtomicU64::new(f64::MAX.to_bits())),
+            }
+        }
+
+        fn push(&self, neighbor: Neighbor, n: usize) {
+            use std::sync::atomic::Ordering;
+
+            if f64::from_bits(self.threshold.load(Ordering::Relaxed)) < neighbor.distance() {
+                return; // neighbor is not competitive.
+            }
+
+            let mut neighbors = self.rep.lock().unwrap();
+            neighbors.push(neighbor);
+            if neighbors.len() == n * 2 {
+                let (_, t, _) = neighbors.select_nth_unstable(n - 1);
+                self.threshold
+                    .store(t.distance().to_bits(), Ordering::Relaxed);
+                neighbors.truncate(n);
+            }
+        }
+    }
+
+    let topn = args.rerank_budget.unwrap_or(args.recall_k).get();
+    let mut query_topn = Vec::with_capacity(query_limit);
+    query_topn.resize_with(query_limit, || TopNeighbors::new(topn));
+    (0..vectors.len())
+        .into_par_iter()
+        .progress_count((vectors.len()) as u64)
+        .for_each(|d| {
+            let doc = coder.encode(&vectors[d]);
+            for (q, s) in query_scorers.iter().enumerate() {
+                query_topn[q].push(Neighbor::new(d as i64, s.distance(&doc)), topn);
+            }
+        });
+
+    let matching = neighbors
+        .iter()
+        .zip(
+            query_topn
+                .into_iter()
+                .map(|r| r.rep.into_inner().into_inner().unwrap()),
+        )
+        .map(|(neighbors, results)| {
+            results
+                .iter()
+                .filter(|n| neighbors[..args.recall_k.get()].contains(&(n.vertex() as u32)))
+                .count()
+        })
+        .sum::<usize>();
+    println!(
+        "Recall@{}: {:.6}",
+        args.recall_k.get(),
+        matching as f64 / (args.recall_k.get() * query_scorers.len()) as f64
+    );
+
+    Ok(())
+}
+
 fn main() -> io::Result<()> {
     let cli = Cli::parse();
 
@@ -240,5 +391,6 @@ fn main() -> io::Result<()> {
     match cli.command {
         Command::QuantizationLoss(args) => quantization_loss(args, &vectors),
         Command::DistanceLoss(args) => distance_loss(args, &vectors),
+        Command::QuantizationRecall(args) => quantization_recall(args, &vectors),
     }
 }


### PR DESCRIPTION
This is a better grounded version of `distance-loss`.

This leverages a pre-computed topN set so we can skip `f32` scoring. Document vectors are quantized and then
compared against all the query vectors, which are then grouped by query. This is done using shared state because
managing this inversion directly with `rayon` leads to a ton of allocations.

One thing I've learned here is that the scaled-uniform quantization functions are _very_ slow.