### PR TITLE
SIMD accelerate lvq vector encoding on aarch64

### DIFF
--- a/src/vectors/lvq.rs
+++ b/src/vectors/lvq.rs
@@ -19,7 +19,7 @@ use aarch64::*;
 #[cfg(not(target_arch = "aarch64"))]
 use scalar::*;
 
-use std::{borrow::Cow, iter::FusedIterator};
+use std::borrow::Cow;
 
 use crate::vectors::{F32VectorCoder, QueryVectorDistance, VectorDistance};
 
@@ -112,103 +112,6 @@ const MINIMUM_MSE_GRID: [(f32, f32); 8] = [
 ];
 
 const LAMBDA: f32 = 0.1;
-
-struct PrimaryQuantizer<'a> {
-    it: std::slice::Iter<'a, f32>,
-    header: VectorHeader,
-    delta: f32,
-}
-
-impl<'a> PrimaryQuantizer<'a> {
-    fn new(v: &'a [f32], bits: usize) -> Self {
-        let stats = VectorStats::from(v);
-        let mut header = VectorHeader::from(stats);
-        (header.lower, header.upper) = optimize_interval(v, &stats, bits);
-        let delta = (header.upper - header.lower) / ((1 << bits) - 1) as f32;
-        Self {
-            it: v.iter(),
-            header,
-            delta,
-        }
-    }
-
-    fn into_header(self) -> VectorHeader {
-        assert_eq!(self.it.len(), 0);
-        self.header
-    }
-}
-
-impl Iterator for PrimaryQuantizer<'_> {
-    type Item = u8;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.it.next().map(|x| {
-            let q = ((x.clamp(self.header.lower, self.header.upper) - self.header.lower)
-                / self.delta)
-                .round() as u8;
-            self.header.component_sum += u32::from(q);
-            q
-        })
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        self.it.size_hint()
-    }
-}
-
-impl ExactSizeIterator for PrimaryQuantizer<'_> {}
-
-impl FusedIterator for PrimaryQuantizer<'_> {}
-
-struct TwoLevelQuantizer<'a> {
-    primary_it: PrimaryQuantizer<'a>,
-    f32_it: std::slice::Iter<'a, f32>,
-    lower: f32,
-    upper: f32,
-    delta: f32,
-}
-
-impl<'a> TwoLevelQuantizer<'a> {
-    pub fn new(v: &'a [f32], bits1: usize, bits2: usize) -> Self {
-        let primary_it = PrimaryQuantizer::new(v, bits1);
-        let f32_it = v.iter();
-        let lower = -primary_it.delta / 2.0;
-        let upper = primary_it.delta / 2.0;
-        let delta = primary_it.delta / ((1 << bits2) - 1) as f32;
-        Self {
-            primary_it,
-            f32_it,
-            lower,
-            upper,
-            delta,
-        }
-    }
-
-    fn into_header(self) -> VectorHeader {
-        self.primary_it.into_header()
-    }
-}
-
-impl Iterator for TwoLevelQuantizer<'_> {
-    type Item = (u8, u8);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let x = self.f32_it.next()?;
-        let q = self.primary_it.next()?;
-        let res = (*x - ((q as f32 * self.primary_it.delta) + self.primary_it.header.lower))
-            .clamp(self.lower, self.upper);
-        let r = ((res - self.lower) / self.delta).round() as u8;
-        Some((q, r))
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        self.primary_it.size_hint()
-    }
-}
-
-impl ExactSizeIterator for TwoLevelQuantizer<'_> {}
-
-impl FusedIterator for TwoLevelQuantizer<'_> {}
 
 /// An LVQ1 coded primary vector.
 ///
@@ -331,12 +234,20 @@ pub struct TwoLevelVectorCoder<const B1: usize, const B2: usize>;
 
 impl<const B1: usize, const B2: usize> F32VectorCoder for TwoLevelVectorCoder<B1, B2> {
     fn encode_to(&self, vector: &[f32], out: &mut [u8]) {
-        let mut it = TwoLevelQuantizer::new(vector, B1, B2);
+        let stats = VectorStats::from(vector);
+        let mut header = VectorHeader::from(stats);
+        (header.lower, header.upper) = optimize_interval(vector, &stats, B1);
         let (header_bytes, vector_bytes) = VectorHeader::split_output_buf(out).unwrap();
         let split = packing::two_vector_split(vector_bytes.len(), B1, B2);
         let (primary, residual) = vector_bytes.split_at_mut(split);
-        packing::pack_iter2::<B1, B2>(it.by_ref(), primary, residual);
-        it.into_header().serialize(header_bytes);
+        header.component_sum = scalar::lvq2_quantize_and_pack::<B1, B2>(
+            vector,
+            header.lower,
+            header.upper,
+            primary,
+            residual,
+        );
+        header.serialize(header_bytes);
     }
 
     fn byte_len(&self, dimensions: usize) -> usize {

--- a/src/vectors/lvq.rs
+++ b/src/vectors/lvq.rs
@@ -12,6 +12,13 @@
 mod aarch64;
 mod scalar;
 
+#[allow(unused_imports)]
+#[cfg(target_arch = "aarch64")]
+use aarch64::*;
+#[allow(unused_imports)]
+#[cfg(not(target_arch = "aarch64"))]
+use scalar::*;
+
 use std::{borrow::Cow, iter::FusedIterator};
 
 use crate::vectors::{F32VectorCoder, QueryVectorDistance, VectorDistance};
@@ -28,18 +35,13 @@ struct VectorStats {
 impl From<&[f32]> for VectorStats {
     fn from(value: &[f32]) -> Self {
         if value.is_empty() {
-            return VectorStats {
+            VectorStats {
                 l2_norm_sq: 1.0,
                 ..Default::default()
-            };
+            }
+        } else {
+            compute_vector_stats(value)
         }
-
-        #[cfg(target_arch = "aarch64")]
-        use aarch64::compute_vector_stats;
-        #[cfg(not(target_arch = "aarch64"))]
-        use scalar::compute_vector_stats;
-
-        compute_vector_stats(value)
     }
 }
 
@@ -110,11 +112,6 @@ const MINIMUM_MSE_GRID: [(f32, f32); 8] = [
 ];
 
 const LAMBDA: f32 = 0.1;
-
-#[cfg(target_arch = "aarch64")]
-use aarch64::optimize_interval;
-#[cfg(not(target_arch = "aarch64"))]
-use scalar::optimize_interval;
 
 struct PrimaryQuantizer<'a> {
     it: std::slice::Iter<'a, f32>,
@@ -311,18 +308,13 @@ pub struct PrimaryVectorCoder<const B: usize>;
 
 impl<const B: usize> F32VectorCoder for PrimaryVectorCoder<B> {
     fn encode_to(&self, vector: &[f32], out: &mut [u8]) {
-        /*
-        let it = PrimaryQuantizer::new(vector, B);
+        let stats = VectorStats::from(vector);
+        let mut header = VectorHeader::from(stats);
+        (header.lower, header.upper) = optimize_interval(vector, &stats, B);
         let (header_bytes, vector_bytes) = VectorHeader::split_output_buf(out).unwrap();
-        let mut header = it.header;
         header.component_sum =
-            aarch64::lvq1_quantize_and_pack::<B>(vector, header.lower, header.upper, vector_bytes);
+            lvq1_quantize_and_pack::<B>(vector, header.lower, header.upper, vector_bytes);
         header.serialize(header_bytes);
-        */
-        let mut it = PrimaryQuantizer::new(vector, B);
-        let (header_bytes, vector_bytes) = VectorHeader::split_output_buf(out).unwrap();
-        packing::pack_iter::<B>(it.by_ref(), vector_bytes);
-        it.into_header().serialize(header_bytes);
     }
 
     fn byte_len(&self, dimensions: usize) -> usize {

--- a/src/vectors/lvq.rs
+++ b/src/vectors/lvq.rs
@@ -311,6 +311,14 @@ pub struct PrimaryVectorCoder<const B: usize>;
 
 impl<const B: usize> F32VectorCoder for PrimaryVectorCoder<B> {
     fn encode_to(&self, vector: &[f32], out: &mut [u8]) {
+        /*
+        let it = PrimaryQuantizer::new(vector, B);
+        let (header_bytes, vector_bytes) = VectorHeader::split_output_buf(out).unwrap();
+        let mut header = it.header;
+        header.component_sum =
+            aarch64::lvq1_quantize_and_pack::<B>(vector, header.lower, header.upper, vector_bytes);
+        header.serialize(header_bytes);
+        */
         let mut it = PrimaryQuantizer::new(vector, B);
         let (header_bytes, vector_bytes) = VectorHeader::split_output_buf(out).unwrap();
         packing::pack_iter::<B>(it.by_ref(), vector_bytes);

--- a/src/vectors/lvq.rs
+++ b/src/vectors/lvq.rs
@@ -240,13 +240,8 @@ impl<const B1: usize, const B2: usize> F32VectorCoder for TwoLevelVectorCoder<B1
         let (header_bytes, vector_bytes) = VectorHeader::split_output_buf(out).unwrap();
         let split = packing::two_vector_split(vector_bytes.len(), B1, B2);
         let (primary, residual) = vector_bytes.split_at_mut(split);
-        header.component_sum = scalar::lvq2_quantize_and_pack::<B1, B2>(
-            vector,
-            header.lower,
-            header.upper,
-            primary,
-            residual,
-        );
+        header.component_sum =
+            lvq2_quantize_and_pack::<B1, B2>(vector, header.lower, header.upper, primary, residual);
         header.serialize(header_bytes);
     }
 

--- a/src/vectors/lvq/aarch64.rs
+++ b/src/vectors/lvq/aarch64.rs
@@ -329,10 +329,12 @@ pub fn lvq1_quantize_and_pack<const B: usize>(
         0
     };
 
-    let s = component_sum
-        + super::scalar::lvq1_quantize_and_pack::<B>(&v[tail_split..], lower, upper, tail);
-    super::scalar::lvq1_quantize_and_pack::<B>(v, lower, upper, out);
-    s
+    if tail_split < v.len() {
+        component_sum
+            + super::scalar::lvq1_quantize_and_pack::<B>(&v[tail_split..], lower, upper, tail)
+    } else {
+        component_sum
+    }
 }
 
 #[allow(dead_code, unused_variables)]

--- a/src/vectors/lvq/aarch64.rs
+++ b/src/vectors/lvq/aarch64.rs
@@ -1,13 +1,13 @@
 //! aarch64 implementations of lvq routines.
 
 use std::arch::aarch64::{
-    float32x4_t, vaddlvq_u8, vaddq_f32, vaddq_f64, vaddvq_f32, vaddvq_u16, vaddvq_u32, vaddvq_u64,
-    vcvt_f64_f32, vcvt_high_f64_f32, vcvtaq_u32_f32, vdivq_f32, vdupq_n_f32, vdupq_n_f64,
-    vextq_f64, vfmaq_f32, vfmaq_f64, vget_low_f32, vgetq_lane_f64, vld1q_f32, vld1q_s16, vld1q_s32,
-    vld1q_s64, vld1q_s8, vmaxq_f32, vmaxvq_f32, vminq_f32, vminvq_f32, vmovn_high_u16,
-    vmovn_high_u32, vmovn_u16, vmovn_u32, vmulq_f32, vmulq_f64, vpaddlq_u16, vpaddlq_u32,
-    vpaddlq_u8, vrndaq_f32, vshlq_u16, vshlq_u32, vshlq_u64, vshlq_u8, vst1q_u8, vsubq_f32,
-    vsubq_f64,
+    float32x4_t, uint32x4_t, uint8x16x4_t, vaddlvq_u8, vaddq_f32, vaddq_f64, vaddvq_f32,
+    vaddvq_u16, vaddvq_u32, vaddvq_u64, vcvt_f64_f32, vcvt_high_f64_f32, vcvtaq_u32_f32, vdivq_f32,
+    vdupq_n_f32, vdupq_n_f64, vextq_f64, vfmaq_f32, vfmaq_f64, vget_low_f32, vgetq_lane_f64,
+    vld1q_f32, vld1q_s16, vld1q_s32, vld1q_s64, vld1q_s8, vld1q_u8, vmaxq_f32, vmaxvq_f32,
+    vminq_f32, vminvq_f32, vmovn_high_u16, vmovn_high_u32, vmovn_u16, vmovn_u32, vmulq_f32,
+    vmulq_f64, vpaddlq_u16, vpaddlq_u32, vpaddlq_u8, vqtbl4q_u8, vreinterpretq_u8_u32, vrndaq_f32,
+    vshlq_u16, vshlq_u32, vshlq_u64, vshlq_u8, vst1q_u8, vsubq_f32, vsubq_f64,
 };
 
 use super::{VectorStats, LAMBDA, MINIMUM_MSE_GRID};
@@ -261,67 +261,13 @@ pub fn lvq1_quantize_and_pack<const B: usize>(
                     deltav,
                 ));
 
-                // Narrow the 16 values into a single 8x16 register. 6x instr, 7 for component_sum
-                let qab = vmovn_high_u32(vmovn_u32(qa), qb);
-                let qcd = vmovn_high_u32(vmovn_u32(qc), qd);
-                let qabcd = vmovn_high_u16(vmovn_u16(qab), qcd);
-                // Add to component sum as an across vector op to minimize vector instructions.
-                // Alternatives are 4 32x4 adds or 2 16x8 adds plus a an add across every 256d.
-                component_sumv += u32::from(vaddlvq_u8(qabcd));
-                match B {
-                    1 => {
-                        // pack 2 dimensions in a single lane and widen to 16
-                        let qp2abcd = vpaddlq_u8(vshlq_u8(
-                            qabcd,
-                            vld1q_s8([0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1].as_ptr()),
-                        ));
-                        let v = vaddvq_u16(vshlq_u16(
-                            qp2abcd,
-                            vld1q_s16([0, 2, 4, 6, 8, 10, 12, 14].as_ptr()),
-                        ));
-                        std::ptr::write_unaligned(
-                            head.as_mut_ptr().add(i / 8) as *mut u16,
-                            v.to_le(),
-                        );
-                    }
-                    2 => {
-                        // pack 2 dimensions in a single lane with pair add and widen
-                        let qp2abcd = vpaddlq_u8(vshlq_u8(
-                            qabcd,
-                            vld1q_s8([0, 2, 4, 8, 0, 2, 4, 8, 0, 2, 4, 8, 0, 2, 4, 8].as_ptr()),
-                        ));
-                        // pack 4 dimensions in a single lane (low byte) with pair add and widen.
-                        let qp4abcd = vpaddlq_u16(qp2abcd);
-                        // shift each entry into a different byte and sum across.
-                        let v = vaddvq_u32(vshlq_u32(qp4abcd, vld1q_s32([0, 8, 16, 24].as_ptr())));
-                        std::ptr::write_unaligned(
-                            head.as_mut_ptr().add(i / 4) as *mut u32,
-                            v.to_le(),
-                        );
-                    }
-                    4 => {
-                        // pack 2 dimensions in a single lane with pair add and widen to 16
-                        let qp2abcd = vpaddlq_u8(vshlq_u8(
-                            qabcd,
-                            vld1q_s8([0, 4, 0, 4, 0, 4, 0, 4, 0, 4, 0, 4, 0, 4, 0, 4].as_ptr()),
-                        ));
-                        // pack 4 dimensions in a single lane with pair add and widen to 32.
-                        let qp4abcd = vpaddlq_u16(vshlq_u16(
-                            qp2abcd,
-                            vld1q_s16([0, 8, 0, 8, 0, 8, 0, 8].as_ptr()),
-                        ));
-                        // pack 8 dimensions in a single lane with pair add and widen to 32.
-                        let qp8abcd =
-                            vpaddlq_u32(vshlq_u32(qp4abcd, vld1q_s32([0, 16, 0, 16].as_ptr())));
-                        let v = vaddvq_u64(vshlq_u64(qp8abcd, vld1q_s64([0, 32].as_ptr())));
-                        std::ptr::write_unaligned(
-                            head.as_mut_ptr().add(i / 2) as *mut u64,
-                            v.to_le(),
-                        );
-                    }
-                    8 => vst1q_u8(head.as_mut_ptr().add(i), qabcd),
+                component_sumv += match B {
+                    1 => pack1(i, qa, qb, qc, qd, head),
+                    2 => pack2(i, qa, qb, qc, qd, head),
+                    4 => pack4(i, qa, qb, qc, qd, head),
+                    8 => pack8(i, qa, qb, qc, qd, head),
                     _ => unimplemented!(),
-                }
+                };
             }
             component_sumv
         }
@@ -345,6 +291,118 @@ pub fn lvq2_quantize_and_pack<const B1: usize, const B2: usize>(
     out: &mut [u8],
 ) -> u32 {
     todo!()
+}
+
+/// Pack 16 scalar quantized entries into 1 bit per dimension (2 bytes) and write to out.
+#[inline(always)]
+unsafe fn pack1(
+    start_dim: usize,
+    qa: uint32x4_t,
+    qb: uint32x4_t,
+    qc: uint32x4_t,
+    qd: uint32x4_t,
+    out: &mut [u8],
+) -> u32 {
+    let qab = vmovn_high_u32(vmovn_u32(qa), qb);
+    let qcd = vmovn_high_u32(vmovn_u32(qc), qd);
+    let qabcd = vmovn_high_u16(vmovn_u16(qab), qcd);
+
+    // pack 2 dimensions in a single lane and widen to 16
+    let qp2abcd = vpaddlq_u8(vshlq_u8(
+        qabcd,
+        vld1q_s8([0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1].as_ptr()),
+    ));
+    let v = vaddvq_u16(vshlq_u16(
+        qp2abcd,
+        vld1q_s16([0, 2, 4, 6, 8, 10, 12, 14].as_ptr()),
+    ));
+    std::ptr::write_unaligned(out.as_mut_ptr().add(start_dim / 8) as *mut u16, v.to_le());
+
+    u32::from(vaddlvq_u8(qabcd))
+}
+
+/// Pack 16 scalar quantized entries into 2 bits per dimension (4 bytes) and write to out.
+#[inline(always)]
+unsafe fn pack2(
+    start_dim: usize,
+    qa: uint32x4_t,
+    qb: uint32x4_t,
+    qc: uint32x4_t,
+    qd: uint32x4_t,
+    out: &mut [u8],
+) -> u32 {
+    let qab = vmovn_high_u32(vmovn_u32(qa), qb);
+    let qcd = vmovn_high_u32(vmovn_u32(qc), qd);
+    let qabcd = vmovn_high_u16(vmovn_u16(qab), qcd);
+
+    // pack 2 dimensions in a single lane with pair add and widen
+    let qp2abcd = vpaddlq_u8(vshlq_u8(
+        qabcd,
+        vld1q_s8([0, 2, 4, 8, 0, 2, 4, 8, 0, 2, 4, 8, 0, 2, 4, 8].as_ptr()),
+    ));
+    // pack 4 dimensions in a single lane (low byte) with pair add and widen.
+    let qp4abcd = vpaddlq_u16(qp2abcd);
+    // shift each entry into a different byte and sum across.
+    let v = vaddvq_u32(vshlq_u32(qp4abcd, vld1q_s32([0, 8, 16, 24].as_ptr())));
+    std::ptr::write_unaligned(out.as_mut_ptr().add(start_dim / 4) as *mut u32, v.to_le());
+
+    u32::from(vaddlvq_u8(qabcd))
+}
+
+/// Pack 16 scalar quantized entries into 4 bits per dimension (8 bytes) and write to out.
+#[inline(always)]
+unsafe fn pack4(
+    start_dim: usize,
+    qa: uint32x4_t,
+    qb: uint32x4_t,
+    qc: uint32x4_t,
+    qd: uint32x4_t,
+    out: &mut [u8],
+) -> u32 {
+    // XXX i can probably do better here by shuffling into <evens> and <odds>
+    let qab = vmovn_high_u32(vmovn_u32(qa), qb);
+    let qcd = vmovn_high_u32(vmovn_u32(qc), qd);
+    let qabcd = vmovn_high_u16(vmovn_u16(qab), qcd);
+
+    // pack 2 dimensions in a single lane with pair add and widen to 16
+    let qp2abcd = vpaddlq_u8(vshlq_u8(
+        qabcd,
+        vld1q_s8([0, 4, 0, 4, 0, 4, 0, 4, 0, 4, 0, 4, 0, 4, 0, 4].as_ptr()),
+    ));
+    // pack 4 dimensions in a single lane with pair add and widen to 32.
+    let qp4abcd = vpaddlq_u16(vshlq_u16(
+        qp2abcd,
+        vld1q_s16([0, 8, 0, 8, 0, 8, 0, 8].as_ptr()),
+    ));
+    // pack 8 dimensions in a single lane with pair add and widen to 32.
+    let qp8abcd = vpaddlq_u32(vshlq_u32(qp4abcd, vld1q_s32([0, 16, 0, 16].as_ptr())));
+    let v = vaddvq_u64(vshlq_u64(qp8abcd, vld1q_s64([0, 32].as_ptr())));
+    std::ptr::write_unaligned(out.as_mut_ptr().add(start_dim / 2) as *mut u64, v.to_le());
+
+    u32::from(vaddlvq_u8(qabcd))
+}
+
+/// Pack 16 scalar quantized entries into 8 bits per dimension (16 bytes) and write to out.
+#[inline(always)]
+unsafe fn pack8(
+    start_dim: usize,
+    qa: uint32x4_t,
+    qb: uint32x4_t,
+    qc: uint32x4_t,
+    qd: uint32x4_t,
+    out: &mut [u8],
+) -> u32 {
+    let qabcd = vqtbl4q_u8(
+        uint8x16x4_t(
+            vreinterpretq_u8_u32(qa),
+            vreinterpretq_u8_u32(qb),
+            vreinterpretq_u8_u32(qc),
+            vreinterpretq_u8_u32(qd),
+        ),
+        vld1q_u8([0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60].as_ptr()),
+    );
+    vst1q_u8(out.as_mut_ptr().add(start_dim), qabcd);
+    u32::from(vaddlvq_u8(qabcd))
 }
 
 #[cfg(test)]

--- a/src/vectors/lvq/aarch64.rs
+++ b/src/vectors/lvq/aarch64.rs
@@ -2,12 +2,12 @@
 
 use std::arch::aarch64::{
     float32x4_t, uint32x4_t, uint8x16_t, vaddlvq_u8, vaddq_f32, vaddq_f64, vaddvq_f32, vaddvq_u16,
-    vaddvq_u32, vaddvq_u64, vcvt_f64_f32, vcvt_high_f64_f32, vcvtaq_u32_f32, vdivq_f32,
-    vdupq_n_f32, vdupq_n_f64, vextq_f64, vfmaq_f32, vfmaq_f64, vget_low_f32, vgetq_lane_f64,
-    vld1q_f32, vld1q_s16, vld1q_s32, vld1q_s64, vld1q_s8, vmaxq_f32, vmaxvq_f32, vminq_f32,
-    vminvq_f32, vmovn_high_u16, vmovn_high_u32, vmovn_u16, vmovn_u32, vmulq_f32, vmulq_f64,
-    vpaddlq_u16, vpaddlq_u32, vpaddlq_u8, vrndaq_f32, vshlq_u16, vshlq_u32, vshlq_u64, vshlq_u8,
-    vst1q_u8, vsubq_f32, vsubq_f64,
+    vaddvq_u32, vaddvq_u64, vcvt_f64_f32, vcvt_high_f64_f32, vcvtaq_u32_f32, vcvtq_f32_u32,
+    vdivq_f32, vdupq_n_f32, vdupq_n_f64, vextq_f64, vfmaq_f32, vfmaq_f64, vget_low_f32,
+    vgetq_lane_f64, vld1q_f32, vld1q_s16, vld1q_s32, vld1q_s64, vld1q_s8, vmaxq_f32, vmaxvq_f32,
+    vminq_f32, vminvq_f32, vmovn_high_u16, vmovn_high_u32, vmovn_u16, vmovn_u32, vmulq_f32,
+    vmulq_f64, vpaddlq_u16, vpaddlq_u32, vpaddlq_u8, vrndaq_f32, vshlq_u16, vshlq_u32, vshlq_u64,
+    vshlq_u8, vst1q_u8, vsubq_f32, vsubq_f64,
 };
 
 use super::{VectorStats, LAMBDA, MINIMUM_MSE_GRID};
@@ -228,7 +228,7 @@ pub fn lvq1_quantize_and_pack<const B: usize>(
     let delta = (upper - lower) / ((1 << B) - 1) as f32;
 
     let tail_split = v.len() & !15;
-    let (head, tail) = out.split_at_mut(tail_split * B / 8);
+    let (head, tail) = out.split_at_mut(super::packing::byte_len(tail_split, B));
     let component_sum = if tail_split > 0 {
         unsafe {
             let lowerv = vdupq_n_f32(lower);
@@ -242,9 +242,7 @@ pub fn lvq1_quantize_and_pack<const B: usize>(
                 let qd = quantize4(vld1q_f32(v.as_ptr().add(i + 12)), lowerv, deltav);
 
                 // Reduce to a single byte per dimension.
-                let qab = vmovn_high_u32(vmovn_u32(qa), qb);
-                let qcd = vmovn_high_u32(vmovn_u32(qc), qd);
-                let qabcd = vmovn_high_u16(vmovn_u16(qab), qcd);
+                let qabcd = pack_to_byte(qa, qb, qc, qd);
                 component_sumv += u32::from(vaddlvq_u8(qabcd));
 
                 match B {
@@ -274,14 +272,110 @@ pub fn lvq2_quantize_and_pack<const B1: usize, const B2: usize>(
     v: &[f32],
     lower: f32,
     upper: f32,
-    out: &mut [u8],
+    primary: &mut [u8],
+    residual: &mut [u8],
 ) -> u32 {
-    todo!()
+    let delta = (upper - lower) / ((1 << B1) - 1) as f32;
+    let res_lower = -delta / 2.0;
+    let res_upper = delta / 2.0;
+    let res_delta = delta / ((1 << B2) - 1) as f32;
+
+    let tail_split = v.len() & !15;
+    let (head_primary, tail_primary) =
+        primary.split_at_mut(super::packing::byte_len(tail_split, B1));
+    let (head_residual, tail_residual) =
+        residual.split_at_mut(super::packing::byte_len(tail_split, B2));
+    let component_sum = if tail_split > 0 {
+        unsafe {
+            let lowerv = vdupq_n_f32(lower);
+            let deltav = vdupq_n_f32(delta);
+            let delta_inv = vdupq_n_f32(delta.recip());
+            let res_lowerv = vdupq_n_f32(res_lower);
+            let res_delta_inv = vdupq_n_f32(res_delta.recip());
+            let mut component_sumv = 0u32;
+            for i in (0..tail_split).step_by(16) {
+                // Load and quantize 16 values, primary and residual
+                let a = vld1q_f32(v.as_ptr().add(i));
+                let qa = quantize4(a, lowerv, delta_inv);
+                let ra = quantize_residual4(a, qa, lowerv, deltav, res_lowerv, res_delta_inv);
+
+                let b = vld1q_f32(v.as_ptr().add(i + 4));
+                let qb = quantize4(b, lowerv, delta_inv);
+                let rb = quantize_residual4(b, qb, lowerv, deltav, res_lowerv, res_delta_inv);
+
+                let c = vld1q_f32(v.as_ptr().add(i + 8));
+                let qc = quantize4(c, lowerv, delta_inv);
+                let rc = quantize_residual4(c, qc, lowerv, deltav, res_lowerv, res_delta_inv);
+
+                let d = vld1q_f32(v.as_ptr().add(i + 12));
+                let qd = quantize4(d, lowerv, delta_inv);
+                let rd = quantize_residual4(d, qd, lowerv, deltav, res_lowerv, res_delta_inv);
+
+                // Reduce to a single byte per dimension, sum, and pack.
+                let qabcd = pack_to_byte(qa, qb, qc, qd);
+                component_sumv += u32::from(vaddlvq_u8(qabcd));
+                match B1 {
+                    1 => pack1(i, qabcd, head_primary),
+                    2 => pack2(i, qabcd, head_primary),
+                    4 => pack4(i, qabcd, head_primary),
+                    8 => pack8(i, qabcd, head_primary),
+                    _ => unimplemented!(),
+                };
+
+                // Reduce to a single byte per dimension and pack.
+                let rabcd = pack_to_byte(ra, rb, rc, rd);
+                match B2 {
+                    1 => pack1(i, rabcd, head_residual),
+                    2 => pack2(i, rabcd, head_residual),
+                    4 => pack4(i, rabcd, head_residual),
+                    8 => pack8(i, rabcd, head_residual),
+                    _ => unimplemented!(),
+                };
+            }
+            component_sumv
+        }
+    } else {
+        0
+    };
+
+    if tail_split < v.len() {
+        component_sum
+            + super::scalar::lvq2_quantize_and_pack::<B1, B2>(
+                &v[tail_split..],
+                lower,
+                upper,
+                tail_primary,
+                tail_residual,
+            )
+    } else {
+        component_sum
+    }
 }
 
 #[inline(always)]
 unsafe fn quantize4(v: float32x4_t, lower: float32x4_t, delta_inv: float32x4_t) -> uint32x4_t {
     vcvtaq_u32_f32(vmulq_f32(vsubq_f32(v, lower), delta_inv))
+}
+
+#[inline(always)]
+unsafe fn quantize_residual4(
+    v: float32x4_t,
+    q: uint32x4_t,
+    lower: float32x4_t,
+    delta: float32x4_t,
+    res_lower: float32x4_t,
+    res_delta_inv: float32x4_t,
+) -> uint32x4_t {
+    let q = vfmaq_f32(lower, vcvtq_f32_u32(q), delta);
+    let res = vsubq_f32(v, q);
+    vcvtaq_u32_f32(vmulq_f32(vsubq_f32(res, res_lower), res_delta_inv))
+}
+
+#[inline(always)]
+unsafe fn pack_to_byte(a: uint32x4_t, b: uint32x4_t, c: uint32x4_t, d: uint32x4_t) -> uint8x16_t {
+    let ab = vmovn_high_u32(vmovn_u32(a), b);
+    let cd = vmovn_high_u32(vmovn_u32(c), d);
+    vmovn_high_u16(vmovn_u16(ab), cd)
 }
 
 /// Pack 16 scalar quantized entries into 1 bit per dimension (2 bytes) and write to out.

--- a/src/vectors/lvq/scalar.rs
+++ b/src/vectors/lvq/scalar.rs
@@ -99,3 +99,22 @@ pub fn compute_loss(vector: &[f32], interval: (f32, f32), norm_sq: f64, bits: us
     }
     (1.0 - LAMBDA as f64) * xe * xe / norm_sq + LAMBDA as f64 * e
 }
+
+pub fn lvq1_quantize_and_pack<const B: usize>(
+    v: &[f32],
+    lower: f32,
+    upper: f32,
+    out: &mut [u8],
+) -> u32 {
+    let delta = (upper - lower) / ((1 << B) - 1) as f32;
+    let mut component_sum = 0u32;
+    super::packing::pack_iter::<B>(
+        v.iter().copied().map(|x| {
+            let q = ((x.clamp(lower, upper) - lower) / delta).round() as u8;
+            component_sum += u32::from(q);
+            q
+        }),
+        out,
+    );
+    component_sum
+}

--- a/src/vectors/lvq/scalar.rs
+++ b/src/vectors/lvq/scalar.rs
@@ -118,3 +118,31 @@ pub fn lvq1_quantize_and_pack<const B: usize>(
     );
     component_sum
 }
+
+pub fn lvq2_quantize_and_pack<const B1: usize, const B2: usize>(
+    v: &[f32],
+    lower: f32,
+    upper: f32,
+    primary: &mut [u8],
+    residual: &mut [u8],
+) -> u32 {
+    let delta = (upper - lower) / ((1 << B1) - 1) as f32;
+    let res_lower = -delta / 2.0;
+    let res_upper = delta / 2.0;
+    let res_delta = delta / ((1 << B2) - 1) as f32;
+    let mut component_sum = 0u32;
+    super::packing::pack_iter2::<B1, B2>(
+        v.iter().copied().map(|x| {
+            let q = ((x.clamp(lower, upper) - lower) / delta).round() as u8;
+            component_sum += u32::from(q);
+            // After producing the primary value, calculate the error produced and quantize that
+            // value based on the delta between primary items.
+            let res = (x - ((q as f32 * delta) + lower)).clamp(res_lower, res_upper);
+            let r = ((res - res_lower) / res_delta).round() as u8;
+            (q, r)
+        }),
+        primary,
+        residual,
+    );
+    component_sum
+}


### PR DESCRIPTION
Quantize and pack in SIMD in addition to computing stats and interval optimization.

Note that stats and interval optimization are ~70% of the workload and are much more expensive with fewer
quantization bits. Even without interval optimization this is still 2x slower than scaled uniform.

This is noticeably faster on an M2 Mac:
```
lvq1x1/coding           time:   [4.0248 µs 4.0441 µs 4.0633 µs]
                        change: [−29.439% −29.162% −28.910%] (p = 0.00 < 0.05)
lvq1x4/coding           time:   [3.4349 µs 3.4500 µs 3.4662 µs]
                        change: [−25.608% −25.210% −24.801%] (p = 0.00 < 0.05)
lvq1x8/coding           time:   [2.7516 µs 2.7637 µs 2.7767 µs]
                        change: [−9.1523% −7.8572% −6.6888%] (p = 0.00 < 0.05)
lvq2x1x8/coding         time:   [4.1979 µs 4.2157 µs 4.2347 µs]
                        change: [−36.795% −36.477% −36.203%] (p = 0.00 < 0.05)
lvq2x4x4/coding         time:   [3.6373 µs 3.6541 µs 3.6715 µs]
                        change: [−39.567% −39.261% −38.976%] (p = 0.00 < 0.05)
lvq2x4x8/coding         time:   [3.5709 µs 3.5835 µs 3.5966 µs]
                        change: [−40.355% −40.149% −39.918%] (p = 0.00 < 0.05)
lvq2x8x8/coding         time:   [2.8876 µs 2.8981 µs 2.9088 µs]
                        change: [−45.855% −45.610% −45.361%] (p = 0.00 < 0.05)
```