### PR TITLE
Add support to modify values in WT

### DIFF
--- a/wt_mdb/Cargo.toml
+++ b/wt_mdb/Cargo.toml
@@ -6,6 +6,7 @@ description = "WiredTiger bindings intended to be used MongoDB way."
 
 [dependencies]
 rustix = "1.0.7"
+smallvec = "1"
 tracing = "0.1.41"
 wt_sys = { path = "../wt_sys" }
 

--- a/wt_mdb/src/connection.rs
+++ b/wt_mdb/src/connection.rs
@@ -157,6 +157,8 @@ pub struct CreateOptionsBuilder {
     key_format: FormatString,
     value_format: FormatString,
     app_metadata: Option<String>,
+    leaf_page_max: Option<u32>,
+    leaf_value_max: Option<u32>,
 }
 
 impl Default for CreateOptionsBuilder {
@@ -165,6 +167,8 @@ impl Default for CreateOptionsBuilder {
             key_format: FormatString::new(c"q"),
             value_format: FormatString::new(c"u"),
             app_metadata: None,
+            leaf_page_max: None,
+            leaf_value_max: None,
         }
     }
 }
@@ -191,6 +195,21 @@ impl CreateOptionsBuilder {
         self.app_metadata = Some(metadata.to_owned());
         self
     }
+
+    /// Maximum size of leaf pages in bytes. Values exceeding half this size (or `leaf_value_max`
+    /// if set) are stored as overflow items and are not cached by WiredTiger.
+    pub fn leaf_page_max(mut self, bytes: u32) -> Self {
+        self.leaf_page_max = Some(bytes);
+        self
+    }
+
+    /// Maximum value size in bytes before a value is stored as an overflow item.
+    /// Defaults to half of `leaf_page_max`. Set equal to `leaf_page_max` to allow a single
+    /// value to occupy an entire page.
+    pub fn leaf_value_max(mut self, bytes: u32) -> Self {
+        self.leaf_value_max = Some(bytes);
+        self
+    }
 }
 
 /// Options when creating a table, column group, index, or file in WiredTiger.
@@ -211,6 +230,12 @@ impl From<CreateOptionsBuilder> for CreateOptions {
         ];
         if let Some(metadata) = value.app_metadata {
             parts.push(format!("app_metadata={metadata}"));
+        }
+        if let Some(v) = value.leaf_page_max {
+            parts.push(format!("leaf_page_max={v}"));
+        }
+        if let Some(v) = value.leaf_value_max {
+            parts.push(format!("leaf_value_max={v}"));
         }
         Self(CString::new(parts.join(",")).expect("no nulls"))
     }

--- a/wt_mdb/src/lib.rs
+++ b/wt_mdb/src/lib.rs
@@ -129,7 +129,7 @@ impl From<Error> for std::io::Error {
 pub use connection::{BulkLoadCursor, Connection};
 pub use session::{
     IndexCursor, IndexCursorGuard, RecordCursor, RecordCursorGuard, StatCursor, TypedCursor,
-    TypedCursorGuard,
+    TypedCursorGuard, ValueDelta,
 };
 pub use transaction::Transaction;
 pub type Result<T> = std::result::Result<T, Error>;
@@ -255,7 +255,7 @@ mod test {
             SetGlobalTimestampType,
         },
         session::{Formatted, QueryTransactionTimestampType, SetTransactionTimestampType},
-        Error, RecordCursorGuard, Result, Statistics, Transaction, WiredTigerError,
+        Error, RecordCursorGuard, Result, Statistics, Transaction, ValueDelta, WiredTigerError,
     };
 
     fn conn_options() -> Option<crate::connection::Options> {
@@ -836,6 +836,101 @@ mod test {
         assert_eq!(
             std::io::Error::from(err).to_string(),
             std::io::Error::new(ErrorKind::NotFound, err).to_string()
+        );
+    }
+
+    #[test]
+    fn index_modify_replace() -> Result<()> {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let conn = Connection::open(tmpdir.path().to_str().unwrap(), conn_options()).unwrap();
+        conn.create_table("test", index_table_options()).unwrap();
+        let txn = conn.begin_transaction(None).unwrap();
+        let mut cursor = txn.open_index_cursor("test").unwrap();
+        cursor.set(&b"key".as_slice(), &b"hello world".as_slice())?;
+        cursor.modify(
+            &b"key".as_slice(),
+            &[ValueDelta::Replace {
+                range: (6..11).into(),
+                data: b"rust",
+            }],
+        )?;
+        assert_eq!(
+            cursor.seek_exact(&b"key".as_slice()),
+            Some(Ok(b"hello rust".to_vec()))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn record_modify_replace() -> Result<()> {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let conn = Connection::open(tmpdir.path().to_str().unwrap(), conn_options()).unwrap();
+        conn.create_table("test", None).unwrap();
+        let txn = conn.begin_transaction(None).unwrap();
+        let mut cursor = txn.open_record_cursor("test").unwrap();
+        cursor.set(1, b"hello world")?;
+        cursor.modify(
+            1,
+            &[ValueDelta::Replace {
+                range: (6..11).into(),
+                data: b"rust",
+            }],
+        )?;
+        assert_eq!(cursor.seek_exact(1), Some(Ok(b"hello rust".to_vec())));
+        Ok(())
+    }
+
+    #[test]
+    fn index_modify_insert() -> Result<()> {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let conn = Connection::open(tmpdir.path().to_str().unwrap(), conn_options()).unwrap();
+        conn.create_table("test", index_table_options()).unwrap();
+        let txn = conn.begin_transaction(None).unwrap();
+        let mut cursor = txn.open_index_cursor("test").unwrap();
+        cursor.set(&b"key".as_slice(), &b"hello".as_slice())?;
+        cursor.modify(
+            &b"key".as_slice(),
+            &[ValueDelta::Insert {
+                data: b" world",
+                offset: 5,
+            }],
+        )?;
+        assert_eq!(
+            cursor.seek_exact(&b"key".as_slice()),
+            Some(Ok(b"hello world".to_vec()))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn index_modify_delete() -> Result<()> {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let conn = Connection::open(tmpdir.path().to_str().unwrap(), conn_options()).unwrap();
+        conn.create_table("test", index_table_options()).unwrap();
+        let txn = conn.begin_transaction(None).unwrap();
+        let mut cursor = txn.open_index_cursor("test").unwrap();
+        cursor.set(&b"key".as_slice(), &b"hello world".as_slice())?;
+        cursor.modify(
+            &b"key".as_slice(),
+            &[ValueDelta::Delete((5..11).into())],
+        )?;
+        assert_eq!(
+            cursor.seek_exact(&b"key".as_slice()),
+            Some(Ok(b"hello".to_vec()))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn modify_wrong_format() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let conn = Connection::open(tmpdir.path().to_str().unwrap(), conn_options()).unwrap();
+        conn.create_table("test", None).unwrap();
+        let txn = conn.begin_transaction(None).unwrap();
+        let mut cursor = txn.open_metadata_cursor().unwrap();
+        assert_eq!(
+            cursor.modify(c"table:test", &[]),
+            Err(Error::Errno(Errno::NOTSUP))
         );
     }
 }

--- a/wt_mdb/src/session.rs
+++ b/wt_mdb/src/session.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 
 pub use format::{pack1, pack2, pack3, unpack1, unpack2, unpack3, FormatString, Formatted};
-pub use typed_cursor::{TypedCursor, TypedCursorGuard};
+pub use typed_cursor::{TypedCursor, TypedCursorGuard, ValueDelta};
 
 pub(crate) const METADATA_URI: &CStr = c"metadata:";
 

--- a/wt_mdb/src/session/typed_cursor.rs
+++ b/wt_mdb/src/session/typed_cursor.rs
@@ -2,9 +2,13 @@ use std::{
     marker::PhantomData,
     mem::ManuallyDrop,
     ops::{Bound, Deref, DerefMut, RangeBounds},
+    os::raw::c_void,
+    range::Range,
 };
 
 use rustix::io::Errno;
+use smallvec::SmallVec;
+use wt_sys::{WT_ITEM, WT_MODIFY};
 
 use crate::{
     map_not_found,
@@ -22,6 +26,52 @@ macro_rules! format_to_buf {
     ($var:expr, $formatter:ident, $buf:expr) => {{
         $formatter::pack($var, &mut $buf).map(|()| $buf.as_slice())
     }};
+}
+
+/// A delta to be applied to an existing value using [`TypedCursor::modify`].
+#[derive(Debug, Copy, Clone)]
+pub enum ValueDelta<'a> {
+    /// Insert `data` at `offset`. If `offset` is beyond the end of the value padding bytes will be
+    /// inserted before `data` appears.
+    Insert { data: &'a [u8], offset: usize },
+    /// Delete all bytes in range from the value.
+    Delete(Range<usize>),
+    /// Replace all bytes in `range` in the value with `data`.
+    Replace { range: Range<usize>, data: &'a [u8] },
+}
+
+impl<'a> From<ValueDelta<'a>> for WT_MODIFY {
+    fn from(value: ValueDelta) -> Self {
+        match value {
+            ValueDelta::Insert { data, offset } => WT_MODIFY {
+                data: wt_item_from_slice(data),
+                offset,
+                size: 0,
+            },
+            ValueDelta::Delete(range) => WT_MODIFY {
+                data: wt_item_from_slice(EMPTY_BYTE_SLICE),
+                offset: range.start,
+                size: range.end - range.start,
+            },
+            ValueDelta::Replace { range, data } => WT_MODIFY {
+                data: wt_item_from_slice(data),
+                offset: range.start,
+                size: range.end - range.start,
+            },
+        }
+    }
+}
+
+const EMPTY_BYTE_SLICE: &[u8] = &[];
+
+fn wt_item_from_slice(s: &[u8]) -> WT_ITEM {
+    WT_ITEM {
+        data: s.as_ptr() as *const c_void,
+        size: s.len(),
+        mem: std::ptr::null_mut(),
+        memsize: 0,
+        flags: 0,
+    }
 }
 
 pub struct TypedCursor<'a, K, V> {
@@ -81,6 +131,22 @@ impl<'a, K: Formatted, V: Formatted> TypedCursor<'a, K, V> {
         unsafe {
             wt_call!(void self.inner.0, set_key, &Item::from(key).0)?;
             wt_call!(self.inner.0, remove)
+        }
+    }
+
+    /// Apply `deltas` to an existing record at `key`.
+    ///
+    /// Returns `ENOTSUP` if the value format is not `u`.
+    pub fn modify(&mut self, key: K::Ref<'_>, deltas: &[ValueDelta<'_>]) -> Result<()> {
+        if V::FORMAT.format_str() != "u" {
+            return Err(Error::Errno(Errno::NOTSUP));
+        }
+        let key = format_to_buf!(key, K, self.key_buf)?;
+        let mut entries: SmallVec<[WT_MODIFY; 32]> =
+            deltas.iter().copied().map(WT_MODIFY::from).collect();
+        unsafe {
+            wt_call!(void self.inner.0, set_key, &Item::from(key).0)?;
+            wt_call!(self.inner.0, modify, entries.as_mut_ptr(), entries.len() as i32)
         }
     }
 


### PR DESCRIPTION
This requires the key exist and that the table use byte values (most of our tables).

Also allow manipulating leaf page maximums. Between these two changes it should be possible to represent postings as a single key with a large value that contains packed ids and vectors without massive write amplification.