### PR TITLE
Tool to generate random vectors

### DIFF
--- a/et/src/generate.rs
+++ b/et/src/generate.rs
@@ -1,0 +1,83 @@
+use std::{
+    fs::File,
+    io::{self, BufWriter, Write},
+    num::NonZero,
+    path::PathBuf,
+};
+
+use clap::{Args, ValueEnum};
+use rand::{Rng, SeedableRng};
+use rand_xoshiro::Xoshiro256PlusPlus;
+
+use crate::ui::progress_bar;
+
+#[derive(Clone, ValueEnum)]
+pub enum Distribution {
+    /// Generate vectors with each dimension in [-1, 1], then unit normalize.
+    F32Unit,
+    /// Generate vectors where each dimension is a random i8, then convert to f32.
+    I8,
+    /// Generate vectors where each dimension is a random u8, then convert to f32.
+    U8,
+}
+
+#[derive(Args)]
+pub struct GenerateArgs {
+    /// Output file to write generated vectors as little-endian f32 values.
+    #[arg(short, long)]
+    output: PathBuf,
+    /// Number of dimensions per vector.
+    #[arg(short, long)]
+    dimensions: NonZero<usize>,
+    /// Number of vectors to generate.
+    #[arg(short, long)]
+    count: NonZero<usize>,
+    /// Random seed for reproducible generation.
+    #[arg(short, long)]
+    seed: u64,
+    /// Distribution used to generate vector values.
+    #[arg(long, default_value = "f32-unit")]
+    distribution: Distribution,
+}
+
+pub fn generate(args: GenerateArgs) -> io::Result<()> {
+    let mut rng = Xoshiro256PlusPlus::seed_from_u64(args.seed);
+    let mut out = BufWriter::new(File::create(&args.output)?);
+    let dims = args.dimensions.get();
+    let count = args.count.get();
+    let progress = progress_bar(count, "generate");
+
+    let mut v = vec![0.0f32; dims];
+
+    for _ in 0..count {
+        match args.distribution {
+            Distribution::F32Unit => {
+                for x in &mut v {
+                    *x = rng.random_range(-1.0f32..=1.0f32);
+                }
+                let norm = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+                if norm > 0.0 {
+                    for x in &mut v {
+                        *x /= norm;
+                    }
+                }
+            }
+            Distribution::I8 => {
+                for x in &mut v {
+                    *x = rng.random::<i8>() as f32;
+                }
+            }
+            Distribution::U8 => {
+                for x in &mut v {
+                    *x = rng.random::<u8>() as f32;
+                }
+            }
+        }
+        for &x in &v {
+            out.write_all(&x.to_le_bytes())?;
+        }
+        progress.inc(1);
+    }
+
+    Ok(())
+}

--- a/et/src/main.rs
+++ b/et/src/main.rs
@@ -1,4 +1,5 @@
 mod compute_neighbors;
+mod generate;
 mod neighbor_util;
 mod quantization;
 mod recall;
@@ -12,6 +13,7 @@ use std::io::{self};
 
 use clap::{command, Parser, Subcommand};
 use compute_neighbors::{compute_neighbors, ComputeNeighborsArgs};
+use generate::{generate, GenerateArgs};
 use quantization::{quantization, QuantizationArgs};
 use spann::{spann_command, SpannArgs};
 use tracing::level_filters::LevelFilter;
@@ -36,6 +38,8 @@ enum Commands {
     ComputeNeighbors(ComputeNeighborsArgs),
     /// Quantization related utilities.
     Quantization(QuantizationArgs),
+    /// Generate random vectors and write them to a file.
+    Generate(GenerateArgs),
 }
 
 fn main() -> io::Result<()> {
@@ -55,5 +59,6 @@ fn main() -> io::Result<()> {
         Commands::Vamana(args) => vamana_command(args),
         Commands::ComputeNeighbors(args) => compute_neighbors(args),
         Commands::Quantization(args) => quantization(args),
+        Commands::Generate(args) => generate(args),
     }
 }

--- a/et/src/quantization/loss.rs
+++ b/et/src/quantization/loss.rs
@@ -31,25 +31,30 @@ pub fn loss(
     // Assume Euclidean. It might be best to make this configurable as some encodings might perform
     // better when the inputs are l2 normalized.
     let coder = args.format.coder(VectorSimilarity::Euclidean, mean);
-    let (abs_error, sq_error) = (0..vectors.len())
+    let (abs_error, sq_error, magnitude) = (0..vectors.len())
         .into_par_iter()
         .progress_with(progress_bar(vectors.len(), "loss"))
         .map(|i| {
             let v = &vectors[i];
             let encoded = coder.encode(&v);
             let q = coder.decode(&encoded);
-            let (abs_error, sq_error) = v
+            let (abs_error, sq_error, sq_magnitude) = v
                 .iter()
                 .zip(q.iter())
                 .map(|(d, q)| {
                     let diff = *d - *q;
-                    (diff.abs(), diff * diff)
+                    (diff.abs(), diff * diff, *d * *d)
                 })
-                .reduce(|a, b| (a.0 + b.0, a.1 + b.1))
+                .reduce(|a, b| (a.0 + b.0, a.1 + b.1, a.2 + b.2))
                 .unwrap();
-            (abs_error, sq_error.sqrt())
+            (abs_error, sq_error.sqrt(), sq_magnitude.sqrt())
         })
-        .reduce(|| (0.0f32, 0.0f32), |a, b| (a.0 + b.0, a.1 + b.1));
+        .reduce(
+            || (0.0f32, 0.0f32, 0.0f32),
+            |a, b| (a.0 + b.0, a.1 + b.1, a.2 + b.2),
+        );
+    let n = vectors.len() as f32;
+    let mean_magnitude = magnitude / n;
     println!("Vectors: {}", vectors.len());
     println!(
         "Sum of absolute error: {:.6} error l2 norm: {:.6}",
@@ -57,8 +62,14 @@ pub fn loss(
     );
     println!(
         "Per vector absolute error: {:.6} error l2 norm: {:.6}",
-        abs_error / vectors.len() as f32,
-        sq_error / vectors.len() as f32
+        abs_error / n,
+        sq_error / n
+    );
+    println!("Mean vector magnitude: {:.6}", mean_magnitude);
+    println!(
+        "Error ratio (abs/magnitude): {:.6} error ratio (l2/magnitude): {:.6}",
+        abs_error / n / mean_magnitude,
+        sq_error / n / mean_magnitude
     );
     Ok(())
 }


### PR DESCRIPTION
Generate random vectors in different formats including i8 or u8 vectors expressed as f32. This allows us to test quantization with otherwise "pre-quantized" inputs.

Adjust distance loss code to print magnitude normalized output so that MSE loss is comparable across different types of generated vectors.