### PR TITLE
Add the ability to center vectors in a vamana graph

### DIFF
--- a/et/src/spann/bulk_load.rs
+++ b/et/src/spann/bulk_load.rs
@@ -168,6 +168,7 @@ pub fn bulk_load(
                 patience_count: c,
             }),
         },
+        centroid: None,
     };
     let spann_config = IndexConfig {
         replica_count: args.replica_count.get(),

--- a/et/src/spann/init_index.rs
+++ b/et/src/spann/init_index.rs
@@ -127,6 +127,7 @@ pub fn init_index(
                 patience_count: c,
             }),
         },
+        centroid: None,
     };
     let beam_width = args
         .head_edge_candidates

--- a/et/src/vamana/bulk_load.rs
+++ b/et/src/vamana/bulk_load.rs
@@ -75,6 +75,11 @@ pub struct BulkLoadArgs {
     /// Limit the number of input vectors. Useful for testing.
     #[arg(short, long)]
     limit: Option<usize>,
+
+    /// If set, compute a mean vector from the input dataset and use it as a centering offset
+    /// during quantization and distance computation.
+    #[arg(long, default_value_t = false)]
+    center: bool,
 }
 
 pub fn bulk_load(
@@ -86,6 +91,23 @@ pub fn bulk_load(
         unsafe { memmap2::Mmap::map(&File::open(args.f32_vectors)?)? },
         args.dimensions,
     )?;
+
+    let num_vectors = f32_vectors.len();
+    let limit = args.limit.unwrap_or(num_vectors);
+
+    let centroid = if args.center {
+        let dims = args.dimensions.get();
+        let mut sum = vec![0.0f64; dims];
+        for v in f32_vectors.iter().take(limit) {
+            for (s, x) in sum.iter_mut().zip(v.iter()) {
+                *s += *x as f64;
+            }
+        }
+        let n = limit as f64;
+        Some(sum.iter().map(|s| (s / n) as f32).collect::<Vec<f32>>())
+    } else {
+        None
+    };
 
     let config = GraphConfig {
         dimensions: args.dimensions,
@@ -104,15 +126,13 @@ pub fn bulk_load(
                 patience_count: c,
             }),
         },
-        centroid: None,
+        centroid,
     };
     if args.drop_tables {
         drop_index(connection.clone(), index_name)?;
     }
     let index = TableGraphVectorIndex::from_init(config, index_name)?;
 
-    let num_vectors = f32_vectors.len();
-    let limit = args.limit.unwrap_or(num_vectors);
     let mut builder = BulkLoadBuilder::new(
         connection.clone(),
         index,

--- a/et/src/vamana/bulk_load.rs
+++ b/et/src/vamana/bulk_load.rs
@@ -104,6 +104,7 @@ pub fn bulk_load(
                 patience_count: c,
             }),
         },
+        centroid: None,
     };
     if args.drop_tables {
         drop_index(connection.clone(), index_name)?;

--- a/et/src/vamana/init_index.rs
+++ b/et/src/vamana/init_index.rs
@@ -93,6 +93,7 @@ pub fn init_index(
                     patience_count: c,
                 }),
             },
+            centroid: None,
         },
         index_name,
     )

--- a/et/src/vamana/lookup.rs
+++ b/et/src/vamana/lookup.rs
@@ -50,6 +50,7 @@ pub fn lookup(connection: Arc<Connection>, index_name: &str, args: LookupArgs) -
             txn.open_record_cursor(index.nav_table().name())?,
             index.config().similarity,
             index.nav_table().format(),
+            index.nav_table().centroid().map(std::sync::Arc::from),
         );
         match vectors.get(args.id) {
             None => {

--- a/src/vamana.rs
+++ b/src/vamana.rs
@@ -81,7 +81,7 @@ impl EdgePruningConfig {
 }
 
 /// Configuration describing graph shape and construction. Used to read and mutate the graph.
-#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GraphConfig {
     /// Number of vector dimensions.
     pub dimensions: NonZero<usize>,
@@ -110,6 +110,11 @@ pub struct GraphConfig {
     ///
     /// This dictates the set of candidate edges provided to pruning.
     pub index_search_params: GraphSearchParams,
+    /// Optional center vector used for quantization.
+    ///
+    /// When present, this centroid is subtracted from vectors before encoding and is passed to all
+    /// distance computation functions to apply the appropriate correction terms.
+    pub centroid: Option<Vec<f32>>,
 }
 
 /// `GraphVectorIndex` is used to generate objects for graph navigation and mutation.
@@ -203,14 +208,18 @@ pub trait GraphVectorStore {
     /// Return the format that vectors in the store are encoded in.
     fn format(&self) -> F32VectorCoding;
 
+    /// Return the centering vector used for quantization, if any.
+    fn centroid(&self) -> Option<&[f32]>;
+
     /// Create a new distance function that operates over vectors on this table.
     fn new_distance_function(&self) -> Box<dyn VectorDistance> {
-        self.format().distance_symmetric(self.similarity(), None)
+        self.format().distance_symmetric(self.similarity(), self.centroid())
     }
 
     /// Create a new coder for vectors of this type.
     fn new_coder(&self) -> Box<dyn F32VectorCoder> {
-        self.format().coder(self.similarity(), None)
+        self.format()
+            .coder(self.similarity(), self.centroid().map(|c| c.to_vec()))
     }
 
     /// Return the contents of the vector at vertex, or `None` if the vertex is unknown.

--- a/src/vamana/bulk.rs
+++ b/src/vamana/bulk.rs
@@ -467,7 +467,7 @@ where
         let vertex_dist_fn = vector_format.query_distance_symmetric(
             self.index.config().similarity,
             &vertex_vector,
-            None,
+            self.index.config().centroid.as_deref(),
         );
         let limit = self.index.config().index_search_params.beam_width.get();
         for in_flight_vertex in in_flight.filter(|v| *v != vertex_id) {
@@ -590,28 +590,35 @@ impl<D: VectorStore<Elem = f32> + Send + Sync> GraphVectorIndex
     }
 
     fn nav_vectors(&self) -> Result<Self::VectorStore<'_>> {
+        let centroid: Option<Arc<[f32]>> =
+            self.config().centroid.as_deref().map(Arc::from);
         if let Some(s) = self.0.quantized_vectors.as_ref() {
             Ok(BulkLoadGraphVectorStore::Memory(
                 s,
                 self.config().similarity,
                 self.config().nav_format,
+                centroid,
             ))
         } else {
             Ok(BulkLoadGraphVectorStore::Cursor(CursorVectorStore::new(
                 self.1.open_record_cursor(self.0.index.nav_table().name())?,
                 self.config().similarity,
                 self.config().nav_format,
+                centroid,
             )))
         }
     }
 
     fn rerank_vectors(&self) -> Option<Result<Self::VectorStore<'_>>> {
         self.0.index.rerank_table().map(|t| {
+            let centroid: Option<Arc<[f32]>> =
+                self.0.index.config().centroid.as_deref().map(Arc::from);
             self.1.open_record_cursor(t.name()).map(|c| {
                 BulkLoadGraphVectorStore::Cursor(CursorVectorStore::new(
                     c,
                     self.0.index.config().similarity,
                     t.format(),
+                    centroid,
                 ))
             })
         })
@@ -699,6 +706,7 @@ enum BulkLoadGraphVectorStore<'a> {
         &'a DerefVectorStore<u8, memmap2::Mmap>,
         VectorSimilarity,
         F32VectorCoding,
+        Option<Arc<[f32]>>,
     ),
 }
 
@@ -706,21 +714,28 @@ impl GraphVectorStore for BulkLoadGraphVectorStore<'_> {
     fn format(&self) -> F32VectorCoding {
         match self {
             Self::Cursor(c) => c.format(),
-            Self::Memory(_, _, f) => *f,
+            Self::Memory(_, _, f, _) => *f,
         }
     }
 
     fn similarity(&self) -> VectorSimilarity {
         match self {
             Self::Cursor(c) => c.similarity(),
-            Self::Memory(_, s, _) => *s,
+            Self::Memory(_, s, _, _) => *s,
+        }
+    }
+
+    fn centroid(&self) -> Option<&[f32]> {
+        match self {
+            Self::Cursor(c) => c.centroid(),
+            Self::Memory(_, _, _, c) => c.as_deref(),
         }
     }
 
     fn get(&mut self, vertex_id: i64) -> Option<Result<&[u8]>> {
         match self {
             Self::Cursor(c) => c.get(vertex_id),
-            Self::Memory(m, _, _) => {
+            Self::Memory(m, _, _, _) => {
                 if vertex_id >= 0 && (vertex_id as usize) < m.len() {
                     Some(Ok(&m[vertex_id as usize]))
                 } else {

--- a/src/vamana/bulk.rs
+++ b/src/vamana/bulk.rs
@@ -305,13 +305,15 @@ where
                         if iv.len() == iv.capacity() || ev.len() == ev.capacity() {
                             true
                         } else {
-                            // Another concurrent search may have added this edge already, so skip
-                            // it if that is the case.
-                            if !iv.contains(&e) {
+                            // Another concurrent insertion may have added this edge already, so
+                            // skip it if that is the case. Compare by vertex id only: the same
+                            // vertex can appear with different distances (e.g. asymmetric vs
+                            // symmetric distance), and Neighbor equality includes distance.
+                            if !iv.iter().any(|n| n.vertex() == e.vertex()) {
                                 iv.push(e);
                             }
                             let backedge = Neighbor::new(v as i64, e.distance());
-                            if !ev.contains(&backedge) {
+                            if !ev.iter().any(|n| n.vertex() == v as i64) {
                                 ev.push(backedge);
                             }
                             false
@@ -471,6 +473,14 @@ where
         );
         let limit = self.index.config().index_search_params.beam_width.get();
         for in_flight_vertex in in_flight.filter(|v| *v != vertex_id) {
+            // Skip vertices already in edges: the graph search may have found this vertex
+            // while it was concurrently being inserted, producing a different distance than
+            // the symmetric distance computed here. Since Neighbor equality is (vertex, distance),
+            // binary_search below would not find the existing entry and would insert a duplicate.
+            if edges.iter().any(|n| n.vertex() == in_flight_vertex as i64) {
+                continue;
+            }
+
             let in_flight_vertex_vector = vector_store.get(in_flight_vertex as i64).unwrap()?;
             let n = Neighbor::new(
                 in_flight_vertex as i64,

--- a/src/vamana/mutate.rs
+++ b/src/vamana/mutate.rs
@@ -380,6 +380,7 @@ mod tests {
                         rerank_format: Some(F32VectorCoding::F32),
                         pruning: EdgePruningConfig::new(NonZero::new(4).unwrap()),
                         index_search_params: Self::search_params(),
+                        centroid: None,
                     },
                     "test",
                 )

--- a/src/vamana/search.rs
+++ b/src/vamana/search.rs
@@ -167,7 +167,7 @@ impl GraphSearcher {
         let nav_query = reader.config().nav_format.query_distance_symmetric(
             reader.config().similarity,
             &nav_query_rep,
-            None,
+            reader.config().centroid.as_deref(),
         );
 
         let rerank_query = if self.params.num_rerank > 0 {
@@ -180,7 +180,7 @@ impl GraphSearcher {
                 Some(
                     vectors
                         .format()
-                        .query_distance_symmetric(vectors.similarity(), query, None),
+                        .query_distance_symmetric(vectors.similarity(), query, vectors.centroid()),
                 )
             } else {
                 None
@@ -206,13 +206,16 @@ impl GraphSearcher {
         let nav_query = reader.config().nav_format.query_distance_asymmetric(
             reader.config().similarity,
             query,
-            None,
+            reader.config().centroid.as_deref(),
         );
         let rerank_query = if self.params.num_rerank > 0 {
-            reader
-                .config()
-                .rerank_format
-                .map(|f| f.query_distance_asymmetric(reader.config().similarity, query, None))
+            reader.config().rerank_format.map(|f| {
+                f.query_distance_asymmetric(
+                    reader.config().similarity,
+                    query,
+                    reader.config().centroid.as_deref(),
+                )
+            })
         } else {
             None
         };
@@ -482,7 +485,21 @@ mod test {
             T: IntoIterator<Item = V>,
             V: Into<Vec<f32>>,
         {
-            let coder = F32VectorCoding::BinaryQuantized.coder(VectorSimilarity::Euclidean, None);
+            Self::new_with_centroid(max_edges, distance_fn, iter, None)
+        }
+
+        pub fn new_with_centroid<T, V>(
+            max_edges: NonZero<usize>,
+            distance_fn: Box<dyn F32VectorDistance>,
+            iter: T,
+            centroid: Option<Vec<f32>>,
+        ) -> Self
+        where
+            T: IntoIterator<Item = V>,
+            V: Into<Vec<f32>>,
+        {
+            let coder = F32VectorCoding::BinaryQuantized
+                .coder(VectorSimilarity::Euclidean, centroid.clone());
             let mut rep = iter
                 .into_iter()
                 .map(|x| {
@@ -510,6 +527,7 @@ mod test {
                     num_rerank: usize::MAX,
                     patience: None,
                 },
+                centroid,
             };
             Self { data: rep, config }
         }
@@ -663,6 +681,10 @@ mod test {
             self.0.config.similarity
         }
 
+        fn centroid(&self) -> Option<&[f32]> {
+            self.0.config.centroid.as_deref()
+        }
+
         fn get(&mut self, vertex_id: i64) -> Option<Result<&[u8]>> {
             self.0.data.get(vertex_id as usize).map(|v| {
                 Ok(match self.1 {
@@ -694,6 +716,23 @@ mod test {
                     dim_values[(v >> 6) & 0x3],
                 ])
             }),
+        )
+    }
+
+    fn build_test_graph_with_centroid(max_edges: usize, centroid: Vec<f32>) -> TestGraphVectorIndex {
+        let dim_values = [-0.25, -0.125, 0.125, 0.25];
+        TestGraphVectorIndex::new_with_centroid(
+            NonZero::new(max_edges).unwrap(),
+            VectorSimilarity::Dot.new_distance_function(),
+            (0..256).map(|v| {
+                Vec::from([
+                    dim_values[v & 0x3],
+                    dim_values[(v >> 2) & 0x3],
+                    dim_values[(v >> 4) & 0x3],
+                    dim_values[(v >> 6) & 0x3],
+                ])
+            }),
+            Some(centroid),
         )
     }
 
@@ -797,5 +836,60 @@ mod test {
             "Expected at least 1 filtered candidate, got {}",
             stats.filtered
         );
+    }
+
+    /// Nav-only search with a centroid exercises query_distance_asymmetric with centroid.
+    /// Verifies that the graph can be traversed and returns a sorted candidate list.
+    #[test]
+    fn centroid_no_rerank() {
+        let centroid = vec![0.0625, 0.0625, 0.0625, 0.0625];
+        let index = build_test_graph_with_centroid(4, centroid);
+        let mut searcher = GraphSearcher::new(GraphSearchParams {
+            beam_width: NonZero::new(4).unwrap(),
+            num_rerank: 0,
+            patience: None,
+        });
+        let results = searcher
+            .search(&[-0.1, -0.1, -0.1, -0.1], &mut index.reader())
+            .unwrap();
+        // Results must be non-empty and sorted by increasing BQ distance.
+        assert!(!results.is_empty());
+        for w in results.windows(2) {
+            assert!(
+                w[0].distance() <= w[1].distance(),
+                "BQ distances not sorted: {w:?}"
+            );
+        }
+    }
+
+    /// Rerank search with a centroid exercises query_distance_symmetric (nav, encoded query) and
+    /// query_distance_asymmetric (rerank, f32 query) both with centroid.
+    ///
+    /// Vertices 1, 4, 16, 64 each differ from the query [-0.1, -0.1, -0.1, -0.1] in exactly one
+    /// dimension (at -0.25 vs -0.1) and are the nearest reachable vertices under raw F32 distance.
+    /// With F32 reranking they should appear first with squared-Euclidean distance ≈ 0.0681.
+    #[test]
+    fn centroid_with_rerank() {
+        let centroid = vec![0.0625, 0.0625, 0.0625, 0.0625];
+        let index = build_test_graph_with_centroid(4, centroid);
+        let mut searcher = GraphSearcher::new(GraphSearchParams {
+            beam_width: NonZero::new(4).unwrap(),
+            num_rerank: 4,
+            patience: None,
+        });
+        let results = searcher
+            .search(&[-0.1, -0.1, -0.1, -0.1], &mut index.reader())
+            .unwrap();
+        assert!(!results.is_empty());
+        // Results must be sorted by increasing F32 squared-Euclidean distance.
+        for w in results.windows(2) {
+            assert!(
+                w[0].distance() <= w[1].distance(),
+                "rerank distances not sorted: {w:?}"
+            );
+        }
+        // Top result distance should match the known nearest reachable vertex (squared dist ≈ 0.0681).
+        let top_dist = normalize_scores(results)[0].distance();
+        assert_eq!(top_dist, 0.06813, "unexpected top rerank distance");
     }
 }

--- a/src/vamana/wt.rs
+++ b/src/vamana/wt.rs
@@ -123,6 +123,7 @@ pub struct CursorVectorStore<'a> {
     inner: RecordCursorGuard<'a>,
     similarity: VectorSimilarity,
     format: F32VectorCoding,
+    centroid: Option<Arc<[f32]>>,
 }
 
 impl<'a> CursorVectorStore<'a> {
@@ -130,11 +131,13 @@ impl<'a> CursorVectorStore<'a> {
         inner: RecordCursorGuard<'a>,
         similarity: VectorSimilarity,
         format: F32VectorCoding,
+        centroid: Option<Arc<[f32]>>,
     ) -> Self {
         Self {
             inner,
             similarity,
             format,
+            centroid,
         }
     }
 }
@@ -146,6 +149,10 @@ impl GraphVectorStore for CursorVectorStore<'_> {
 
     fn format(&self) -> F32VectorCoding {
         self.format
+    }
+
+    fn centroid(&self) -> Option<&[f32]> {
+        self.centroid.as_deref()
     }
 
     fn get(&mut self, vertex_id: i64) -> Option<Result<&[u8]>> {
@@ -170,6 +177,7 @@ pub struct GraphVectorTable {
     table_name: String,
     format: F32VectorCoding,
     similarity: VectorSimilarity,
+    centroid: Option<Arc<[f32]>>,
 }
 
 impl GraphVectorTable {
@@ -181,12 +189,18 @@ impl GraphVectorTable {
         self.format
     }
 
+    pub fn centroid(&self) -> Option<&[f32]> {
+        self.centroid.as_deref()
+    }
+
     pub fn new_coder(&self) -> Box<dyn F32VectorCoder> {
-        self.format.coder(self.similarity, None)
+        self.format
+            .coder(self.similarity, self.centroid.as_deref().map(|c| c.to_vec()))
     }
 
     pub fn new_distance_function(&self) -> Box<dyn VectorDistance> {
-        self.format.distance_symmetric(self.similarity, None)
+        self.format
+            .distance_symmetric(self.similarity, self.centroid.as_deref())
     }
 }
 
@@ -230,17 +244,20 @@ impl TableGraphVectorIndex {
         if config.index_search_params.num_rerank > 0 && config.rerank_format.is_none() {
             return Err(Error::Errno(Errno::NOTSUP).into());
         }
+        let centroid: Option<Arc<[f32]>> = config.centroid.as_deref().map(Arc::from);
         Ok(Self {
             graph_table_name,
             nav_table: GraphVectorTable {
                 table_name: nav_table_name,
                 format: config.nav_format,
                 similarity: config.similarity,
+                centroid: centroid.clone(),
             },
             rerank_table: config.rerank_format.map(|f| GraphVectorTable {
                 table_name: rerank_table_name,
                 format: f,
                 similarity: config.similarity,
+                centroid: centroid.clone(),
             }),
             config,
         })
@@ -371,11 +388,12 @@ impl GraphVectorIndex for TransactionGraphVectorIndex {
     }
 
     fn nav_vectors(&self) -> Result<Self::VectorStore<'_>> {
+        let nav = self.index.nav_table();
         Ok(CursorVectorStore::new(
-            self.transaction
-                .open_record_cursor(self.index.nav_table().name())?,
+            self.transaction.open_record_cursor(nav.name())?,
             self.index.config.similarity,
-            self.index.config().nav_format,
+            nav.format(),
+            nav.centroid().map(Arc::from),
         ))
     }
 
@@ -383,7 +401,7 @@ impl GraphVectorIndex for TransactionGraphVectorIndex {
         self.index.rerank_table().map(|t| {
             self.transaction
                 .open_record_cursor(t.name())
-                .map(|c| CursorVectorStore::new(c, self.index.config().similarity, t.format()))
+                .map(|c| CursorVectorStore::new(c, self.index.config().similarity, t.format(), t.centroid().map(Arc::from)))
         })
     }
 }


### PR DESCRIPTION
This provides a really marginal improvement to recall with 1-bit vectors.

Fix a race condition in the bulk loader.