### PR TITLE
Convert LVQ headers to f16 representation

### DIFF
--- a/vectors/src/lvq.rs
+++ b/vectors/src/lvq.rs
@@ -403,8 +403,7 @@ impl<const B: usize> TurboPrimaryCoder<B> {
             delta: f16::from_f32((interval.1 - interval.0) / ((1 << B) - 1) as f32),
         };
 
-        // XXX interval.1 need to do a f16 round trip.
-        let terms = VectorEncodeTerms::from_primary::<B>(&header, interval.1);
+        let terms = VectorEncodeTerms::from_primary::<B>(&header, f16::from_f32(interval.1));
         match inst {
             InstructionSet::Scalar => scalar::primary_quantize_and_pack::<B>(vector, terms, out),
             #[cfg(target_arch = "aarch64")]
@@ -634,12 +633,10 @@ struct VectorEncodeTerms {
 }
 
 impl VectorEncodeTerms {
-    // XXX should consume the upper bound, it did the wrong thing here.
-    fn from_primary<const B: usize>(primary: &PrimaryVectorHeader, _upper: f32) -> Self {
+    fn from_primary<const B: usize>(primary: &PrimaryVectorHeader, upper: f16) -> Self {
         let lower = primary.lower.to_f32();
-        let delta = primary.delta.to_f32();
-        let upper = lower + delta * ((1 << B) - 1) as f32;
-        let delta_inv = 1.0 / delta;
+        let upper = upper.to_f32();
+        let delta_inv = ((1 << B) - 1) as f32 / (upper - lower);
         Self {
             lower,
             upper,
@@ -713,8 +710,8 @@ impl<const B: usize> TurboResidualCoder<B> {
             magnitude: f16::from_f32(residual_magnitude),
         };
 
-        // XXX interval.1 need to do a f16 round trip.
-        let primary_terms = VectorEncodeTerms::from_primary::<B>(&primary_header, interval.1);
+        let primary_terms =
+            VectorEncodeTerms::from_primary::<B>(&primary_header, f16::from_f32(interval.1));
         let residual_terms = VectorEncodeTerms::from_residual(residual_header.magnitude.to_f32());
         match inst {
             InstructionSet::Scalar => scalar::residual_quantize_and_pack::<B>(

--- a/vectors/src/lvq.rs
+++ b/vectors/src/lvq.rs
@@ -151,7 +151,7 @@ fn optimize_interval(vector: &[f32], stats: &VectorStats, bits: usize) -> (f32, 
 struct PrimaryVectorHeader {
     l2_norm: f16,
     lower: f16,
-    delta: f16,
+    upper: f16,
     component_sum: f16,
 }
 
@@ -169,7 +169,7 @@ impl PrimaryVectorHeader {
         let header = header_bytes.as_chunks_mut::<2>().0;
         header[0] = self.l2_norm.to_le_bytes();
         header[1] = self.lower.to_le_bytes();
-        header[2] = self.delta.to_le_bytes();
+        header[2] = self.upper.to_le_bytes();
         header[3] = self.component_sum.to_le_bytes();
     }
 
@@ -181,7 +181,7 @@ impl PrimaryVectorHeader {
             Self {
                 l2_norm: f16::from_le_bytes(header_entries[0]),
                 lower: f16::from_le_bytes(header_entries[1]),
-                delta: f16::from_le_bytes(header_entries[2]),
+                upper: f16::from_le_bytes(header_entries[2]),
                 component_sum: f16::from_le_bytes(header_entries[3]),
             },
             vector_bytes,
@@ -281,6 +281,15 @@ struct PrimaryVectorTerms {
 }
 
 impl PrimaryVectorTerms {
+    fn from_header<const B: usize>(header: PrimaryVectorHeader) -> Self {
+        Self {
+            l2_norm: header.l2_norm.to_f32(),
+            component_sum: header.component_sum.to_f32(),
+            lower: header.lower.to_f32(),
+            delta: (header.upper.to_f32() - header.lower.to_f32()) / ((1 << B) - 1) as f32,
+        }
+    }
+
     fn correct_dot(&self, dot: u32, dim: usize, other: &PrimaryVectorTerms) -> f32 {
         // Note that any dot value larger than (2 << 24) will be rounded when converted to f32 which can
         // cause vector comparisons a <-> b and b <-> a to return slightly different results. To prevent
@@ -292,17 +301,6 @@ impl PrimaryVectorTerms {
     }
 }
 
-impl From<PrimaryVectorHeader> for PrimaryVectorTerms {
-    fn from(header: PrimaryVectorHeader) -> Self {
-        Self {
-            l2_norm: header.l2_norm.to_f32(),
-            component_sum: header.component_sum.to_f32(),
-            lower: header.lower.to_f32(),
-            delta: header.delta.to_f32(),
-        }
-    }
-}
-
 #[derive(Debug, Clone, Copy)]
 struct ResidualVectorTerms {
     primary: PrimaryVectorTerms,
@@ -311,6 +309,14 @@ struct ResidualVectorTerms {
 }
 
 impl ResidualVectorTerms {
+    fn from_header<const B: usize>(header: (PrimaryVectorHeader, ResidualVectorHeader)) -> Self {
+        Self {
+            primary: PrimaryVectorTerms::from_header::<B>(header.0),
+            lower: -header.1.magnitude.to_f32() / 2.0,
+            delta: header.1.magnitude.to_f32() / RESIDUAL_MAX,
+        }
+    }
+
     fn correct_dot(&self, dot: &ResidualDotComponents, dim: usize, other: &Self) -> f32 {
         let dot_raw = dot.ap_dot_bp as f64 * (self.primary.delta * other.primary.delta) as f64
             + dot.ap_dot_br as f64 * (self.primary.delta * other.delta) as f64
@@ -325,16 +331,6 @@ impl ResidualVectorTerms {
     }
 }
 
-impl From<(PrimaryVectorHeader, ResidualVectorHeader)> for ResidualVectorTerms {
-    fn from(header: (PrimaryVectorHeader, ResidualVectorHeader)) -> Self {
-        Self {
-            primary: PrimaryVectorTerms::from(header.0),
-            lower: -header.1.magnitude.to_f32() / 2.0,
-            delta: header.1.magnitude.to_f32() / RESIDUAL_MAX,
-        }
-    }
-}
-
 #[derive(Debug, Clone, Copy)]
 struct TurboPrimaryVector<'a, const B: usize> {
     data: &'a [u8],
@@ -346,7 +342,7 @@ impl<'a, const B: usize> TurboPrimaryVector<'a, B> {
         let (header, vector_bytes) = PrimaryVectorHeader::deserialize(data)?;
         Some(Self {
             data: vector_bytes,
-            terms: PrimaryVectorTerms::from(header),
+            terms: PrimaryVectorTerms::from_header::<B>(header),
         })
     }
 
@@ -400,10 +396,10 @@ impl<const B: usize> TurboPrimaryCoder<B> {
             l2_norm: f16::from_f32(stats.l2_norm_sq.sqrt()),
             component_sum: f16::from_f32(stats.component_sum),
             lower: f16::from_f32(interval.0),
-            delta: f16::from_f32((interval.1 - interval.0) / ((1 << B) - 1) as f32),
+            upper: f16::from_f32(interval.1),
         };
 
-        let terms = VectorEncodeTerms::from_primary::<B>(&header, f16::from_f32(interval.1));
+        let terms = VectorEncodeTerms::from_primary::<B>(&header);
         match inst {
             InstructionSet::Scalar => scalar::primary_quantize_and_pack::<B>(vector, terms, out),
             #[cfg(target_arch = "aarch64")]
@@ -510,7 +506,7 @@ impl<const B: usize> TurboPrimaryQueryDistance<B> {
         Self {
             similarity,
             query,
-            terms: PrimaryVectorTerms::from(header),
+            terms: PrimaryVectorTerms::from_header::<PRIMARY_QUERY_BITS>(header),
             inst,
         }
     }
@@ -581,7 +577,7 @@ impl<'a, const B: usize> TurboResidualVector<'a, B> {
         Some(Self {
             primary_data: primary_vector,
             residual_data: residual_vector,
-            terms: ResidualVectorTerms::from((primary_header, residual_header)),
+            terms: ResidualVectorTerms::from_header::<B>((primary_header, residual_header)),
         })
     }
 
@@ -633,9 +629,10 @@ struct VectorEncodeTerms {
 }
 
 impl VectorEncodeTerms {
-    fn from_primary<const B: usize>(primary: &PrimaryVectorHeader, upper: f16) -> Self {
-        let lower = primary.lower.to_f32();
-        let upper = upper.to_f32();
+    fn from_primary<const B: usize>(header: &PrimaryVectorHeader) -> Self {
+        let lower = header.lower.to_f32();
+        let upper = header.upper.to_f32();
+        // XXX memoize B component
         let delta_inv = ((1 << B) - 1) as f32 / (upper - lower);
         Self {
             lower,
@@ -704,21 +701,22 @@ impl<const B: usize> TurboResidualCoder<B> {
             l2_norm: f16::from_f32(stats.l2_norm_sq.sqrt()),
             component_sum: f16::from_f32(stats.component_sum),
             lower: f16::from_f32(interval.0),
-            delta: f16::from_f32((interval.1 - interval.0) / ((1 << B) - 1) as f32),
+            upper: f16::from_f32(interval.1),
         };
         let residual_header = ResidualVectorHeader {
             magnitude: f16::from_f32(residual_magnitude),
         };
 
-        let primary_terms =
-            VectorEncodeTerms::from_primary::<B>(&primary_header, f16::from_f32(interval.1));
+        let primary_terms = VectorEncodeTerms::from_primary::<B>(&primary_header);
         let residual_terms = VectorEncodeTerms::from_residual(residual_header.magnitude.to_f32());
+        // XXX memorize B component 1/ (2^B - 1)
+        let primary_delta = (primary_terms.upper - primary_terms.lower) / ((1 << B) - 1) as f32;
         match inst {
             InstructionSet::Scalar => scalar::residual_quantize_and_pack::<B>(
                 vector,
                 primary_terms,
                 residual_terms,
-                primary_header.delta.to_f32(),
+                primary_delta,
                 primary,
                 residual,
             ),
@@ -727,7 +725,7 @@ impl<const B: usize> TurboResidualCoder<B> {
                 vector,
                 primary_terms,
                 residual_terms,
-                primary_header.delta.to_f32(),
+                primary_delta,
                 primary,
                 residual,
             ),
@@ -737,7 +735,7 @@ impl<const B: usize> TurboResidualCoder<B> {
                     vector,
                     primary_terms,
                     residual_terms,
-                    primary_header.delta.to_f32(),
+                    primary_delta,
                     primary,
                     residual,
                 )
@@ -856,7 +854,7 @@ impl<const B: usize> TurboResidualQueryDistance<B> {
             similarity,
             primary_vector,
             residual_vector,
-            terms: ResidualVectorTerms::from((primary_header, residual_header)),
+            terms: ResidualVectorTerms::from_header::<B>((primary_header, residual_header)),
             inst: InstructionSet::default(),
         }
     }
@@ -912,7 +910,7 @@ impl<const B: usize> TurboResidualFastQueryDistance<B> {
     pub fn new(similarity: VectorSimilarity, query: &[f32]) -> Self {
         let inst = InstructionSet::default();
         let (header, query) = TurboPrimaryCoder::<B>::encode_parts(inst, query);
-        let terms = PrimaryVectorTerms::from(header);
+        let terms = PrimaryVectorTerms::from_header::<B>(header);
 
         Self {
             similarity,
@@ -1102,7 +1100,7 @@ mod test {
                 other.l2_norm.to_f32(),
                 epsilon = epsilon
             ) && abs_diff_eq!(self.lower.to_f32(), other.lower.to_f32(), epsilon = epsilon)
-                && abs_diff_eq!(self.delta.to_f32(), other.delta.to_f32(), epsilon = epsilon)
+                && abs_diff_eq!(self.upper.to_f32(), other.upper.to_f32(), epsilon = epsilon)
                 && abs_diff_eq!(
                     self.component_sum.to_f32(),
                     other.component_sum.to_f32(),
@@ -1169,7 +1167,7 @@ mod test {
             PrimaryVectorHeader {
                 l2_norm: f16::from_f32(2.5226507),
                 lower: f16::from_f32(-0.49564388),
-                delta: f16::from_f32(1.2012576),
+                upper: f16::from_f32(0.7055664),
                 component_sum: f16::from_f32(3.176),
             }
         );
@@ -1212,7 +1210,7 @@ mod test {
             PrimaryVectorHeader {
                 l2_norm: f16::from_f32(2.5226507),
                 lower: f16::from_f32(-0.6709247),
-                delta: f16::from_f32(0.5039812),
+                upper: f16::from_f32(0.8408203),
                 component_sum: f16::from_f32(3.176),
             }
         );
@@ -1255,7 +1253,7 @@ mod test {
             PrimaryVectorHeader {
                 l2_norm: f16::from_f32(2.5226507),
                 lower: f16::from_f32(-0.93474734),
-                delta: f16::from_f32(0.12319123),
+                upper: f16::from_f32(0.91308594),
                 component_sum: f16::from_f32(3.176),
             }
         );
@@ -1265,24 +1263,24 @@ mod test {
             decoded.as_ref(),
             [
                 -0.9345703,
-                -0.072387695,
-                0.666626,
-                0.666626,
-                0.54345703,
-                0.4202881,
-                0.666626,
-                0.05078125,
-                -0.19555664,
-                -0.44189453,
-                0.7897949,
-                -0.6882324,
-                -0.3187256,
-                0.54345703,
-                -0.6882324,
-                0.4202881,
-                0.91296387,
-                0.666626,
-                0.1739502
+                -0.07233074,
+                0.6667317,
+                0.6667317,
+                0.54355466,
+                0.42037758,
+                0.6667317,
+                0.05084634,
+                -0.19550782,
+                -0.441862,
+                0.7899088,
+                -0.68821615,
+                -0.3186849,
+                0.54355466,
+                -0.68821615,
+                0.42037758,
+                0.91308594,
+                0.6667317,
+                0.17402342
             ]
             .as_ref(),
             epsilon = 0.0001,
@@ -1298,7 +1296,7 @@ mod test {
             PrimaryVectorHeader {
                 l2_norm: f16::from_f32(2.5226507),
                 lower: f16::from_f32(-0.92000645),
-                delta: f16::from_f32(0.0071822493),
+                upper: f16::from_f32(0.9116211),
                 component_sum: f16::from_f32(3.176),
             }
         );
@@ -1308,24 +1306,24 @@ mod test {
             decoded.as_ref(),
             [
                 -0.9199219,
-                -0.05795288,
-                0.6603546,
-                0.6675377,
-                0.5741577,
-                0.43049622,
-                0.64598846,
-                -0.00048828125,
-                -0.20161438,
-                -0.43147278,
-                0.73218536,
-                -0.7044296,
-                -0.27344513,
-                0.53824234,
-                -0.7331619,
-                0.4376793,
-                0.91176224,
-                0.69627,
-                0.20063782
+                -0.05801932,
+                0.6602328,
+                0.6674153,
+                0.57404256,
+                0.43039212,
+                0.64586776,
+                -0.0005591512,
+                -0.20166975,
+                -0.43151042,
+                0.73205805,
+                -0.70444626,
+                -0.27349496,
+                0.5381299,
+                -0.73317635,
+                0.43757465,
+                0.91162103,
+                0.6961454,
+                0.20055145
             ]
             .as_ref(),
             epsilon = 0.0001
@@ -1342,7 +1340,7 @@ mod test {
             PrimaryVectorHeader {
                 l2_norm: f16::from_f32(2.5226507),
                 lower: f16::from_f32(-0.49564388),
-                delta: f16::from_f32(1.2012576),
+                upper: f16::from_f32(0.7055664),
                 component_sum: f16::from_f32(3.176),
             }
         );
@@ -1393,7 +1391,7 @@ mod test {
             PrimaryVectorHeader {
                 l2_norm: f16::from_f32(2.5226507),
                 lower: f16::from_f32(-0.6709247),
-                delta: f16::from_f32(0.5039812),
+                upper: f16::from_f32(0.8408203),
                 component_sum: f16::from_f32(3.176),
             }
         );
@@ -1444,7 +1442,7 @@ mod test {
             PrimaryVectorHeader {
                 l2_norm: f16::from_f32(2.5226507),
                 lower: f16::from_f32(-0.93474734),
-                delta: f16::from_f32(0.12319123),
+                upper: f16::from_f32(0.91308594),
                 component_sum: f16::from_f32(3.176),
             }
         );
@@ -1461,24 +1459,24 @@ mod test {
             decoded.as_ref(),
             [
                 -0.9208044,
-                -0.061036833,
-                0.6591392,
-                0.6697656,
-                0.5731625,
-                0.43115592,
-                0.64609784,
-                0.00078914687,
-                -0.20014529,
-                -0.4281286,
-                0.73014253,
-                -0.70393044,
-                -0.27308062,
-                0.53886837,
-                -0.73097926,
-                0.4359861,
-                0.9132054,
-                0.6939163,
-                0.2022066
+                -0.06097988,
+                0.658762,
+                0.66987133,
+                0.5727771,
+                0.4307624,
+                0.6462036,
+                0.00085423514,
+                -0.20009647,
+                -0.42809606,
+                0.7297734,
+                -0.70391417,
+                -0.27303994,
+                0.538966,
+                -0.730963,
+                0.43607557,
+                0.9128444,
+                0.69402206,
+                0.2017968
             ]
             .as_ref(),
             epsilon = 0.0001,
@@ -1495,7 +1493,7 @@ mod test {
             PrimaryVectorHeader {
                 l2_norm: f16::from_f32(2.5226507),
                 lower: f16::from_f32(-0.92000645),
-                delta: f16::from_f32(0.0071822493),
+                upper: f16::from_f32(0.9116211),
                 component_sum: f16::from_f32(3.176),
             }
         );

--- a/vectors/src/lvq.rs
+++ b/vectors/src/lvq.rs
@@ -14,6 +14,7 @@ mod scalar;
 #[cfg(target_arch = "x86_64")]
 mod x86_64;
 
+use half::f16;
 use std::{
     borrow::Cow,
     ops::{Add, AddAssign},
@@ -148,10 +149,10 @@ fn optimize_interval(vector: &[f32], stats: &VectorStats, bits: usize) -> (f32, 
 #[derive(Debug, Copy, Clone, PartialEq)]
 #[repr(C)]
 struct PrimaryVectorHeader {
-    l2_norm: f32,
-    lower: f32,
-    delta: f32,
-    component_sum: f32,
+    l2_norm: f16,
+    lower: f16,
+    delta: f16,
+    component_sum: f16,
 }
 
 impl PrimaryVectorHeader {
@@ -165,7 +166,7 @@ impl PrimaryVectorHeader {
 
     #[inline]
     fn serialize(&self, header_bytes: &mut [u8]) {
-        let header = header_bytes.as_chunks_mut::<4>().0;
+        let header = header_bytes.as_chunks_mut::<2>().0;
         header[0] = self.l2_norm.to_le_bytes();
         header[1] = self.lower.to_le_bytes();
         header[2] = self.delta.to_le_bytes();
@@ -175,13 +176,13 @@ impl PrimaryVectorHeader {
     #[inline]
     fn deserialize(raw: &[u8]) -> Option<(Self, &[u8])> {
         let (header_bytes, vector_bytes) = raw.split_at_checked(Self::LEN)?;
-        let header_entries = header_bytes.as_chunks::<4>().0;
+        let header_entries = header_bytes.as_chunks::<2>().0;
         Some((
             Self {
-                l2_norm: f32::from_le_bytes(header_entries[0]),
-                lower: f32::from_le_bytes(header_entries[1]),
-                delta: f32::from_le_bytes(header_entries[2]),
-                component_sum: f32::from_le_bytes(header_entries[3]),
+                l2_norm: f16::from_le_bytes(header_entries[0]),
+                lower: f16::from_le_bytes(header_entries[1]),
+                delta: f16::from_le_bytes(header_entries[2]),
+                component_sum: f16::from_le_bytes(header_entries[3]),
             },
             vector_bytes,
         ))
@@ -196,7 +197,7 @@ impl PrimaryVectorHeader {
 #[derive(Debug, Copy, Clone, PartialEq)]
 #[repr(C)]
 struct ResidualVectorHeader {
-    magnitude: f32,
+    magnitude: f16,
 }
 
 impl ResidualVectorHeader {
@@ -210,17 +211,17 @@ impl ResidualVectorHeader {
 
     #[inline]
     fn serialize(&self, header_bytes: &mut [u8]) {
-        let header = header_bytes.as_chunks_mut::<4>().0;
+        let header = header_bytes.as_chunks_mut::<2>().0;
         header[0] = self.magnitude.to_le_bytes();
     }
 
     #[inline]
     fn deserialize(raw: &[u8]) -> Option<(Self, &[u8])> {
         let (header_bytes, vector_bytes) = raw.split_at_checked(Self::LEN)?;
-        let header_entries = header_bytes.as_chunks::<4>().0;
+        let header_entries = header_bytes.as_chunks::<2>().0;
         Some((
             Self {
-                magnitude: f32::from_le_bytes(header_entries[0]),
+                magnitude: f16::from_le_bytes(header_entries[0]),
             },
             vector_bytes,
         ))
@@ -291,14 +292,13 @@ impl PrimaryVectorTerms {
     }
 }
 
-// NB: this is kind of silly, but it will be less silly when the header is packed f16.
 impl From<PrimaryVectorHeader> for PrimaryVectorTerms {
     fn from(header: PrimaryVectorHeader) -> Self {
         Self {
-            l2_norm: header.l2_norm,
-            component_sum: header.component_sum,
-            lower: header.lower,
-            delta: header.delta,
+            l2_norm: header.l2_norm.to_f32(),
+            component_sum: header.component_sum.to_f32(),
+            lower: header.lower.to_f32(),
+            delta: header.delta.to_f32(),
         }
     }
 }
@@ -325,13 +325,12 @@ impl ResidualVectorTerms {
     }
 }
 
-// NB: this is kind of silly, but it will be less silly when the header is packed f16.
 impl From<(PrimaryVectorHeader, ResidualVectorHeader)> for ResidualVectorTerms {
     fn from(header: (PrimaryVectorHeader, ResidualVectorHeader)) -> Self {
         Self {
             primary: PrimaryVectorTerms::from(header.0),
-            lower: -header.1.magnitude / 2.0,
-            delta: header.1.magnitude / RESIDUAL_MAX,
+            lower: -header.1.magnitude.to_f32() / 2.0,
+            delta: header.1.magnitude.to_f32() / RESIDUAL_MAX,
         }
     }
 }
@@ -398,12 +397,13 @@ impl<const B: usize> TurboPrimaryCoder<B> {
         let stats = VectorStats::from(vector);
         let interval = optimize_interval(vector, &stats, B);
         let header = PrimaryVectorHeader {
-            l2_norm: stats.l2_norm_sq.sqrt(),
-            component_sum: stats.component_sum,
-            lower: interval.0,
-            delta: (interval.1 - interval.0) / ((1 << B) - 1) as f32,
+            l2_norm: f16::from_f32(stats.l2_norm_sq.sqrt()),
+            component_sum: f16::from_f32(stats.component_sum),
+            lower: f16::from_f32(interval.0),
+            delta: f16::from_f32((interval.1 - interval.0) / ((1 << B) - 1) as f32),
         };
 
+        // XXX interval.1 need to do a f16 round trip.
         let terms = VectorEncodeTerms::from_primary::<B>(&header, interval.1);
         match inst {
             InstructionSet::Scalar => scalar::primary_quantize_and_pack::<B>(vector, terms, out),
@@ -634,10 +634,14 @@ struct VectorEncodeTerms {
 }
 
 impl VectorEncodeTerms {
-    fn from_primary<const B: usize>(primary: &PrimaryVectorHeader, upper: f32) -> Self {
-        let delta_inv = ((1 << B) - 1) as f32 / (upper - primary.lower);
+    // XXX should consume the upper bound, it did the wrong thing here.
+    fn from_primary<const B: usize>(primary: &PrimaryVectorHeader, _upper: f32) -> Self {
+        let lower = primary.lower.to_f32();
+        let delta = primary.delta.to_f32();
+        let upper = lower + delta * ((1 << B) - 1) as f32;
+        let delta_inv = 1.0 / delta;
         Self {
-            lower: primary.lower,
+            lower,
             upper,
             delta_inv,
         }
@@ -700,23 +704,24 @@ impl<const B: usize> TurboResidualCoder<B> {
         .max_by(f32::total_cmp)
         .expect("3 values input");
         let primary_header = PrimaryVectorHeader {
-            l2_norm: stats.l2_norm_sq.sqrt(),
-            component_sum: stats.component_sum,
-            lower: interval.0,
-            delta: (interval.1 - interval.0) / ((1 << B) - 1) as f32,
+            l2_norm: f16::from_f32(stats.l2_norm_sq.sqrt()),
+            component_sum: f16::from_f32(stats.component_sum),
+            lower: f16::from_f32(interval.0),
+            delta: f16::from_f32((interval.1 - interval.0) / ((1 << B) - 1) as f32),
         };
         let residual_header = ResidualVectorHeader {
-            magnitude: residual_magnitude,
+            magnitude: f16::from_f32(residual_magnitude),
         };
 
+        // XXX interval.1 need to do a f16 round trip.
         let primary_terms = VectorEncodeTerms::from_primary::<B>(&primary_header, interval.1);
-        let residual_terms = VectorEncodeTerms::from_residual(residual_magnitude);
+        let residual_terms = VectorEncodeTerms::from_residual(residual_header.magnitude.to_f32());
         match inst {
             InstructionSet::Scalar => scalar::residual_quantize_and_pack::<B>(
                 vector,
                 primary_terms,
                 residual_terms,
-                primary_header.delta,
+                primary_header.delta.to_f32(),
                 primary,
                 residual,
             ),
@@ -725,7 +730,7 @@ impl<const B: usize> TurboResidualCoder<B> {
                 vector,
                 primary_terms,
                 residual_terms,
-                primary_header.delta,
+                primary_header.delta.to_f32(),
                 primary,
                 residual,
             ),
@@ -735,7 +740,7 @@ impl<const B: usize> TurboResidualCoder<B> {
                     vector,
                     primary_terms,
                     residual_terms,
-                    primary_header.delta,
+                    primary_header.delta.to_f32(),
                     primary,
                     residual,
                 )
@@ -1079,6 +1084,7 @@ mod packing {
 #[cfg(test)]
 mod test {
     use approx::{AbsDiffEq, abs_diff_eq, assert_abs_diff_eq};
+    use half::f16;
 
     use crate::lvq::{
         PrimaryVectorHeader, ResidualVectorHeader, TurboPrimaryCoder, TurboResidualCoder,
@@ -1094,10 +1100,17 @@ mod test {
         }
 
         fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
-            abs_diff_eq!(self.l2_norm, other.l2_norm, epsilon = epsilon)
-                && abs_diff_eq!(self.lower, other.lower, epsilon = epsilon)
-                && abs_diff_eq!(self.delta, other.delta, epsilon = epsilon)
-                && abs_diff_eq!(self.component_sum, other.component_sum, epsilon = epsilon)
+            abs_diff_eq!(
+                self.l2_norm.to_f32(),
+                other.l2_norm.to_f32(),
+                epsilon = epsilon
+            ) && abs_diff_eq!(self.lower.to_f32(), other.lower.to_f32(), epsilon = epsilon)
+                && abs_diff_eq!(self.delta.to_f32(), other.delta.to_f32(), epsilon = epsilon)
+                && abs_diff_eq!(
+                    self.component_sum.to_f32(),
+                    other.component_sum.to_f32(),
+                    epsilon = epsilon
+                )
         }
     }
 
@@ -1110,7 +1123,11 @@ mod test {
 
         fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
             // TODO: tlvq8x8 fails on aarch64 when epsilon = 0; figure this out
-            abs_diff_eq!(self.magnitude, other.magnitude, epsilon = epsilon)
+            abs_diff_eq!(
+                self.magnitude.to_f32(),
+                other.magnitude.to_f32(),
+                epsilon = epsilon
+            )
         }
     }
 
@@ -1153,10 +1170,10 @@ mod test {
         assert_abs_diff_eq!(
             PrimaryVectorHeader::deserialize(&encoded).unwrap().0,
             PrimaryVectorHeader {
-                l2_norm: 2.5226507,
-                lower: -0.49564388,
-                delta: 1.2012576,
-                component_sum: 3.176,
+                l2_norm: f16::from_f32(2.5226507),
+                lower: f16::from_f32(-0.49564388),
+                delta: f16::from_f32(1.2012576),
+                component_sum: f16::from_f32(3.176),
             }
         );
         let mut decoded = vec![0.0f32; TEST_VECTOR.len()];
@@ -1164,25 +1181,25 @@ mod test {
         assert_abs_diff_eq!(
             decoded.as_ref(),
             [
-                -0.49564388,
-                -0.49564388,
-                0.70561373,
-                0.70561373,
-                0.70561373,
-                0.70561373,
-                0.70561373,
-                -0.49564388,
-                -0.49564388,
-                -0.49564388,
-                0.70561373,
-                -0.49564388,
-                -0.49564388,
-                0.70561373,
-                -0.49564388,
-                0.70561373,
-                0.70561373,
-                0.70561373,
-                0.70561373
+                -0.49560547,
+                -0.49560547,
+                0.7055664,
+                0.7055664,
+                0.7055664,
+                0.7055664,
+                0.7055664,
+                -0.49560547,
+                -0.49560547,
+                -0.49560547,
+                0.7055664,
+                -0.49560547,
+                -0.49560547,
+                0.7055664,
+                -0.49560547,
+                0.7055664,
+                0.7055664,
+                0.7055664,
+                0.7055664
             ]
             .as_ref(),
             epsilon = 0.00001
@@ -1196,10 +1213,10 @@ mod test {
         assert_abs_diff_eq!(
             PrimaryVectorHeader::deserialize(&encoded).unwrap().0,
             PrimaryVectorHeader {
-                l2_norm: 2.5226507,
-                lower: -0.6709247,
-                delta: 0.5039812,
-                component_sum: 3.176,
+                l2_norm: f16::from_f32(2.5226507),
+                lower: f16::from_f32(-0.6709247),
+                delta: f16::from_f32(0.5039812),
+                component_sum: f16::from_f32(3.176),
             }
         );
         let mut decoded = vec![0.0f32; TEST_VECTOR.len()];
@@ -1207,25 +1224,25 @@ mod test {
         assert_abs_diff_eq!(
             decoded.as_ref(),
             [
-                -0.6709247,
-                -0.16694355,
-                0.8410188,
-                0.8410188,
-                0.33703762,
-                0.33703762,
-                0.8410188,
-                -0.16694355,
-                -0.16694355,
-                -0.6709247,
-                0.8410188,
-                -0.6709247,
-                -0.16694355,
-                0.33703762,
-                -0.6709247,
-                0.33703762,
-                0.8410188,
-                0.8410188,
-                0.33703762
+                -0.67089844,
+                -0.16699219,
+                0.8408203,
+                0.8408203,
+                0.33691406,
+                0.33691406,
+                0.8408203,
+                -0.16699219,
+                -0.16699219,
+                -0.67089844,
+                0.8408203,
+                -0.67089844,
+                -0.16699219,
+                0.33691406,
+                -0.67089844,
+                0.33691406,
+                0.8408203,
+                0.8408203,
+                0.33691406
             ]
             .as_ref(),
             epsilon = 0.0001,
@@ -1239,10 +1256,10 @@ mod test {
         assert_abs_diff_eq!(
             PrimaryVectorHeader::deserialize(&encoded).unwrap().0,
             PrimaryVectorHeader {
-                l2_norm: 2.5226507,
-                lower: -0.93474734,
-                delta: 0.12319123,
-                component_sum: 3.176,
+                l2_norm: f16::from_f32(2.5226507),
+                lower: f16::from_f32(-0.93474734),
+                delta: f16::from_f32(0.12319123),
+                component_sum: f16::from_f32(3.176),
             }
         );
         let mut decoded = vec![0.0f32; TEST_VECTOR.len()];
@@ -1250,25 +1267,25 @@ mod test {
         assert_abs_diff_eq!(
             decoded.as_ref(),
             [
-                -0.93474734,
-                -0.072408736,
-                0.6667386,
-                0.6667386,
-                0.5435474,
-                0.42035615,
-                0.6667386,
-                0.0507825,
-                -0.19559997,
-                -0.44198242,
-                0.78992987,
-                -0.68836486,
-                -0.3187912,
-                0.5435474,
-                -0.68836486,
-                0.42035615,
-                0.9131211,
-                0.6667386,
-                0.17397368
+                -0.9345703,
+                -0.072387695,
+                0.666626,
+                0.666626,
+                0.54345703,
+                0.4202881,
+                0.666626,
+                0.05078125,
+                -0.19555664,
+                -0.44189453,
+                0.7897949,
+                -0.6882324,
+                -0.3187256,
+                0.54345703,
+                -0.6882324,
+                0.4202881,
+                0.91296387,
+                0.666626,
+                0.1739502
             ]
             .as_ref(),
             epsilon = 0.0001,
@@ -1282,10 +1299,10 @@ mod test {
         assert_abs_diff_eq!(
             PrimaryVectorHeader::deserialize(&encoded).unwrap().0,
             PrimaryVectorHeader {
-                l2_norm: 2.5226507,
-                lower: -0.92000645,
-                delta: 0.0071822493,
-                component_sum: 3.176,
+                l2_norm: f16::from_f32(2.5226507),
+                lower: f16::from_f32(-0.92000645),
+                delta: f16::from_f32(0.0071822493),
+                component_sum: f16::from_f32(3.176),
             }
         );
         let mut decoded = vec![0.0f32; TEST_VECTOR.len()];
@@ -1293,25 +1310,25 @@ mod test {
         assert_abs_diff_eq!(
             decoded.as_ref(),
             [
-                -0.92000645,
-                -0.058136523,
-                0.66008836,
-                0.6672706,
-                0.57390136,
-                0.43025643,
-                0.6457239,
-                -0.0006785393,
-                -0.20178151,
-                -0.42443126,
-                0.7319109,
-                -0.70453894,
-                -0.27360404,
-                0.53799015,
-                -0.73326796,
-                0.43743867,
-                0.91146713,
-                0.6959997,
-                0.20042449
+                -0.9199219,
+                -0.05795288,
+                0.6603546,
+                0.6675377,
+                0.5741577,
+                0.43049622,
+                0.64598846,
+                -0.00048828125,
+                -0.20161438,
+                -0.43147278,
+                0.73218536,
+                -0.7044296,
+                -0.27344513,
+                0.53824234,
+                -0.7331619,
+                0.4376793,
+                0.91176224,
+                0.69627,
+                0.20063782
             ]
             .as_ref(),
             epsilon = 0.0001
@@ -1326,17 +1343,17 @@ mod test {
         assert_abs_diff_eq!(
             primary_header,
             PrimaryVectorHeader {
-                l2_norm: 2.5226507,
-                lower: -0.49564388,
-                delta: 1.2012576,
-                component_sum: 3.176,
+                l2_norm: f16::from_f32(2.5226507),
+                lower: f16::from_f32(-0.49564388),
+                delta: f16::from_f32(1.2012576),
+                component_sum: f16::from_f32(3.176),
             }
         );
         let (residual_header, _) = ResidualVectorHeader::deserialize(&vector_bytes).unwrap();
         assert_abs_diff_eq!(
             residual_header,
             ResidualVectorHeader {
-                magnitude: 1.2012576,
+                magnitude: f16::from_f32(1.2012576),
             }
         );
         let mut decoded = vec![0.0f32; TEST_VECTOR.len()];
@@ -1344,25 +1361,25 @@ mod test {
         assert_abs_diff_eq!(
             decoded.as_ref(),
             [
-                -0.9219725,
-                -0.05989358,
-                0.660861,
-                0.6702826,
-                0.5713555,
-                0.4300311,
-                0.6467286,
-                0.0013469756,
-                -0.20121804,
-                -0.42733708,
-                0.7315232,
-                -0.7052751,
-                -0.27188024,
-                0.5383798,
-                -0.72882915,
-                0.4347419,
-                0.91524494,
-                0.6938367,
-                0.20391202
+                -0.9219037,
+                -0.059886307,
+                0.66081685,
+                0.6702378,
+                0.5713178,
+                0.43000343,
+                0.6466854,
+                0.001349926,
+                -0.20120063,
+                -0.42730355,
+                0.73147404,
+                -0.7052218,
+                -0.2718578,
+                0.53834444,
+                -0.72877413,
+                0.4347139,
+                0.91518265,
+                0.6937902,
+                0.20390052
             ]
             .as_ref(),
             epsilon = 0.00001
@@ -1377,17 +1394,17 @@ mod test {
         assert_abs_diff_eq!(
             primary_header,
             PrimaryVectorHeader {
-                l2_norm: 2.5226507,
-                lower: -0.6709247,
-                delta: 0.5039812,
-                component_sum: 3.176,
+                l2_norm: f16::from_f32(2.5226507),
+                lower: f16::from_f32(-0.6709247),
+                delta: f16::from_f32(0.5039812),
+                component_sum: f16::from_f32(3.176),
             }
         );
         let (residual_header, _) = ResidualVectorHeader::deserialize(&vector_bytes).unwrap();
         assert_abs_diff_eq!(
             residual_header,
             ResidualVectorHeader {
-                magnitude: 0.5039812,
+                magnitude: f16::from_f32(0.5039812),
             }
         );
         let mut decoded = vec![0.0f32; TEST_VECTOR.len()];
@@ -1395,25 +1412,25 @@ mod test {
         assert_abs_diff_eq!(
             decoded.as_ref(),
             [
-                -0.9209389,
-                -0.06120634,
-                0.6582021,
-                0.67006046,
-                0.57321703,
-                0.43091646,
-                0.6463437,
-                6.195903e-5,
-                -0.19955412,
-                -0.42881614,
-                0.72935236,
-                -0.70353526,
-                -0.2726808,
-                0.53961825,
-                -0.7312048,
-                0.43684563,
-                0.9131573,
-                0.6937772,
-                0.20165443
+                -0.92087543,
+                -0.06127066,
+                0.6580308,
+                0.6698874,
+                0.57305837,
+                0.43077898,
+                0.6461742,
+                0.0019646436,
+                -0.19959787,
+                -0.4288258,
+                0.7291705,
+                -0.70350415,
+                -0.2727137,
+                0.53946465,
+                -0.7311696,
+                0.4367073,
+                0.9129481,
+                0.69360065,
+                0.20155102
             ]
             .as_ref(),
             epsilon = 0.0001,
@@ -1428,17 +1445,17 @@ mod test {
         assert_abs_diff_eq!(
             primary_header,
             PrimaryVectorHeader {
-                l2_norm: 2.5226507,
-                lower: -0.93474734,
-                delta: 0.12319123,
-                component_sum: 3.176,
+                l2_norm: f16::from_f32(2.5226507),
+                lower: f16::from_f32(-0.93474734),
+                delta: f16::from_f32(0.12319123),
+                component_sum: f16::from_f32(3.176),
             }
         );
         let (residual_header, _) = ResidualVectorHeader::deserialize(&vector_bytes).unwrap();
         assert_abs_diff_eq!(
             residual_header,
             ResidualVectorHeader {
-                magnitude: 0.12319123,
+                magnitude: f16::from_f32(0.12319123),
             }
         );
         let mut decoded = vec![0.0f32; TEST_VECTOR.len()];
@@ -1446,25 +1463,25 @@ mod test {
         assert_abs_diff_eq!(
             decoded.as_ref(),
             [
-                -0.9209789,
-                -0.06105582,
-                0.65876746,
-                0.6698788,
-                0.5727751,
-                0.43122596,
-                0.64620674,
-                0.0007813573,
-                -0.20018944,
-                -0.42821398,
-                0.72978354,
-                -0.7040657,
-                -0.273138,
-                0.5389579,
-                -0.73111945,
-                0.436057,
-                0.9128795,
-                0.6940339,
-                0.20223519
+                -0.9208044,
+                -0.061036833,
+                0.6591392,
+                0.6697656,
+                0.5731625,
+                0.43115592,
+                0.64609784,
+                0.00078914687,
+                -0.20014529,
+                -0.4281286,
+                0.73014253,
+                -0.70393044,
+                -0.27308062,
+                0.53886837,
+                -0.73097926,
+                0.4359861,
+                0.9132054,
+                0.6939163,
+                0.2022066
             ]
             .as_ref(),
             epsilon = 0.0001,
@@ -1479,17 +1496,17 @@ mod test {
         assert_abs_diff_eq!(
             primary_header,
             PrimaryVectorHeader {
-                l2_norm: 2.5226507,
-                lower: -0.92000645,
-                delta: 0.0071822493,
-                component_sum: 3.176,
+                l2_norm: f16::from_f32(2.5226507),
+                lower: f16::from_f32(-0.92000645),
+                delta: f16::from_f32(0.0071822493),
+                component_sum: f16::from_f32(3.176),
             }
         );
         let (residual_header, _) = ResidualVectorHeader::deserialize(&vector_bytes).unwrap();
         assert_abs_diff_eq!(
             residual_header,
             ResidualVectorHeader {
-                magnitude: 0.0071822493,
+                magnitude: f16::from_f32(0.0071822493),
             }
         );
         let mut decoded = vec![0.0f32; TEST_VECTOR.len()];


### PR DESCRIPTION
This halves the size of the headers, 8 bytes for primary vectors and 2 bytes for residual vectors.

This undoes the header `delta` changes in #162 as once we reduce precision in the delta it causes more
quantization loss than storing the `upper` value and computing the delta on the fly.

Quantization loss -- mean quantization error norm:
| Config | single | half |
| --- | --- | --- |
| 1 | 0.718180 | 0.718180 |
| 2 | 0.375909 | 0.375909 |
| 4 | 0.108365 | 0.108367 |
| 8 | 0.008383 | 0.008384 |
| 1x8 | 0.005668 | 0.005668 |
| 2x8 | 0.004093 | 0.004093 |
| 4x8 | 0.002498 | 0.002498 |
| 8x8 | 0.000151 | 0.000218 |

XXX this table needs to be fixed with the upper changes.

This mostly affects 8 bit quantization, probably due to loss of precision in the delta value. Maybe it would've been best to stick with the upper value rather than pre-encoding a delta?

<TODO: this also needs recall testing>