### PR TITLE
Improve LVQ distance computation perf

### DIFF
--- a/benches/distance.rs
+++ b/benches/distance.rs
@@ -1,7 +1,5 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use easy_tiger::vectors::{
-    new_query_vector_distance_f32, F32VectorCoding, NonUniformQuantizedDimensions, VectorSimilarity,
-};
+use easy_tiger::vectors::{new_query_vector_distance_f32, F32VectorCoding, VectorSimilarity};
 use rand::{Rng, SeedableRng};
 
 fn generate_test_vectors(dim: usize) -> (Vec<f32>, Vec<f32>) {
@@ -110,13 +108,6 @@ pub fn i4_scaled_uniform_benchmarks(c: &mut Criterion) {
     );
 }
 
-pub fn i8_scaled_non_uniform_benchmarks(c: &mut Criterion) {
-    let format = F32VectorCoding::I8ScaledNonUniformQuantized(
-        NonUniformQuantizedDimensions::try_from([256, 512].as_slice()).unwrap(),
-    );
-    query_and_doc_benchmarks(c, format, VectorSimilarity::all());
-}
-
 pub fn i1_benchmarks(c: &mut Criterion) {
     let (x, y) = generate_test_vectors(1024);
 
@@ -177,7 +168,6 @@ criterion_group!(
     i16_scaled_uniform_benchmarks,
     i8_scaled_uniform_benchmarks,
     i4_scaled_uniform_benchmarks,
-    i8_scaled_non_uniform_benchmarks,
     i1_benchmarks,
     lvq2x8x8_benchmarks,
     lvq2x4x8_benchmarks,

--- a/src/vectors/lvq.rs
+++ b/src/vectors/lvq.rs
@@ -290,12 +290,7 @@ impl<'a, const B: usize> PrimaryQueryDotProductDistance<'a, B> {
 impl<const B: usize> QueryVectorDistance for PrimaryQueryDotProductDistance<'_, B> {
     fn distance(&self, vector: &[u8]) -> f64 {
         let vector = PrimaryVector::<B>::new(vector).unwrap();
-        let dot = self
-            .0
-            .iter()
-            .zip(vector.f32_iter())
-            .map(|(q, d)| *q * d)
-            .sum::<f32>() as f64;
+        let dot = lvq1_f32_dot_unnormalized(self.0.as_ref(), &vector) / vector.l2_norm();
         (-dot + 1.0) / 2.0
     }
 }

--- a/src/vectors/lvq.rs
+++ b/src/vectors/lvq.rs
@@ -321,13 +321,7 @@ impl<const B1: usize, const B2: usize> QueryVectorDistance
 {
     fn distance(&self, vector: &[u8]) -> f64 {
         let vector = TwoLevelVector::<B1, B2>::new(vector).unwrap();
-        let dot = self
-            .0
-            .iter()
-            .zip(vector.f32_iter())
-            .map(|(s, o)| *s * o)
-            .sum::<f32>() as f64
-            / vector.l2_norm();
+        let dot = lvq2_f32_dot_unnormalized(self.0.as_ref(), &vector) / vector.l2_norm();
         (-dot + 1.0) / 2.0
     }
 }

--- a/src/vectors/lvq.rs
+++ b/src/vectors/lvq.rs
@@ -302,12 +302,7 @@ impl<const B1: usize, const B2: usize> VectorDistance for TwoLevelDotProductDist
     fn distance(&self, query: &[u8], doc: &[u8]) -> f64 {
         let query = TwoLevelVector::<B1, B2>::new(query).unwrap();
         let doc = TwoLevelVector::<B1, B2>::new(doc).unwrap();
-        let dot = query
-            .f32_iter()
-            .zip(doc.f32_iter())
-            .map(|(q, d)| q * d)
-            .sum::<f32>() as f64
-            / (query.l2_norm() * doc.l2_norm());
+        let dot = lvq2_dot_unnormalized(&query, &doc) / (query.l2_norm() * doc.l2_norm());
         (-dot + 1.0) / 2.0
     }
 }

--- a/src/vectors/lvq.rs
+++ b/src/vectors/lvq.rs
@@ -146,18 +146,12 @@ impl<'a, const B: usize> PrimaryVector<'a, B> {
     }
 
     fn dot_unnormalized(&self, other: &Self) -> f64 {
-        let dot_quantized = if B == 1 {
-            self.vector
-                .iter()
-                .zip(other.vector.iter())
-                .map(|(s, o)| (*s & *o).count_ones())
-                .sum::<u32>()
-        } else {
-            packing::unpack_iter::<B>(self.vector)
-                .zip(packing::unpack_iter::<B>(other.vector))
-                .map(|(s, o)| s as u32 * o as u32)
-                .sum::<u32>()
-        };
+        let dot_quantized = self
+            .vector
+            .iter()
+            .zip(other.vector.iter())
+            .map(|(s, o)| Self::dot_packed(*s, *o))
+            .sum::<u32>();
         let sdelta = f64::from(self.delta);
         let slower = f64::from(self.header.lower);
         let odelta = f64::from(other.delta);
@@ -166,6 +160,24 @@ impl<'a, const B: usize> PrimaryVector<'a, B> {
             + self.header.component_sum as f64 * sdelta * olower
             + other.header.component_sum as f64 * odelta * slower
             + slower * olower * (self.vector.len() * 8).div_ceil(B) as f64
+    }
+
+    fn dot_packed(a: u8, b: u8) -> u32 {
+        match B {
+            1 => (a & b).count_ones(),
+            2 => {
+                let a = [a & 0x3, (a >> 2) & 0x3, (a >> 4) & 0x3, (a >> 6) & 0x3];
+                let b = [b & 0x3, (b >> 2) & 0x3, (b >> 4) & 0x3, (b >> 6) & 0x3];
+                (a[0] * b[0] + a[1] * b[1] + a[2] * b[2] + a[3] * b[3]).into()
+            }
+            4 => {
+                let a = [a & 0xf, a >> 4];
+                let b = [b & 0xf, b >> 4];
+                (a[0] as u16 * b[0] as u16 + a[1] as u16 * b[1] as u16).into()
+            }
+            8 => a as u32 * b as u32,
+            _ => unimplemented!(),
+        }
     }
 }
 

--- a/src/vectors/lvq/aarch64.rs
+++ b/src/vectors/lvq/aarch64.rs
@@ -560,7 +560,6 @@ pub fn lvq2_dot_unnormalized<const B1: usize, const B2: usize>(
     };
 
     if tail_split < dim {
-        // XXX for this to actually be _fast_ I need to implement nth on the unpacking iterator.
         pdot + a
             .f32_iter()
             .skip(tail_split)
@@ -605,7 +604,6 @@ pub fn lvq2_f32_dot_unnormalized<const B1: usize, const B2: usize>(
     };
 
     if tail_split < query.len() {
-        // XXX for this to actually be _fast_ I need to implement nth on the unpacking iterator.
         pdot + query
             .iter()
             .skip(tail_split)

--- a/src/vectors/lvq/scalar.rs
+++ b/src/vectors/lvq/scalar.rs
@@ -2,6 +2,8 @@
 
 #![allow(dead_code)]
 
+use crate::vectors::lvq::PrimaryVector;
+
 use super::{VectorStats, LAMBDA, MINIMUM_MSE_GRID};
 
 pub fn compute_vector_stats(vector: &[f32]) -> VectorStats {
@@ -145,4 +147,16 @@ pub fn lvq2_quantize_and_pack<const B1: usize, const B2: usize>(
         residual,
     );
     component_sum
+}
+
+pub fn lvq1_f32_dot_unnormalized<const B: usize>(query: &[f32], doc: &PrimaryVector<'_, B>) -> f64 {
+    query
+        .iter()
+        .zip(
+            super::packing::unpack_iter::<B>(doc.vector)
+                .map(|q| q as f32 * doc.delta + doc.header.lower),
+        )
+        .map(|(q, d)| *q * d)
+        .sum::<f32>()
+        .into()
 }

--- a/src/vectors/lvq/scalar.rs
+++ b/src/vectors/lvq/scalar.rs
@@ -171,3 +171,15 @@ pub fn lvq2_dot_unnormalized<const B1: usize, const B2: usize>(
         .sum::<f32>()
         .into()
 }
+
+pub fn lvq2_f32_dot_unnormalized<const B1: usize, const B2: usize>(
+    query: &[f32],
+    doc: &TwoLevelVector<'_, B1, B2>,
+) -> f64 {
+    query
+        .iter()
+        .zip(doc.f32_iter())
+        .map(|(q, d)| *q * d)
+        .sum::<f32>()
+        .into()
+}

--- a/src/vectors/lvq/scalar.rs
+++ b/src/vectors/lvq/scalar.rs
@@ -2,7 +2,7 @@
 
 #![allow(dead_code)]
 
-use crate::vectors::lvq::PrimaryVector;
+use crate::vectors::lvq::{PrimaryVector, TwoLevelVector};
 
 use super::{VectorStats, LAMBDA, MINIMUM_MSE_GRID};
 
@@ -157,6 +157,17 @@ pub fn lvq1_f32_dot_unnormalized<const B: usize>(query: &[f32], doc: &PrimaryVec
                 .map(|q| q as f32 * doc.delta + doc.header.lower),
         )
         .map(|(q, d)| *q * d)
+        .sum::<f32>()
+        .into()
+}
+
+pub fn lvq2_dot_unnormalized<const B1: usize, const B2: usize>(
+    a: &TwoLevelVector<'_, B1, B2>,
+    b: &TwoLevelVector<'_, B1, B2>,
+) -> f64 {
+    a.f32_iter()
+        .zip(b.f32_iter())
+        .map(|(a, b)| a * b)
         .sum::<f32>()
         .into()
 }


### PR DESCRIPTION
Some of the changes are in scalar code and should be durable across platforms. Most of them are the result of
unpacking bit packed formats using SIMD intrinsics and shuffling.

Most modes improve by at least 65% with the exception of a previously optimized lvq1x1 path, some improve
by as much as 95%. Query (f32 x quantized) paths generally improve to the point where they are +/- 25% of
raw f32 dot product.

On an M2 Mac:
```
lvq2x8x8/doc/dot        time:   [331.65 ns 332.33 ns 333.16 ns]
                        change: [−95.942% −95.928% −95.914%] (p = 0.00 < 0.05)
lvq2x8x8/query/dot      time:   [289.43 ns 289.95 ns 290.51 ns]
                        change: [−68.261% −68.133% −67.973%] (p = 0.00 < 0.05)
lvq2x4x8/doc/dot        time:   [393.21 ns 395.79 ns 399.48 ns]
                        change: [−95.644% −95.586% −95.520%] (p = 0.00 < 0.05)
lvq2x4x8/query/dot      time:   [296.33 ns 297.15 ns 298.01 ns]
                        change: [−77.234% −76.682% −76.354%] (p = 0.00 < 0.05)
lvq2x4x4/doc/dot        time:   [459.80 ns 466.94 ns 477.01 ns]
                        change: [−94.773% −94.718% −94.638%] (p = 0.00 < 0.05)
lvq2x4x4/query/dot      time:   [299.99 ns 300.63 ns 301.35 ns]
                        change: [−77.165% −77.073% −76.977%] (p = 0.00 < 0.05)
lvq2x1x8/doc/dot        time:   [396.85 ns 398.56 ns 400.52 ns]
                        change: [−94.802% −94.777% −94.753%] (p = 0.00 < 0.05)
lvq2x1x8/query/dot      time:   [295.91 ns 296.79 ns 298.24 ns]
                        change: [−70.950% −70.838% −70.725%] (p = 0.00 < 0.05)
lvq1x8/doc/dot          time:   [27.340 ns 27.562 ns 27.970 ns]
                        change: [−26.905% −26.497% −25.905%] (p = 0.00 < 0.05)
lvq1x8/query/dot        time:   [249.37 ns 250.30 ns 251.19 ns]
                        change: [−73.041% −72.741% −72.489%] (p = 0.00 < 0.05)
lvq1x4/doc/dot          time:   [47.908 ns 48.075 ns 48.242 ns]
                        change: [−94.333% −94.311% −94.291%] (p = 0.00 < 0.05)
lvq1x4/query/dot        time:   [261.69 ns 262.36 ns 263.07 ns]
                        change: [−71.544% −71.435% −71.320%] (p = 0.00 < 0.05)
lvq1x1/doc/dot          time:   [10.236 ns 10.249 ns 10.263 ns]
                        change: [−2.9462% −2.5931% −2.2838%] (p = 0.00 < 0.05)
lvq1x1/query/dot        time:   [277.57 ns 282.43 ns 287.50 ns]
                        change: [−70.369% −69.993% −69.646%] (p = 0.00 < 0.05)
```