### PR TITLE
Measure vector coder performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,10 @@ tempfile = "3.20.0"
 name = "distance"
 harness = false
 
+[[bench]]
+name = "coding"
+harness = false
+
 [workspace]
 members = ["et", "pt", "qt", "wt_mdb", "wt_sys"]
 

--- a/src/vectors/scaled_uniform.rs
+++ b/src/vectors/scaled_uniform.rs
@@ -94,7 +94,7 @@ impl F32VectorCoder for I8VectorCoder {
         let (scale, inv_scale) = compute_scale::<{ i8::MAX as i16 }>(vector);
         out[0..4].copy_from_slice(&inv_scale.to_le_bytes());
         out[4..8].copy_from_slice(&l2_norm.to_le_bytes());
-        self.encode_vector(vector, scale, out);
+        self.encode_vector(vector, scale, &mut out[8..]);
     }
 
     fn byte_len(&self, dimensions: usize) -> usize {


### PR DESCRIPTION
This is a significant chunk of the cost of quantization recall testing, on the order of 3-4us/vector.

Much of this cost is computing the maximum absolute value for the scaling factor, so vectorize that and reduce quantization
cost by ~80%.