### PR TITLE
Use aarch64 SIMD in `f16` implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,9 @@ criterion = "0.7.0"
 rand_xoshiro = "0.7.0"
 tempfile = "3.20.0"
 
+[build-dependencies]
+cc = "1.2.31"
+
 [[bench]]
 name = "distance"
 harness = false

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    println!("cargo::rerun-if-changed=src/vector/float16.c");
+    cc::Build::new()
+        .file("src/vectors/float16.c")
+        .compile("float16");
+}

--- a/src/vectors/float16.c
+++ b/src/vectors/float16.c
@@ -7,7 +7,7 @@
 float et_dot_f16(const __fp16* a, const __fp16* b, size_t len) {
   size_t tail_split = len & ~7;
   float32x4_t dotv = vdupq_n_f32(0.0);
-  for (int i = 0; i < tail_split; i += 8) {
+  for (size_t i = 0; i < tail_split; i += 8) {
     float16x8_t av = vld1q_f16(a + i);
     float16x8_t bv = vld1q_f16(b + i);
     dotv = vfmaq_f32(dotv, vcvt_f32_f16(vget_low_f16(av)),
@@ -21,7 +21,7 @@ float et_dot_f16(const __fp16* a, const __fp16* b, size_t len) {
     memset(&tail_a, 0, sizeof(tail_a));
     __fp16 tail_b[8];
     memset(&tail_b, 0, sizeof(tail_b));
-    for (int i = tail_split; i < len; i++) {
+    for (size_t i = tail_split; i < len; i++) {
       int dest = i - tail_split;
       tail_a[dest] = a[i];
       tail_b[dest] = b[i];

--- a/src/vectors/float16.c
+++ b/src/vectors/float16.c
@@ -18,6 +18,17 @@ HIDDEN float16x4_t load_tail_f16x4(const __fp16* v, size_t len) {
   return vld1_f16(&tail[0]);
 }
 
+// Load a partial value into a vector register to cover cases comparing to f16
+// where we will also have to a partial value into a vector register.
+HIDDEN float32x4_t load_tail_f32x4(const float* v, size_t len) {
+  float tail[4];
+  memset(&tail, 0, sizeof(tail));
+  for (size_t i = 0; i < len; i++) {
+    tail[i] = v[i];
+  }
+  return vld1q_f32(&tail[0]);
+}
+
 EXPORT float et_dot_f16_f16(const __fp16* a, const __fp16* b, size_t len) {
   size_t tail_split = len & ~3;
   float32x4_t dotv = vdupq_n_f32(0.0);
@@ -30,6 +41,25 @@ EXPORT float et_dot_f16_f16(const __fp16* a, const __fp16* b, size_t len) {
   if (tail_split < len) {
     float32x4_t av =
         vcvt_f32_f16(load_tail_f16x4(a + tail_split, len - tail_split));
+    float32x4_t bv =
+        vcvt_f32_f16(load_tail_f16x4(b + tail_split, len - tail_split));
+    dotv = vfmaq_f32(dotv, av, bv);
+  }
+
+  return vaddvq_f32(dotv);
+}
+
+EXPORT float et_dot_f32_f16(const float* a, const __fp16* b, size_t len) {
+  size_t tail_split = len & ~3;
+  float32x4_t dotv = vdupq_n_f32(0.0);
+  for (size_t i = 0; i < tail_split; i += 4) {
+    float32x4_t av = vld1q_f32(a + i);
+    float32x4_t bv = vcvt_f32_f16(vld1_f16(b + i));
+    dotv = vfmaq_f32(dotv, av, bv);
+  }
+
+  if (tail_split < len) {
+    float32x4_t av = load_tail_f32x4(a + tail_split, len - tail_split);
     float32x4_t bv =
         vcvt_f32_f16(load_tail_f16x4(b + tail_split, len - tail_split));
     dotv = vfmaq_f32(dotv, av, bv);
@@ -51,6 +81,27 @@ EXPORT float et_l2_f16_f16(const __fp16* a, const __fp16* b, size_t len) {
   if (tail_split < len) {
     float32x4_t av =
         vcvt_f32_f16(load_tail_f16x4(a + tail_split, len - tail_split));
+    float32x4_t bv =
+        vcvt_f32_f16(load_tail_f16x4(b + tail_split, len - tail_split));
+    float32x4_t dv = vsubq_f32(av, bv);
+    l2v = vfmaq_f32(l2v, dv, dv);
+  }
+
+  return vaddvq_f32(l2v);
+}
+
+EXPORT float et_l2_f32_f16(const float* a, const __fp16* b, size_t len) {
+  size_t tail_split = len & ~3;
+  float32x4_t l2v = vdupq_n_f32(0.0);
+  for (size_t i = 0; i < tail_split; i += 4) {
+    float32x4_t av = vld1q_f32(a + i);
+    float32x4_t bv = vcvt_f32_f16(vld1_f16(b + i));
+    float32x4_t dv = vsubq_f32(av, bv);
+    l2v = vfmaq_f32(l2v, dv, dv);
+  }
+
+  if (tail_split < len) {
+    float32x4_t av = load_tail_f32x4(a + tail_split, len - tail_split);
     float32x4_t bv =
         vcvt_f32_f16(load_tail_f16x4(b + tail_split, len - tail_split));
     float32x4_t dv = vsubq_f32(av, bv);

--- a/src/vectors/float16.c
+++ b/src/vectors/float16.c
@@ -1,41 +1,63 @@
+#define EXPORT __attribute__((visibility("default")))
+#define HIDDEN __attribute__((visibility("hidden")))
+
 #ifdef __aarch64__
 
 #include <arm_neon.h>
 #include <stddef.h>
 #include <string.h>
 
-float et_dot_f16(const __fp16* a, const __fp16* b, size_t len) {
-  size_t tail_split = len & ~7;
+// It's faster to fill out a full 4 value tail entry than it is
+// to convert and compute one element at a time.
+HIDDEN float16x4_t load_tail_f16x4(const __fp16* v, size_t len) {
+  __fp16 tail[4];
+  memset(&tail, 0, sizeof(tail));
+  for (size_t i = 0; i < len; i++) {
+    tail[i] = v[i];
+  }
+  return vld1_f16(&tail[0]);
+}
+
+EXPORT float et_dot_f16_f16(const __fp16* a, const __fp16* b, size_t len) {
+  size_t tail_split = len & ~3;
   float32x4_t dotv = vdupq_n_f32(0.0);
-  for (size_t i = 0; i < tail_split; i += 8) {
-    float16x8_t av = vld1q_f16(a + i);
-    float16x8_t bv = vld1q_f16(b + i);
-    dotv = vfmaq_f32(dotv, vcvt_f32_f16(vget_low_f16(av)),
-                     vcvt_f32_f16(vget_low_f16(bv)));
-    dotv = vfmaq_f32(dotv, vcvt_f32_f16(vget_high_f16(av)),
-                     vcvt_f32_f16(vget_high_f16(bv)));
+  for (size_t i = 0; i < tail_split; i += 4) {
+    float32x4_t av = vcvt_f32_f16(vld1_f16(a + i));
+    float32x4_t bv = vcvt_f32_f16(vld1_f16(b + i));
+    dotv = vfmaq_f32(dotv, av, bv);
   }
 
   if (tail_split < len) {
-    __fp16 tail_a[8];
-    memset(&tail_a, 0, sizeof(tail_a));
-    __fp16 tail_b[8];
-    memset(&tail_b, 0, sizeof(tail_b));
-    for (size_t i = tail_split; i < len; i++) {
-      int dest = i - tail_split;
-      tail_a[dest] = a[i];
-      tail_b[dest] = b[i];
-    }
-
-    float16x8_t av = vld1q_f16(&tail_a[0]);
-    float16x8_t bv = vld1q_f16(&tail_b[0]);
-    dotv = vfmaq_f32(dotv, vcvt_f32_f16(vget_low_f16(av)),
-                     vcvt_f32_f16(vget_low_f16(bv)));
-    dotv = vfmaq_f32(dotv, vcvt_f32_f16(vget_high_f16(av)),
-                     vcvt_f32_f16(vget_high_f16(bv)));
+    float32x4_t av =
+        vcvt_f32_f16(load_tail_f16x4(a + tail_split, len - tail_split));
+    float32x4_t bv =
+        vcvt_f32_f16(load_tail_f16x4(b + tail_split, len - tail_split));
+    dotv = vfmaq_f32(dotv, av, bv);
   }
 
   return vaddvq_f32(dotv);
+}
+
+EXPORT float et_l2_f16_f16(const __fp16* a, const __fp16* b, size_t len) {
+  size_t tail_split = len & ~3;
+  float32x4_t l2v = vdupq_n_f32(0.0);
+  for (size_t i = 0; i < tail_split; i += 4) {
+    float32x4_t av = vcvt_f32_f16(vld1_f16(a + i));
+    float32x4_t bv = vcvt_f32_f16(vld1_f16(b + i));
+    float32x4_t dv = vsubq_f32(av, bv);
+    l2v = vfmaq_f32(l2v, dv, dv);
+  }
+
+  if (tail_split < len) {
+    float32x4_t av =
+        vcvt_f32_f16(load_tail_f16x4(a + tail_split, len - tail_split));
+    float32x4_t bv =
+        vcvt_f32_f16(load_tail_f16x4(b + tail_split, len - tail_split));
+    float32x4_t dv = vsubq_f32(av, bv);
+    l2v = vfmaq_f32(l2v, dv, dv);
+  }
+
+  return vaddvq_f32(l2v);
 }
 
 #endif /* __aarch64__ */

--- a/src/vectors/float16.c
+++ b/src/vectors/float16.c
@@ -1,0 +1,41 @@
+#ifdef __aarch64__
+
+#include <arm_neon.h>
+#include <stddef.h>
+#include <string.h>
+
+float et_dot_f16(const __fp16* a, const __fp16* b, size_t len) {
+  size_t tail_split = len & ~7;
+  float32x4_t dotv = vdupq_n_f32(0.0);
+  for (int i = 0; i < tail_split; i += 8) {
+    float16x8_t av = vld1q_f16(a + i);
+    float16x8_t bv = vld1q_f16(b + i);
+    dotv = vfmaq_f32(dotv, vcvt_f32_f16(vget_low_f16(av)),
+                     vcvt_f32_f16(vget_low_f16(bv)));
+    dotv = vfmaq_f32(dotv, vcvt_f32_f16(vget_high_f16(av)),
+                     vcvt_f32_f16(vget_high_f16(bv)));
+  }
+
+  if (tail_split < len) {
+    __fp16 tail_a[8];
+    memset(&tail_a, 0, sizeof(tail_a));
+    __fp16 tail_b[8];
+    memset(&tail_b, 0, sizeof(tail_b));
+    for (int i = tail_split; i < len; i++) {
+      int dest = i - tail_split;
+      tail_a[dest] = a[i];
+      tail_b[dest] = b[i];
+    }
+
+    float16x8_t av = vld1q_f16(&tail_a[0]);
+    float16x8_t bv = vld1q_f16(&tail_b[0]);
+    dotv = vfmaq_f32(dotv, vcvt_f32_f16(vget_low_f16(av)),
+                     vcvt_f32_f16(vget_low_f16(bv)));
+    dotv = vfmaq_f32(dotv, vcvt_f32_f16(vget_high_f16(av)),
+                     vcvt_f32_f16(vget_high_f16(bv)));
+  }
+
+  return vaddvq_f32(dotv);
+}
+
+#endif /* __aarch64__ */

--- a/src/vectors/float16.rs
+++ b/src/vectors/float16.rs
@@ -45,7 +45,7 @@ impl VectorCoder {
     fn convert_and_encode(&self, vector: &[f32], scale: Option<f32>, out: &mut [u8]) {
         let vector_it = vector.iter().copied();
         if let Some(scale) = scale {
-            self.convert_and_encode_scalar(vector_it.map(|d| d * s), out)
+            self.convert_and_encode_scalar(vector_it.map(|d| d * scale), out)
         } else {
             self.convert_and_encode_scalar(vector_it, out)
         }


### PR DESCRIPTION
There no native support for `f16` in the toolchains so the generated code is quite naive and slow.

`f16` support is not stable in `std::arch::aarch64` and `std::simd` is also not stable for use with `half` so
write a C extension that uses neon intrinsics. This is _much_ faster than the original implementation and it
may actually be possible to use f16 now.

Benchmarks with f32 included for scale on an M2 Mac:
```
f32/coding/dot          time:   [361.74 ns 362.76 ns 363.88 ns]
f32/coding/l2           time:   [51.490 ns 51.742 ns 52.076 ns]

f16/coding/dot          time:   [405.71 ns 407.40 ns 409.25 ns]
                        change: [−37.873% −37.574% −37.273%] (p = 0.00 < 0.05)
f16/coding/l2           time:   [91.163 ns 91.447 ns 91.758 ns]
                        change: [−74.399% −74.318% −74.233%] (p = 0.00 < 0.05)

f32/dot                 time:   [241.63 ns 242.30 ns 243.06 ns]
f32/l2                  time:   [242.16 ns 243.03 ns 244.02 ns]

f16/doc/dot             time:   [248.88 ns 249.66 ns 250.48 ns]
                        change: [−70.600% −70.489% −70.355%] (p = 0.00 < 0.05)
f16/query/dot           time:   [245.72 ns 246.80 ns 248.21 ns]
                        change: [−71.077% −70.964% −70.858%] (p = 0.00 < 0.05)
f16/doc/l2              time:   [253.54 ns 254.50 ns 255.58 ns]
                        change: [−70.534% −70.332% −70.067%] (p = 0.00 < 0.05)
f16/query/l2            time:   [246.50 ns 247.45 ns 248.47 ns]
                        change: [−71.197% −71.094% −70.965%] (p = 0.00 < 0.05)
```

Note that `dot` similarity will normalize the vectors so improvement there is not as dramatic.