### PR TITLE
Improve LVQ2 accuracy when very few primary bits are used

### DIFF
--- a/qt/src/main.rs
+++ b/qt/src/main.rs
@@ -70,6 +70,7 @@ fn quantization_loss(
     );
     let (abs_error, sq_error) = (0..vectors.len())
         .into_par_iter()
+        .take(100)
         .progress_count(vectors.len() as u64)
         .map(|i| {
             let v = mean

--- a/qt/src/main.rs
+++ b/qt/src/main.rs
@@ -70,7 +70,6 @@ fn quantization_loss(
     );
     let (abs_error, sq_error) = (0..vectors.len())
         .into_par_iter()
-        .take(100)
         .progress_count(vectors.len() as u64)
         .map(|i| {
             let v = mean

--- a/src/vectors/lvq.rs
+++ b/src/vectors/lvq.rs
@@ -199,7 +199,6 @@ impl<'a, const B1: usize, const B2: usize> TwoLevelVector<'a, B1, B2> {
         let interval = f32::from_le_bytes(residual_header_bytes.try_into().unwrap());
         let delta = interval / ((1 << B2) - 1) as f32;
         let lower = -interval / 2.0;
-        //println!("residual interval {interval} lower {lower} delta {delta}");
         Some(Self {
             primary,
             vector: residual_vector,
@@ -288,9 +287,7 @@ impl<const B1: usize, const B2: usize> F32VectorCoder for TwoLevelVectorCoder<B1
         let (residual_header_bytes, residual) =
             residual_bytes.split_at_mut(std::mem::size_of::<f32>());
         residual_header_bytes.copy_from_slice(residual_interval.to_le_bytes().as_slice());
-        // XXX something is fucked with the aarch64 implementation.
-        // XXX the test vector isn't large enough to figure this out.
-        header.component_sum = scalar::lvq2_quantize_and_pack::<B1, B2>(
+        header.component_sum = lvq2_quantize_and_pack::<B1, B2>(
             vector,
             header.lower,
             header.upper,

--- a/src/vectors/lvq/aarch64.rs
+++ b/src/vectors/lvq/aarch64.rs
@@ -367,11 +367,11 @@ unsafe fn quantize_residual4(
     lower: float32x4_t,
     delta: float32x4_t,
     res_lower: float32x4_t,
-    res_delta_inv: float32x4_t,
+    res_delta: float32x4_t,
 ) -> uint32x4_t {
     let q = vfmaq_f32(lower, vcvtq_f32_u32(q), delta);
     let res = vsubq_f32(v, q);
-    vcvtaq_u32_f32(vmulq_f32(vsubq_f32(res, res_lower), res_delta_inv))
+    vcvtaq_u32_f32(vmulq_f32(vsubq_f32(res, res_lower), res_delta))
 }
 
 #[inline(always)]

--- a/src/vectors/lvq/aarch64.rs
+++ b/src/vectors/lvq/aarch64.rs
@@ -277,11 +277,12 @@ pub fn lvq2_quantize_and_pack<const B1: usize, const B2: usize>(
     lower: f32,
     upper: f32,
     primary: &mut [u8],
+    residual_interval: f32,
     residual: &mut [u8],
 ) -> u32 {
     let delta = (upper - lower) / ((1 << B1) - 1) as f32;
-    let res_lower = -delta / 2.0;
-    let res_delta = delta / ((1 << B2) - 1) as f32;
+    let res_lower = -residual_interval / 2.0;
+    let res_delta = residual_interval / ((1 << B2) - 1) as f32;
 
     let tail_split = v.len() & !15;
     let (head_primary, tail_primary) = primary.split_at_mut(packing::byte_len(tail_split, B1));
@@ -346,6 +347,7 @@ pub fn lvq2_quantize_and_pack<const B1: usize, const B2: usize>(
                 lower,
                 upper,
                 tail_primary,
+                residual_interval,
                 tail_residual,
             )
     } else {

--- a/src/vectors/lvq/aarch64.rs
+++ b/src/vectors/lvq/aarch64.rs
@@ -237,14 +237,15 @@ pub fn lvq1_quantize_and_pack<const B: usize>(
     let component_sum = if tail_split > 0 {
         unsafe {
             let lowerv = vdupq_n_f32(lower);
+            let upperv = vdupq_n_f32(upper);
             let deltav = vdupq_n_f32(delta.recip());
             let mut component_sumv = 0u32;
             for i in (0..tail_split).step_by(16) {
                 // Load and quantize 16 values.
-                let qa = quantize4(vld1q_f32(v.as_ptr().add(i)), lowerv, deltav);
-                let qb = quantize4(vld1q_f32(v.as_ptr().add(i + 4)), lowerv, deltav);
-                let qc = quantize4(vld1q_f32(v.as_ptr().add(i + 8)), lowerv, deltav);
-                let qd = quantize4(vld1q_f32(v.as_ptr().add(i + 12)), lowerv, deltav);
+                let qa = quantize4(vld1q_f32(v.as_ptr().add(i)), lowerv, upperv, deltav);
+                let qb = quantize4(vld1q_f32(v.as_ptr().add(i + 4)), lowerv, upperv, deltav);
+                let qc = quantize4(vld1q_f32(v.as_ptr().add(i + 8)), lowerv, upperv, deltav);
+                let qd = quantize4(vld1q_f32(v.as_ptr().add(i + 12)), lowerv, upperv, deltav);
 
                 // Reduce to a single byte per dimension.
                 let qabcd = pack_to_byte(qa, qb, qc, qd);
@@ -282,6 +283,7 @@ pub fn lvq2_quantize_and_pack<const B1: usize, const B2: usize>(
 ) -> u32 {
     let delta = (upper - lower) / ((1 << B1) - 1) as f32;
     let res_lower = -residual_interval / 2.0;
+    let res_upper = residual_interval / 2.0;
     let res_delta = residual_interval / ((1 << B2) - 1) as f32;
 
     let tail_split = v.len() & !15;
@@ -290,28 +292,62 @@ pub fn lvq2_quantize_and_pack<const B1: usize, const B2: usize>(
     let component_sum = if tail_split > 0 {
         unsafe {
             let lowerv = vdupq_n_f32(lower);
+            let upperv = vdupq_n_f32(upper);
             let deltav = vdupq_n_f32(delta);
             let delta_inv = vdupq_n_f32(delta.recip());
             let res_lowerv = vdupq_n_f32(res_lower);
+            let res_upperv = vdupq_n_f32(res_upper);
             let res_delta_inv = vdupq_n_f32(res_delta.recip());
             let mut component_sumv = 0u32;
             for i in (0..tail_split).step_by(16) {
                 // Load and quantize 16 values, primary and residual
                 let a = vld1q_f32(v.as_ptr().add(i));
-                let qa = quantize4(a, lowerv, delta_inv);
-                let ra = quantize_residual4(a, qa, lowerv, deltav, res_lowerv, res_delta_inv);
+                let qa = quantize4(a, lowerv, upperv, delta_inv);
+                let ra = quantize_residual4(
+                    a,
+                    qa,
+                    lowerv,
+                    deltav,
+                    res_lowerv,
+                    res_upperv,
+                    res_delta_inv,
+                );
 
                 let b = vld1q_f32(v.as_ptr().add(i + 4));
-                let qb = quantize4(b, lowerv, delta_inv);
-                let rb = quantize_residual4(b, qb, lowerv, deltav, res_lowerv, res_delta_inv);
+                let qb = quantize4(b, lowerv, upperv, delta_inv);
+                let rb = quantize_residual4(
+                    b,
+                    qb,
+                    lowerv,
+                    deltav,
+                    res_lowerv,
+                    res_upperv,
+                    res_delta_inv,
+                );
 
                 let c = vld1q_f32(v.as_ptr().add(i + 8));
-                let qc = quantize4(c, lowerv, delta_inv);
-                let rc = quantize_residual4(c, qc, lowerv, deltav, res_lowerv, res_delta_inv);
+                let qc = quantize4(c, lowerv, upperv, delta_inv);
+                let rc = quantize_residual4(
+                    c,
+                    qc,
+                    lowerv,
+                    deltav,
+                    res_lowerv,
+                    res_upperv,
+                    res_delta_inv,
+                );
 
                 let d = vld1q_f32(v.as_ptr().add(i + 12));
-                let qd = quantize4(d, lowerv, delta_inv);
-                let rd = quantize_residual4(d, qd, lowerv, deltav, res_lowerv, res_delta_inv);
+                let qd = quantize4(d, lowerv, upperv, delta_inv);
+                let rd = quantize_residual4(
+                    d,
+                    qd,
+                    lowerv,
+                    deltav,
+                    res_lowerv,
+                    res_upperv,
+                    res_delta_inv,
+                );
 
                 // Reduce to a single byte per dimension, sum, and pack.
                 let qabcd = pack_to_byte(qa, qb, qc, qd);
@@ -356,8 +392,13 @@ pub fn lvq2_quantize_and_pack<const B1: usize, const B2: usize>(
 }
 
 #[inline(always)]
-unsafe fn quantize4(v: float32x4_t, lower: float32x4_t, delta_inv: float32x4_t) -> uint32x4_t {
-    vcvtaq_u32_f32(vmulq_f32(vsubq_f32(v, lower), delta_inv))
+unsafe fn quantize4(
+    v: float32x4_t,
+    lower: float32x4_t,
+    upper: float32x4_t,
+    delta_inv: float32x4_t,
+) -> uint32x4_t {
+    vcvtaq_u32_f32(vmulq_f32(vsubq_f32(vminq_f32(v, upper), lower), delta_inv))
 }
 
 #[inline(always)]
@@ -367,11 +408,15 @@ unsafe fn quantize_residual4(
     lower: float32x4_t,
     delta: float32x4_t,
     res_lower: float32x4_t,
+    res_upper: float32x4_t,
     res_delta: float32x4_t,
 ) -> uint32x4_t {
     let q = vfmaq_f32(lower, vcvtq_f32_u32(q), delta);
     let res = vsubq_f32(v, q);
-    vcvtaq_u32_f32(vmulq_f32(vsubq_f32(res, res_lower), res_delta))
+    vcvtaq_u32_f32(vmulq_f32(
+        vsubq_f32(vminq_f32(res, res_upper), res_lower),
+        res_delta,
+    ))
 }
 
 #[inline(always)]

--- a/src/vectors/lvq/scalar.rs
+++ b/src/vectors/lvq/scalar.rs
@@ -140,8 +140,8 @@ pub fn lvq2_quantize_and_pack<const B1: usize, const B2: usize>(
             component_sum += u32::from(q);
             // After producing the primary value, calculate the error produced and quantize that
             // value based on the delta between primary items.
-            let res = (x - ((q as f32 * delta) + lower)).clamp(res_lower, res_upper);
-            let r = ((res - res_lower) / res_delta).round() as u8;
+            let res = x - ((q as f32 * delta) + lower);
+            let r = ((res.clamp(res_lower, res_upper) - res_lower) / res_delta).round() as u8;
             (q, r)
         }),
         primary,

--- a/src/vectors/lvq/scalar.rs
+++ b/src/vectors/lvq/scalar.rs
@@ -126,12 +126,13 @@ pub fn lvq2_quantize_and_pack<const B1: usize, const B2: usize>(
     lower: f32,
     upper: f32,
     primary: &mut [u8],
+    residual_interval: f32,
     residual: &mut [u8],
 ) -> u32 {
     let delta = (upper - lower) / ((1 << B1) - 1) as f32;
-    let res_lower = -delta / 2.0;
-    let res_upper = delta / 2.0;
-    let res_delta = delta / ((1 << B2) - 1) as f32;
+    let res_lower = -residual_interval / 2.0;
+    let res_upper = residual_interval / 2.0;
+    let res_delta = residual_interval / ((1 << B2) - 1) as f32;
     let mut component_sum = 0u32;
     super::packing::pack_iter2::<B1, B2>(
         v.iter().copied().map(|x| {


### PR DESCRIPTION
In this case interval optimization may pull in the bounds so far that the delta value is not sufficient to accurately
encode residual values. This is particularly acute when 1 bit is used for the primary vector.

To fix this explicitly pick an interval for the residual vector that is encoded alongside the vector contents. We do
not do anything clever here, choosing the maximum value of the primary vector delta or the gaps between the
(minimum, primary lower) or (maximum, primary upper). This ensures that the residual vector can encode the
minimum and maximum values in the original vector, substantially improving accuracy.

Fix a bug in the aarch64 accelerated implementation where we were relying on the value saturating when converting
from f32 to u32 even though that is not the case.

With this change `lvq2x1x8` is more accurate than `lvq1x8`, which is expected given that it uses 1 extra bit.