### PR TITLE
Add truncatedf32 vector coding

### DIFF
--- a/src/vectors/mod.rs
+++ b/src/vectors/mod.rs
@@ -161,6 +161,13 @@ pub enum F32VectorCoding {
     /// so users should not rely on the value being identical.
     #[default]
     F32,
+    /// Little-endian f32 values truncated at some maximum dimension.
+    ///
+    /// This is useful for Matryoshka Representation Learned (MRL) models.
+    ///
+    /// Note that for dot product similarity the truncated value will be l2 normalized before it is
+    /// encoded.
+    TruncatedF32(usize),
     /// Little-endian IEEE f16 encoding.
     F16,
     /// Single bit (sign bit) per dimension.
@@ -198,12 +205,6 @@ pub enum F32VectorCoding {
     /// This is aimed at MRL vectors that are designed to be truncated and may have different value
     /// distributions in different segments.
     I8ScaledNonUniformQuantized(NonUniformQuantizedDimensions),
-    /// Truncate at a fixed number of dimensions.
-    ///
-    /// Note that for dot product similarity the truncated value will be l2 normalized before it is
-    /// encoded.
-    // XXX name TruncatedF32
-    Truncated(usize),
 }
 
 impl F32VectorCoding {
@@ -211,6 +212,7 @@ impl F32VectorCoding {
     pub fn new_coder(&self, similarity: VectorSimilarity) -> Box<dyn F32VectorCoder> {
         match self {
             Self::F32 => Box::new(float32::VectorCoder::new(similarity)),
+            Self::TruncatedF32(d) => Box::new(truncated::VectorCoder::new(similarity, *d)),
             Self::F16 => Box::new(float16::VectorCoder::new(similarity)),
             Self::BinaryQuantized => Box::new(binary::BinaryQuantizedVectorCoder),
             Self::I8ScaledUniformQuantized => {
@@ -225,7 +227,6 @@ impl F32VectorCoding {
             Self::I8ScaledNonUniformQuantized(s) => {
                 Box::new(scaled_non_uniform::I8VectorCoder::new(similarity, *s))
             }
-            Self::Truncated(d) => Box::new(truncated::VectorCoder::new(similarity, *d)),
         }
     }
 
@@ -237,6 +238,7 @@ impl F32VectorCoding {
             (Self::F32, Cosine) => Box::new(float32::CosineDistance),
             (Self::F32, Dot) => Box::new(float32::DotProductDistance),
             (Self::F32, Euclidean) => Box::new(float32::EuclideanDistance),
+            (Self::TruncatedF32(_), _) => F32VectorCoding::F32.new_vector_distance(similarity),
             (Self::F16, Dot) | (Self::F16, Cosine) => Box::new(float16::DotProductDistance),
             (Self::F16, Euclidean) => Box::new(float16::EuclideanDistance),
             (Self::BinaryQuantized, _) => Box::new(binary::HammingDistance),
@@ -265,7 +267,6 @@ impl F32VectorCoding {
             (Self::I8ScaledNonUniformQuantized(s), Euclidean) => {
                 Box::new(scaled_non_uniform::I8EuclideanDistance::new(*s))
             }
-            (Self::Truncated(_), _) => F32VectorCoding::F32.new_vector_distance(similarity),
         }
     }
 }
@@ -277,6 +278,12 @@ impl FromStr for F32VectorCoding {
         let input_err = |s| io::Error::new(io::ErrorKind::InvalidInput, s);
         match s {
             "raw" | "raw-l2-norm" | "f32" => Ok(Self::F32),
+            s if s.starts_with("truncatedf32:") => {
+                let s = s.strip_prefix("truncatedf32:").expect("prefix matched");
+                s.parse::<usize>()
+                    .map(Self::TruncatedF32)
+                    .map_err(|_| input_err("could not parse dimension".into()))
+            }
             "f16" => Ok(Self::F16),
             "binary" => Ok(Self::BinaryQuantized),
             "i8-scaled-uniform" => Ok(Self::I8ScaledUniformQuantized),
@@ -296,12 +303,6 @@ impl FromStr for F32VectorCoding {
                 .map_err(|e| input_err(e.into()))?;
                 Ok(Self::I8ScaledNonUniformQuantized(splits))
             }
-            s if s.starts_with("truncated:") => {
-                let s = s.strip_prefix("truncated:").expect("prefix matched");
-                s.parse::<usize>()
-                    .map(Self::Truncated)
-                    .map_err(|_| input_err("could not parse dimension".into()))
-            }
             _ => Err(input_err(format!("unknown vector coding {s}"))),
         }
     }
@@ -311,6 +312,7 @@ impl std::fmt::Display for F32VectorCoding {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::F32 => write!(f, "f32"),
+            Self::TruncatedF32(d) => write!(f, "truncatedf32:{}", *d),
             Self::F16 => write!(f, "f16"),
             Self::BinaryQuantized => write!(f, "binary"),
             Self::I8ScaledUniformQuantized => write!(f, "i8-scaled-uniform"),
@@ -325,7 +327,6 @@ impl std::fmt::Display for F32VectorCoding {
                     .collect::<Vec<_>>()
                     .join(",")
             ),
-            Self::Truncated(d) => write!(f, "truncated:{}", *d),
         }
     }
 }
@@ -398,6 +399,15 @@ pub fn new_query_vector_distance_f32<'a>(
 
     match (similarity, coding) {
         (_, F32VectorCoding::F32) => float32::new_query_vector_distance(similarity, query.into()),
+        (_, F32VectorCoding::TruncatedF32(n)) => {
+            let query = query.into();
+            let truncated = match similarity {
+                VectorSimilarity::Dot => l2_normalize(&query[..(n.min(query.len()))]),
+                _ => Cow::from(&query[..(n.min(query.len()))]),
+            }
+            .to_vec();
+            float32::new_query_vector_distance(similarity, truncated.into())
+        }
         (Cosine, F32VectorCoding::F16) => Box::new(float16::DotProductQueryDistance::new(
             l2_normalize(query.into()),
         )),
@@ -448,15 +458,6 @@ pub fn new_query_vector_distance_f32<'a>(
         (Euclidean, F32VectorCoding::I8ScaledNonUniformQuantized(s)) => Box::new(
             scaled_non_uniform::I8EuclideanQueryDistance::new(s, query.into()),
         ),
-        (_, F32VectorCoding::Truncated(n)) => {
-            let query = query.into();
-            let truncated = match similarity {
-                VectorSimilarity::Dot => l2_normalize(&query[..(n.min(query.len()))]),
-                _ => Cow::from(&query[..(n.min(query.len()))]),
-            }
-            .to_vec();
-            float32::new_query_vector_distance(similarity, truncated.into())
-        }
     }
 }
 
@@ -478,6 +479,9 @@ pub fn new_query_vector_distance_indexing<'a>(
         (Cosine, F32VectorCoding::F32) => quantized_qvd!(float32::CosineDistance, query),
         (Dot, F32VectorCoding::F32) => quantized_qvd!(float32::DotProductDistance, query),
         (Euclidean, F32VectorCoding::F32) => quantized_qvd!(float32::EuclideanDistance, query),
+        (_, F32VectorCoding::TruncatedF32(_)) => {
+            new_query_vector_distance_indexing(query, similarity, F32VectorCoding::F32)
+        }
         (Cosine, F32VectorCoding::F16) => unimplemented!(),
         (Dot, F32VectorCoding::F16) => quantized_qvd!(float16::DotProductDistance, query),
         (Euclidean, F32VectorCoding::F16) => quantized_qvd!(float16::EuclideanDistance, query),
@@ -509,9 +513,6 @@ pub fn new_query_vector_distance_indexing<'a>(
         }
         (Euclidean, F32VectorCoding::I8ScaledNonUniformQuantized(s)) => {
             quantized_qvd!(scaled_non_uniform::I8EuclideanDistance::new(s), query)
-        }
-        (_, F32VectorCoding::Truncated(_)) => {
-            new_query_vector_distance_indexing(query, similarity, F32VectorCoding::F32)
         }
     }
 }

--- a/src/vectors/mod.rs
+++ b/src/vectors/mod.rs
@@ -202,6 +202,7 @@ pub enum F32VectorCoding {
     ///
     /// Note that for dot product similarity the truncated value will be l2 normalized before it is
     /// encoded.
+    // XXX name TruncatedF32
     Truncated(usize),
 }
 

--- a/src/vectors/truncated.rs
+++ b/src/vectors/truncated.rs
@@ -1,0 +1,35 @@
+use crate::vectors::{F32VectorCoder, F32VectorCoding, VectorSimilarity};
+
+pub struct VectorCoder {
+    dimensions: usize,
+    coder: Box<dyn F32VectorCoder>,
+}
+
+impl VectorCoder {
+    pub fn new(similarity: VectorSimilarity, dimensions: usize) -> Self {
+        // Coerce dot => cosine to ensure that the truncated vectors are l2 normalized.
+        let similarity = match similarity {
+            VectorSimilarity::Dot => VectorSimilarity::Cosine,
+            _ => similarity,
+        };
+        Self {
+            dimensions,
+            coder: F32VectorCoding::F32.new_coder(similarity),
+        }
+    }
+}
+
+impl F32VectorCoder for VectorCoder {
+    fn byte_len(&self, dimensions: usize) -> usize {
+        self.coder.byte_len(self.dimensions.min(dimensions))
+    }
+
+    fn encode_to(&self, vector: &[f32], out: &mut [u8]) {
+        self.coder
+            .encode_to(&vector[..self.dimensions.min(vector.len())], out)
+    }
+
+    fn decode(&self, encoded: &[u8]) -> Option<Vec<f32>> {
+        self.coder.decode(encoded)
+    }
+}


### PR DESCRIPTION
Allow truncating at a fixed dimensionality. This is useful for MRL model output where certain ranges of dimensions
are "more important" than others to the final similarity result and a truncated vector can be useful on its own.

There is some temptation to generalize this to allow truncating and then applying an arbitrary vector coding. In practice
this is a huge message as `F32VectorCoding` must become `!Copy`.