### PR TITLE
Better setup for x86 64 and accelerate f32 distance computation

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "target-feature=+avx512f"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.88.0"
+channel = "1.89.0"
 components = ["rustfmt", "clippy"]

--- a/src/distance.rs
+++ b/src/distance.rs
@@ -2,6 +2,36 @@
 
 use std::borrow::Cow;
 
+pub(crate) enum Acceleration {
+    Scalar,
+    #[cfg(target_arch = "aarch64")]
+    Neon,
+    #[cfg(target_arch = "x86_64")]
+    Avx512,
+}
+
+impl Default for Acceleration {
+    #[cfg(target_arch = "aarch64")]
+    fn default() -> Self {
+        Acceleration::Neon
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    fn default() -> Self {
+        use std::is_x86_feature_detected;
+        if is_x86_feature_detected!("avx512f") {
+            Acceleration::Avx512
+        } else {
+            Acceleration::Scalar
+        }
+    }
+
+    #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
+    fn default() -> Self {
+        Acceleration::Scalar
+    }
+}
+
 #[inline(always)]
 #[cfg(target_arch = "aarch64")]
 unsafe fn load_f32x4_le(p: *const u8) -> core::arch::aarch64::float32x4_t {
@@ -29,35 +59,58 @@ pub(crate) fn l2sq_f32(q: &[f32], d: &[f32]) -> f64 {
 pub(crate) fn l2sq_f32_bytes(q: &[u8], d: &[u8]) -> f64 {
     assert_eq!(q.len(), d.len());
     assert_eq!(q.len() % 4, 0);
-    #[cfg(target_arch = "aarch64")]
-    unsafe {
-        use core::arch::aarch64::{vaddvq_f32, vdupq_n_f32, vfmaq_f32, vsubq_f32};
-        let suffix_start = q.len() & !15;
-        let mut l2sqv = vdupq_n_f32(0.0);
-        for i in (0..suffix_start).step_by(16) {
-            let dv = vsubq_f32(
-                load_f32x4_le(q.as_ptr().add(i)),
-                load_f32x4_le(d.as_ptr().add(i)),
-            );
-            l2sqv = vfmaq_f32(l2sqv, dv, dv);
+    match Acceleration::default() {
+        Acceleration::Scalar => {
+            f32_le_iter(q)
+                .zip(f32_le_iter(d))
+                .map(|(q, d)| {
+                    let delta = q - d;
+                    delta * delta
+                })
+                .sum::<f32>() as f64
         }
-        let mut l2sq = vaddvq_f32(l2sqv);
-        for i in (suffix_start..q.len()).step_by(4) {
-            let delta = std::ptr::read_unaligned(q.as_ptr().add(i) as *const f32)
-                - std::ptr::read_unaligned(d.as_ptr().add(i) as *const f32);
-            l2sq += delta * delta;
+        #[cfg(target_arch = "aarch64")]
+        Acceleration::Neon => unsafe {
+            use core::arch::aarch64::{vaddvq_f32, vdupq_n_f32, vfmaq_f32, vsubq_f32};
+            let suffix_start = q.len() & !15;
+            let mut l2sqv = vdupq_n_f32(0.0);
+            for i in (0..suffix_start).step_by(16) {
+                let dv = vsubq_f32(
+                    load_f32x4_le(q.as_ptr().add(i)),
+                    load_f32x4_le(d.as_ptr().add(i)),
+                );
+                l2sqv = vfmaq_f32(l2sqv, dv, dv);
+            }
+            let mut l2sq = vaddvq_f32(l2sqv);
+            for i in (suffix_start..q.len()).step_by(4) {
+                let delta = std::ptr::read_unaligned(q.as_ptr().add(i) as *const f32)
+                    - std::ptr::read_unaligned(d.as_ptr().add(i) as *const f32);
+                l2sq += delta * delta;
+            }
+            l2sq as f64
         }
-        l2sq as f64
-    }
-    #[cfg(not(target_arch = "aarch64"))]
-    {
-        f32_le_iter(q)
-            .zip(f32_le_iter(d))
-            .map(|(q, d)| {
-                let delta = q - d;
-                delta * delta
-            })
-            .sum::<f32>() as f64
+        #[cfg(target_arch = "x86_64")]
+        Acceleration::Avx512 => unsafe {
+            use core::arch::x86_64::{
+                _mm512_add_ps, _mm512_castps512_ps128, _mm512_fmadd_ps, _mm512_maskz_loadu_ps,
+                _mm512_set1_ps, _mm512_shuffle_f32x4, _mm_cvtss_f32, _mm_hadd_ps, _mm512_sub_ps
+            };
+            let mut sum = _mm512_set1_ps(0.0);
+            for i in (0..q.len()).step_by(64) {
+                let rem = (q.len() - i).min(64) / 4;
+                let mask = u16::MAX >> (16 - rem);
+                let qv = _mm512_maskz_loadu_ps(mask, q.as_ptr().add(i) as *const f32);
+                let dv = _mm512_maskz_loadu_ps(mask, d.as_ptr().add(i) as *const f32);
+                let diff = _mm512_sub_ps(qv, dv);
+                sum = _mm512_fmadd_ps(diff, diff, sum);
+            }
+
+            let x = _mm512_add_ps(sum, _mm512_shuffle_f32x4(sum, sum, 0b00_00_11_10));
+            let r =
+                _mm512_castps512_ps128(_mm512_add_ps(x, _mm512_shuffle_f32x4(x, x, 0b00_00_00_01)));
+            let r = _mm_hadd_ps(r, r);
+            _mm_cvtss_f32(_mm_hadd_ps(r, r)).into()
+        }
     }
 }
 
@@ -73,31 +126,51 @@ pub(crate) fn dot_f32(q: &[f32], d: &[f32]) -> f64 {
 pub(crate) fn dot_f32_bytes(q: &[u8], d: &[u8]) -> f64 {
     assert_eq!(q.len(), d.len());
     assert_eq!(q.len() % 4, 0);
-    #[cfg(target_arch = "aarch64")]
-    unsafe {
-        use core::arch::aarch64::{vaddvq_f32, vdupq_n_f32, vfmaq_f32};
-        let suffix_start = q.len() & !15;
-        let mut dotv = vdupq_n_f32(0.0);
-        for i in (0..suffix_start).step_by(16) {
-            dotv = vfmaq_f32(
-                dotv,
-                load_f32x4_le(q.as_ptr().add(i)),
-                load_f32x4_le(d.as_ptr().add(i)),
-            );
-        }
-        let mut dot = vaddvq_f32(dotv);
-        for i in (suffix_start..q.len()).step_by(4) {
-            dot += std::ptr::read_unaligned(q.as_ptr().add(i) as *const f32)
-                * std::ptr::read_unaligned(d.as_ptr().add(i) as *const f32);
-        }
-        dot as f64
-    }
-    #[cfg(not(target_arch = "aarch64"))]
-    {
-        f32_le_iter(q)
+    match Acceleration::default() {
+        Acceleration::Scalar => f32_le_iter(q)
             .zip(f32_le_iter(d))
             .map(|(q, d)| q * d)
-            .sum::<f32>() as f64
+            .sum::<f32>() as f64,
+        #[cfg(target_arch = "aarch64")]
+        Acceleration::Neon => unsafe {
+            use core::arch::aarch64::{vaddvq_f32, vdupq_n_f32, vfmaq_f32};
+            let suffix_start = q.len() & !15;
+            let mut dotv = vdupq_n_f32(0.0);
+            for i in (0..suffix_start).step_by(16) {
+                dotv = vfmaq_f32(
+                    dotv,
+                    load_f32x4_le(q.as_ptr().add(i)),
+                    load_f32x4_le(d.as_ptr().add(i)),
+                );
+            }
+            let mut dot = vaddvq_f32(dotv);
+            for i in (suffix_start..q.len()).step_by(4) {
+                dot += std::ptr::read_unaligned(q.as_ptr().add(i) as *const f32)
+                    * std::ptr::read_unaligned(d.as_ptr().add(i) as *const f32);
+            }
+            dot as f64
+        },
+        #[cfg(target_arch = "x86_64")]
+        Acceleration::Avx512 => unsafe {
+            use core::arch::x86_64::{
+                _mm512_add_ps, _mm512_castps512_ps128, _mm512_fmadd_ps, _mm512_maskz_loadu_ps,
+                _mm512_set1_ps, _mm512_shuffle_f32x4, _mm_cvtss_f32, _mm_hadd_ps,
+            };
+            let mut dot = _mm512_set1_ps(0.0);
+            for i in (0..q.len()).step_by(64) {
+                let rem = (q.len() - i).min(64) / 4;
+                let mask = u16::MAX >> (16 - rem);
+                let qv = _mm512_maskz_loadu_ps(mask, q.as_ptr().add(i) as *const f32);
+                let dv = _mm512_maskz_loadu_ps(mask, d.as_ptr().add(i) as *const f32);
+                dot = _mm512_fmadd_ps(qv, dv, dot);
+            }
+
+            let x = _mm512_add_ps(dot, _mm512_shuffle_f32x4(dot, dot, 0b00001110));
+            let r =
+                _mm512_castps512_ps128(_mm512_add_ps(x, _mm512_shuffle_f32x4(x, x, 0b00000001)));
+            let r = _mm_hadd_ps(r, r);
+            _mm_cvtss_f32(_mm_hadd_ps(r, r)).into()
+        },
     }
 }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -444,7 +444,7 @@ mod test {
             Self { data: rep, config }
         }
 
-        pub fn reader(&self) -> TestGraphVectorIndexReader {
+        pub fn reader(&self) -> TestGraphVectorIndexReader<'_> {
             TestGraphVectorIndexReader(self)
         }
 

--- a/src/vectors/mod.rs
+++ b/src/vectors/mod.rs
@@ -567,7 +567,7 @@ mod test {
         let rf32_dist = f32_dist_fn.distance_f32(&a.rvec, &b.rvec);
         let ru8_dist =
             f32_dist_fn.distance(bytemuck::cast_slice(&a.rvec), bytemuck::cast_slice(&b.rvec));
-        assert_float_near!(rf32_dist, ru8_dist, 0.00001, index);
+        assert_float_near!(rf32_dist, ru8_dist, 0.0001, index);
 
         let dist_fn = format.new_vector_distance(similarity);
         let qdist = dist_fn.distance(&a.qvec, &b.qvec);

--- a/wt_mdb/src/session/mod.rs
+++ b/wt_mdb/src/session/mod.rs
@@ -163,7 +163,7 @@ impl Session {
     /// Open a record cursor over the named table.
     ///
     /// Returns [rustix::io::Errno::INVAL] if the underlying table is not a record table.
-    pub fn open_record_cursor(&self, table_name: &str) -> Result<RecordCursor> {
+    pub fn open_record_cursor(&self, table_name: &str) -> Result<RecordCursor<'_>> {
         self.new_typed_cursor::<i64, Vec<u8>>(table_name, None)
     }
 
@@ -175,7 +175,7 @@ impl Session {
     }
 
     /// Open a cursor over database metadata.
-    pub fn open_metadata_cursor(&self) -> Result<MetadataCursor> {
+    pub fn open_metadata_cursor(&self) -> Result<MetadataCursor<'_>> {
         self.new_typed_cursor_uri::<CString, CString>(METADATA_URI, None)
     }
 

--- a/wt_sys/Cargo.toml
+++ b/wt_sys/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 [dependencies]
 
 [build-dependencies]
-bindgen = "0.70.1"
+bindgen = "0.72.1"
 cmake = "0.1.51"

--- a/wt_sys/build.rs
+++ b/wt_sys/build.rs
@@ -11,6 +11,7 @@ fn build_wt() -> PathBuf {
         .define("HAVE_UNITTEST", "0")
         // We have quasi-vendored WT and won't change upstream source to handle errors from new compiler versions.
         .cflag("-Wno-everything")
+        .cflag("-w")
         // CMake crate is not doing this correctly for whatever reason.
         .build_arg(format!("-j{jobs}"))
         .build_target("wiredtiger_static")

--- a/wt_sys/src/lib.rs
+++ b/wt_sys/src/lib.rs
@@ -1,10 +1,12 @@
 //! Automatically generated bindings for the WiredTiger C library.
 //!
 
+#![allow(clippy::all)]
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(dead_code)]
+#![allow(unnecessary_transmutes)]
 #![allow(rustdoc::invalid_html_tags)]
 #![allow(rustdoc::broken_intra_doc_links)]
 


### PR DESCRIPTION
Fix some bugs observed in x86 compile locally.

Accelerate f32 distance computation when the input is unaligned bytes using avx512f, otherwise performance is
very poor. Include simsimd hamming distance for scale. Numbers aren't super consistent across runs but this is
still substantially faster than observed on an m4 macbook air, even for hamming distance.

```
f32/coding/l2           time:   [24.146 ns 24.150 ns 24.155 ns]
f32/coding/dot          time:   [18.246 ns 18.247 ns 18.249 ns]
f32/coding/cos          time:   [82.841 ns 83.052 ns 83.427 ns]
f32/l2                  time:   [52.189 ns 52.267 ns 52.413 ns]
f32/dot                 time:   [48.620 ns 48.767 ns 48.998 ns]
f32/cos                 time:   [48.542 ns 48.563 ns 48.601 ns]
i1/hamming              time:   [3.8556 ns 3.8585 ns 3.8620 ns]
```