### PR TITLE
Add `VectorSimilarity::Cosine`

### DIFF
--- a/benches/coding.rs
+++ b/benches/coding.rs
@@ -29,8 +29,9 @@ fn benchmark_coding(
 }
 
 fn float32_benchmarks(c: &mut Criterion) {
-    benchmark_coding(c, F32VectorCoding::F32, Some(VectorSimilarity::Dot));
-    benchmark_coding(c, F32VectorCoding::F32, Some(VectorSimilarity::Euclidean));
+    for sim in VectorSimilarity::all() {
+        benchmark_coding(c, F32VectorCoding::F32, Some(sim));
+    }
 }
 
 fn float16_benchmarks(c: &mut Criterion) {

--- a/benches/coding.rs
+++ b/benches/coding.rs
@@ -35,8 +35,9 @@ fn float32_benchmarks(c: &mut Criterion) {
 }
 
 fn float16_benchmarks(c: &mut Criterion) {
-    benchmark_coding(c, F32VectorCoding::F16, Some(VectorSimilarity::Dot));
-    benchmark_coding(c, F32VectorCoding::F16, Some(VectorSimilarity::Euclidean));
+    for sim in VectorSimilarity::all() {
+        benchmark_coding(c, F32VectorCoding::F16, Some(sim));
+    }
 }
 
 fn i4_scaled_uniform_benchmarks(c: &mut Criterion) {

--- a/benches/distance.rs
+++ b/benches/distance.rs
@@ -29,7 +29,7 @@ fn benchmark_distance(
     let coder = coding.new_coder(similarity);
     let x = coder.encode(x);
     let y = coder.encode(y);
-    let dist = coding.new_symmetric_vector_distance(similarity).unwrap();
+    let dist = coding.new_vector_distance(similarity);
     c.bench_function(name, |b| {
         b.iter(|| std::hint::black_box(dist.distance(&x, &y)))
     });

--- a/benches/distance.rs
+++ b/benches/distance.rs
@@ -51,22 +51,9 @@ fn benchmark_query_distance(
 pub fn float32_benchmarks(c: &mut Criterion) {
     let (a, b) = generate_test_vectors(1024);
 
-    benchmark_distance(
-        "f32/dot",
-        &a,
-        &b,
-        F32VectorCoding::F32,
-        VectorSimilarity::Dot,
-        c,
-    );
-    benchmark_distance(
-        "f32/l2",
-        &a,
-        &b,
-        F32VectorCoding::F32,
-        VectorSimilarity::Euclidean,
-        c,
-    );
+    for sim in VectorSimilarity::all() {
+        benchmark_distance(&format!("f32/{sim}"), &a, &b, F32VectorCoding::F32, sim, c);
+    }
 }
 
 pub fn float16_benchmarks(c: &mut Criterion) {

--- a/benches/distance.rs
+++ b/benches/distance.rs
@@ -81,7 +81,7 @@ pub fn i8_scaled_non_uniform_benchmarks(c: &mut Criterion) {
 
 fn query_and_doc_benchmarks(c: &mut Criterion, format: F32VectorCoding) {
     let (x, y) = generate_test_vectors(1024);
-    for similarity in [VectorSimilarity::Dot, VectorSimilarity::Euclidean] {
+    for similarity in VectorSimilarity::all() {
         benchmark_distance(
             &format!("{format}/doc/{similarity}"),
             &x,

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -94,9 +94,8 @@ impl GraphConfig {
     }
 
     /// Return a distance function for quantized navigational vectors in the index.
-    pub fn new_nav_distance_function(&self) -> Option<Box<dyn VectorDistance>> {
-        self.nav_format
-            .new_symmetric_vector_distance(self.similarity)
+    pub fn new_nav_distance_function(&self) -> Box<dyn VectorDistance> {
+        self.nav_format.new_vector_distance(self.similarity)
     }
 
     /// Return a new vector coder for the rerank vector format.
@@ -186,10 +185,7 @@ impl EdgeSetDistanceComputer {
         } else {
             let vectors = Self::extract_vectors(&mut reader.nav_vectors()?, edges)?;
             Ok(Self {
-                distance_fn: reader
-                    .config()
-                    .new_nav_distance_function()
-                    .expect("symmetrical vector coding on disk"),
+                distance_fn: reader.config().new_nav_distance_function(),
                 vectors,
             })
         }

--- a/src/vectors/binary.rs
+++ b/src/vectors/binary.rs
@@ -23,76 +23,6 @@ impl F32VectorCoder for BinaryQuantizedVectorCoder {
     }
 }
 
-#[derive(Debug, Copy, Clone)]
-pub struct AsymmetricBinaryQuantizedVectorCoder(usize);
-
-impl AsymmetricBinaryQuantizedVectorCoder {
-    /// Create a new quantizer.
-    ///
-    /// *Panics* if `!(1..=8).contains(&n)`
-    pub fn new(n: usize) -> Self {
-        assert!((1..=8).contains(&n));
-        Self(n)
-    }
-
-    /// Produce a packed u8 representation containing only `bit` from each byte of `dword`.
-    fn summarize_chunk(mut dword: u64, bit: usize) -> u8 {
-        // First, shift and mask so that only `bit` is present as the lowest bit in each byte.
-        // Shift bit to the lowest position in each byte of word.
-        dword = (dword >> bit) & 0x0101010101010101;
-
-        // Add a magic constant and mask to get a different bit set for each value if the
-        // bit for that byte is present in the input word.
-        dword = (dword + 0x7f3f1f0f_07030100) & 0x80402010_08040201;
-
-        // Reduce and mask down to a single byte;
-        let word = dword | (dword >> 32);
-        let hword = word | (word >> 16);
-        (hword | (hword >> 8)) as u8
-    }
-}
-
-impl F32VectorCoder for AsymmetricBinaryQuantizedVectorCoder {
-    fn encode_to(&self, vector: &[f32], out: &mut [u8]) {
-        if vector.is_empty() || self.0 == 1 {
-            BinaryQuantizedVectorCoder.encode_to(vector, out);
-            return;
-        }
-
-        // Scale each dimension to be in [0, 2^n) and produce a trivially quantized vector.
-        let (min, max) = vector.iter().fold((f32::MAX, f32::MIN), |(min, max), d| {
-            assert!(!d.is_nan());
-            (min.min(*d), max.max(*d))
-        });
-        assert!(min <= max);
-        let scale = (max - min) / ((1 << self.0) - 1) as f32;
-        let trivial_quantized = vector
-            .iter()
-            .map(|d| ((*d - min) / scale).round() as u8)
-            .collect::<Vec<_>>();
-
-        let doc_bytes = vector.len().div_ceil(8);
-
-        for (i, chunk) in trivial_quantized.chunks(8).enumerate() {
-            let word = if chunk.len() == 8 {
-                u64::from_le_bytes(chunk.try_into().expect("exactly 8 bytes"))
-            } else {
-                assert!(chunk.len() <= 8);
-                let mut bytes = [0u8; 8];
-                bytes[0..chunk.len()].copy_from_slice(chunk);
-                u64::from_le_bytes(bytes)
-            };
-            for bit in 0..self.0 {
-                out[doc_bytes * bit + i] = Self::summarize_chunk(word, bit);
-            }
-        }
-    }
-
-    fn byte_len(&self, dimensions: usize) -> usize {
-        dimensions.div_ceil(8) * self.0
-    }
-}
-
 /// Computes a score from two bitmaps using hamming distance.
 #[derive(Debug, Copy, Clone)]
 pub struct HammingDistance;
@@ -100,23 +30,5 @@ pub struct HammingDistance;
 impl VectorDistance for HammingDistance {
     fn distance(&self, a: &[u8], b: &[u8]) -> f64 {
         BinarySimilarity::hamming(a, b).expect("same dimensionality")
-    }
-}
-
-/// Computes a score between a query and doc vectors produced by [crate::quantization::AsymmetricBinaryQuantizer]
-#[derive(Debug, Copy, Clone)]
-pub struct AsymmetricHammingDistance;
-
-impl VectorDistance for AsymmetricHammingDistance {
-    fn distance(&self, query: &[u8], doc: &[u8]) -> f64 {
-        assert_eq!(query.len() % doc.len(), 0);
-        query
-            .chunks(doc.len())
-            .enumerate()
-            .map(|(i, v)| {
-                BinarySimilarity::hamming(doc, v).expect("same dimensionality") as usize
-                    * (1usize << i)
-            })
-            .sum::<usize>() as f64
     }
 }

--- a/src/vectors/float16.rs
+++ b/src/vectors/float16.rs
@@ -3,10 +3,7 @@ use std::borrow::Cow;
 use half::f16;
 use simsimd::SpatialSimilarity;
 
-use crate::{
-    distance::l2_normalize,
-    vectors::{F32VectorCoder, QueryVectorDistance, VectorDistance, VectorSimilarity},
-};
+use crate::vectors::{F32VectorCoder, QueryVectorDistance, VectorDistance, VectorSimilarity};
 
 // While the `half` crate supports f16, SIMD features are limited to nightly and even the related
 // intrinsics are not stable on aarch64, so resort to C linkage.
@@ -141,8 +138,7 @@ pub struct DotProductQueryDistance<'a>(Cow<'a, [f32]>);
 
 impl<'a> DotProductQueryDistance<'a> {
     pub fn new(query: Cow<'a, [f32]>) -> Self {
-        // XXX may not need this anymore.
-        Self(l2_normalize(query))
+        Self(query)
     }
 
     #[allow(dead_code)]

--- a/src/vectors/float32.rs
+++ b/src/vectors/float32.rs
@@ -113,7 +113,13 @@ impl F32VectorDistance for CosineDistance {
     fn distance_f32(&self, a: &[f32], b: &[f32]) -> f64 {
         // We can't assume the vectors have been processed/normalized here so we have to perform
         // full cosine similarity.
-        SpatialSimilarity::cos(a, b).unwrap()
+        let (ab, a2, b2) = a
+            .iter()
+            .zip(b.iter())
+            .map(|(a, b)| (*a * b, *a * *a, *b * *b))
+            .fold((0.0, 0.0, 0.0), |s, x| (s.0 + x.0, s.1 + x.1, s.2 + x.2));
+        let cos = ab / (a2.sqrt() * b2.sqrt());
+        (-cos as f64 + 1.0) / 2.0
     }
 }
 

--- a/src/vectors/mod.rs
+++ b/src/vectors/mod.rs
@@ -390,7 +390,10 @@ pub fn new_query_vector_distance_f32<'a>(
 
     match (similarity, coding) {
         (_, F32VectorCoding::F32) => float32::new_query_vector_distance(similarity, query.into()),
-        (Dot, F32VectorCoding::F16) | (Cosine, F32VectorCoding::F16) => {
+        (Cosine, F32VectorCoding::F16) => Box::new(float16::DotProductQueryDistance::new(
+            l2_normalize(query.into()),
+        )),
+        (Dot, F32VectorCoding::F16) => {
             Box::new(float16::DotProductQueryDistance::new(query.into()))
         }
         (Euclidean, F32VectorCoding::F16) => {

--- a/src/vectors/mod.rs
+++ b/src/vectors/mod.rs
@@ -226,44 +226,40 @@ impl F32VectorCoding {
 
     /// Returns a [VectorDistance] for symmetrical vector codings, or [None] if the encoding is not
     /// symmetrical.
-    // XXX should maybe remove this???
-    pub fn new_symmetric_vector_distance(
-        &self,
-        similarity: VectorSimilarity,
-    ) -> Option<Box<dyn VectorDistance>> {
+    pub fn new_vector_distance(&self, similarity: VectorSimilarity) -> Box<dyn VectorDistance> {
         use VectorSimilarity::{Cosine, Dot, Euclidean};
 
         match (self, similarity) {
-            (Self::F32, Cosine) => Some(Box::new(float32::CosineDistance)),
-            (Self::F32, Dot) => Some(Box::new(float32::DotProductDistance)),
-            (Self::F32, Euclidean) => Some(Box::new(float32::EuclideanDistance)),
-            (Self::F16, Dot) | (Self::F16, Cosine) => Some(Box::new(float16::DotProductDistance)),
-            (Self::F16, Euclidean) => Some(Box::new(float16::EuclideanDistance)),
-            (Self::BinaryQuantized, _) => Some(Box::new(HammingDistance)),
+            (Self::F32, Cosine) => Box::new(float32::CosineDistance),
+            (Self::F32, Dot) => Box::new(float32::DotProductDistance),
+            (Self::F32, Euclidean) => Box::new(float32::EuclideanDistance),
+            (Self::F16, Dot) | (Self::F16, Cosine) => Box::new(float16::DotProductDistance),
+            (Self::F16, Euclidean) => Box::new(float16::EuclideanDistance),
+            (Self::BinaryQuantized, _) => Box::new(binary::HammingDistance),
             (Self::I8ScaledUniformQuantized, Dot) | (Self::I8ScaledUniformQuantized, Cosine) => {
-                Some(Box::new(scaled_uniform::I8DotProductDistance))
+                Box::new(scaled_uniform::I8DotProductDistance)
             }
             (Self::I8ScaledUniformQuantized, Euclidean) => {
-                Some(Box::new(scaled_uniform::I8EuclideanDistance))
+                Box::new(scaled_uniform::I8EuclideanDistance)
             }
             (Self::I4ScaledUniformQuantized, Dot) | (Self::I4ScaledUniformQuantized, Cosine) => {
-                Some(Box::new(scaled_uniform::I4PackedDotProductDistance))
+                Box::new(scaled_uniform::I4PackedDotProductDistance)
             }
             (Self::I4ScaledUniformQuantized, Euclidean) => {
-                Some(Box::new(scaled_uniform::I4PackedEuclideanDistance))
+                Box::new(scaled_uniform::I4PackedEuclideanDistance)
             }
             (Self::I16ScaledUniformQuantized, Dot) | (Self::I16ScaledUniformQuantized, Cosine) => {
-                Some(Box::new(scaled_uniform::I16DotProductDistance))
+                Box::new(scaled_uniform::I16DotProductDistance)
             }
             (Self::I16ScaledUniformQuantized, Euclidean) => {
-                Some(Box::new(scaled_uniform::I16EuclideanDistance))
+                Box::new(scaled_uniform::I16EuclideanDistance)
             }
             (Self::I8ScaledNonUniformQuantized(s), Dot)
             | (Self::I8ScaledNonUniformQuantized(s), Cosine) => {
-                Some(Box::new(scaled_non_uniform::I8DotProductDistance::new(*s)))
+                Box::new(scaled_non_uniform::I8DotProductDistance::new(*s))
             }
             (Self::I8ScaledNonUniformQuantized(s), Euclidean) => {
-                Some(Box::new(scaled_non_uniform::I8EuclideanDistance::new(*s)))
+                Box::new(scaled_non_uniform::I8EuclideanDistance::new(*s))
             }
         }
     }
@@ -566,7 +562,7 @@ mod test {
             f32_dist_fn.distance(bytemuck::cast_slice(&a.rvec), bytemuck::cast_slice(&b.rvec));
         assert_float_near!(rf32_dist, ru8_dist, 0.00001, index);
 
-        let dist_fn = format.new_symmetric_vector_distance(similarity).unwrap();
+        let dist_fn = format.new_vector_distance(similarity);
         let qdist = dist_fn.distance(&a.qvec, &b.qvec);
         assert_float_near!(rf32_dist, qdist, threshold, index);
     }


### PR DESCRIPTION
This allows us to run angular distance in two modes:
* `Dot` for l2 normalized inputs
* `Cosine` for unnormalized inputs

Making this distinction allows us to avoid dot product/normalization in vector coding and distance computation
in spots if we know that the vectors are normalized already.

Remove asymmetric binary coding. It doesn't make much sense at the moment and should be a QueryVectorDistance
instead of a full-fledged codec. We'd also likely be better off if this were replaced with an i8 scaled-uniform based
query encoding and decoding.