### PR TITLE
Add a directed graph mode for vamana indexes

### DIFF
--- a/et/src/spann/bulk_load.rs
+++ b/et/src/spann/bulk_load.rs
@@ -12,7 +12,7 @@ use easy_tiger::{
         },
     },
     vamana::{
-        EdgeType, GraphConfig, GraphSearchParams, PatienceParams,
+        GraphConfig, GraphSearchParams, PatienceParams,
         bulk::{self, BulkLoadBuilder},
     },
 };
@@ -20,7 +20,7 @@ use rand_xoshiro::{Xoshiro128PlusPlus, rand_core::SeedableRng};
 use vectors::{F32VectorCoding, VectorSimilarity};
 use wt_mdb::{Connection, connection::DropOptionsBuilder};
 
-use crate::{ui::progress_bar, vamana::EdgePruningArgs};
+use crate::{ui::progress_bar, vamana::{EdgePruningArgs, EdgeTypeArg}};
 
 #[derive(Args)]
 pub struct BulkLoadArgs {
@@ -55,6 +55,10 @@ pub struct BulkLoadArgs {
 
     #[command(flatten)]
     pruning: EdgePruningArgs,
+
+    /// Whether the head graph maintains directed or undirected edges.
+    #[arg(long, value_enum, default_value_t = EdgeTypeArg::Undirected)]
+    head_edge_type: EdgeTypeArg,
 
     /// Number of vectors to buffer at once when clustering.
     ///
@@ -169,7 +173,7 @@ pub fn bulk_load(
             }),
         },
         centroid: None,
-        edge_type: EdgeType::Undirected,
+        edge_type: args.head_edge_type.into(),
     };
     let spann_config = IndexConfig {
         replica_count: args.replica_count.get(),

--- a/et/src/spann/bulk_load.rs
+++ b/et/src/spann/bulk_load.rs
@@ -12,7 +12,7 @@ use easy_tiger::{
         },
     },
     vamana::{
-        GraphConfig, GraphSearchParams, PatienceParams,
+        EdgeType, GraphConfig, GraphSearchParams, PatienceParams,
         bulk::{self, BulkLoadBuilder},
     },
 };
@@ -169,6 +169,7 @@ pub fn bulk_load(
             }),
         },
         centroid: None,
+        edge_type: EdgeType::Undirected,
     };
     let spann_config = IndexConfig {
         replica_count: args.replica_count.get(),

--- a/et/src/spann/init_index.rs
+++ b/et/src/spann/init_index.rs
@@ -4,7 +4,7 @@ use clap::Args;
 use easy_tiger::{
     spann::{IndexConfig, ReplicaSelectionAlgorithm, TableIndex},
     vamana::{
-        GraphConfig, GraphSearchParams, PatienceParams, mutate::insert_vector,
+        EdgeType, GraphConfig, GraphSearchParams, PatienceParams, mutate::insert_vector,
         wt::TransactionGraphVectorIndex,
     },
 };
@@ -128,6 +128,7 @@ pub fn init_index(
             }),
         },
         centroid: None,
+        edge_type: EdgeType::Undirected,
     };
     let beam_width = args
         .head_edge_candidates

--- a/et/src/spann/init_index.rs
+++ b/et/src/spann/init_index.rs
@@ -4,14 +4,14 @@ use clap::Args;
 use easy_tiger::{
     spann::{IndexConfig, ReplicaSelectionAlgorithm, TableIndex},
     vamana::{
-        EdgeType, GraphConfig, GraphSearchParams, PatienceParams, mutate::insert_vector,
+        GraphConfig, GraphSearchParams, PatienceParams, mutate::insert_vector,
         wt::TransactionGraphVectorIndex,
     },
 };
 use vectors::{F32VectorCoding, VectorSimilarity};
 use wt_mdb::{Connection, connection::DropOptionsBuilder};
 
-use crate::vamana::EdgePruningArgs;
+use crate::vamana::{EdgePruningArgs, EdgeTypeArg};
 
 #[derive(Args)]
 pub struct InitIndexArgs {
@@ -43,6 +43,10 @@ pub struct InitIndexArgs {
 
     #[command(flatten)]
     pruning: EdgePruningArgs,
+
+    /// Whether the head graph maintains directed or undirected edges.
+    #[arg(long, value_enum, default_value_t = EdgeTypeArg::Undirected)]
+    head_edge_type: EdgeTypeArg,
 
     /// Minimum number of vectors that should map to each head centroid.
     #[arg(long, default_value_t = 192)]
@@ -128,7 +132,7 @@ pub fn init_index(
             }),
         },
         centroid: None,
-        edge_type: EdgeType::Undirected,
+        edge_type: args.head_edge_type.into(),
     };
     let beam_width = args
         .head_edge_candidates

--- a/et/src/vamana.rs
+++ b/et/src/vamana.rs
@@ -1,4 +1,5 @@
 mod bulk_load;
+mod check_reachability;
 mod drop_index;
 mod init_index;
 mod insert;
@@ -10,6 +11,7 @@ use std::{io, num::NonZero, sync::Arc};
 use clap::{Args, Subcommand};
 
 use bulk_load::{BulkLoadArgs, bulk_load};
+use check_reachability::{CheckReachabilityArgs, check_reachability};
 use drop_index::drop_index;
 use easy_tiger::vamana::{EdgePruningConfig, EdgeType};
 use init_index::{InitIndexArgs, init_index};
@@ -87,6 +89,8 @@ pub enum Command {
     Lookup(LookupArgs),
     /// Insert a vectors from a file into the index.
     Insert(InsertArgs),
+    /// Check whether every vertex in the graph is reachable from the entry point.
+    CheckReachability(CheckReachabilityArgs),
 }
 
 pub fn vamana_command(args: VamanaArgs) -> io::Result<()> {
@@ -100,6 +104,7 @@ pub fn vamana_command(args: VamanaArgs) -> io::Result<()> {
         Command::DropIndex => drop_index(connection, index_name),
         Command::Lookup(args) => lookup(connection, index_name, args),
         Command::Insert(args) => insert(connection, index_name, args),
+        Command::CheckReachability(args) => check_reachability(connection, index_name, args),
     }?;
     cmd_connection.checkpoint()?;
     Ok(())

--- a/et/src/vamana.rs
+++ b/et/src/vamana.rs
@@ -11,7 +11,7 @@ use clap::{Args, Subcommand};
 
 use bulk_load::{BulkLoadArgs, bulk_load};
 use drop_index::drop_index;
-use easy_tiger::vamana::EdgePruningConfig;
+use easy_tiger::vamana::{EdgePruningConfig, EdgeType};
 use init_index::{InitIndexArgs, init_index};
 use insert::{InsertArgs, insert};
 use lookup::{LookupArgs, lookup};
@@ -44,6 +44,22 @@ pub struct EdgePruningArgs {
     /// exceeded. Lower values will trigger fewer iterations. Must be >= 1.0.
     #[arg(long, default_value_t = 1.2)]
     alpha_scale: f64,
+}
+
+#[derive(Copy, Clone, Debug, Default, clap::ValueEnum)]
+pub enum EdgeTypeArg {
+    #[default]
+    Undirected,
+    Directed,
+}
+
+impl From<EdgeTypeArg> for EdgeType {
+    fn from(v: EdgeTypeArg) -> Self {
+        match v {
+            EdgeTypeArg::Undirected => EdgeType::Undirected,
+            EdgeTypeArg::Directed => EdgeType::Directed,
+        }
+    }
 }
 
 impl From<EdgePruningArgs> for EdgePruningConfig {

--- a/et/src/vamana/bulk_load.rs
+++ b/et/src/vamana/bulk_load.rs
@@ -4,7 +4,7 @@ use clap::Args;
 use easy_tiger::{
     input::{DerefVectorStore, VectorStore},
     vamana::{
-        GraphConfig, GraphSearchParams, PatienceParams,
+        EdgeType, GraphConfig, GraphSearchParams, PatienceParams,
         bulk::{BulkLoadBuilder, Options},
         wt::TableGraphVectorIndex,
     },
@@ -127,6 +127,7 @@ pub fn bulk_load(
             }),
         },
         centroid,
+        edge_type: EdgeType::Undirected,
     };
     if args.drop_tables {
         drop_index(connection.clone(), index_name)?;

--- a/et/src/vamana/bulk_load.rs
+++ b/et/src/vamana/bulk_load.rs
@@ -4,7 +4,7 @@ use clap::Args;
 use easy_tiger::{
     input::{DerefVectorStore, VectorStore},
     vamana::{
-        EdgeType, GraphConfig, GraphSearchParams, PatienceParams,
+        GraphConfig, GraphSearchParams, PatienceParams,
         bulk::{BulkLoadBuilder, Options},
         wt::TableGraphVectorIndex,
     },
@@ -14,7 +14,7 @@ use wt_mdb::Connection;
 
 use crate::{
     ui::progress_bar,
-    vamana::{EdgePruningArgs, drop_index::drop_index},
+    vamana::{EdgePruningArgs, EdgeTypeArg, drop_index::drop_index},
     wt_stats::WiredTigerConnectionStats,
 };
 
@@ -67,6 +67,10 @@ pub struct BulkLoadArgs {
 
     #[command(flatten)]
     pruning: EdgePruningArgs,
+
+    /// Whether the graph maintains directed or undirected edges.
+    #[arg(long, value_enum, default_value_t = EdgeTypeArg::Undirected)]
+    edge_type: EdgeTypeArg,
 
     /// If true, drop any WiredTiger tables with the same name before bulk upload.
     #[arg(long, default_value = "false")]
@@ -127,7 +131,7 @@ pub fn bulk_load(
             }),
         },
         centroid,
-        edge_type: EdgeType::Undirected,
+        edge_type: args.edge_type.into(),
     };
     if args.drop_tables {
         drop_index(connection.clone(), index_name)?;

--- a/et/src/vamana/check_reachability.rs
+++ b/et/src/vamana/check_reachability.rs
@@ -1,0 +1,102 @@
+use std::{collections::{HashSet, VecDeque}, io, sync::Arc};
+
+use clap::Args;
+use easy_tiger::vamana::{
+    Graph,
+    wt::{CursorGraph, TableGraphVectorIndex, ENTRY_POINT_KEY},
+};
+use rand::{Rng, SeedableRng};
+use rand_xoshiro::Xoshiro128PlusPlus;
+use wt_mdb::Connection;
+
+#[derive(Args)]
+pub struct CheckReachabilityArgs {
+    /// Number of unreachable vertex IDs to include in the sample output.
+    #[arg(long, default_value_t = 10)]
+    sample_size: usize,
+}
+
+pub fn check_reachability(
+    connection: Arc<Connection>,
+    index_name: &str,
+    args: CheckReachabilityArgs,
+) -> io::Result<()> {
+    let index = TableGraphVectorIndex::from_db(&connection, index_name)?;
+    let txn = connection.begin_transaction(None)?;
+
+    let mut graph = CursorGraph::new(txn.open_record_cursor(index.graph_table_name())?);
+
+    let entry_point = match graph.entry_point() {
+        None => {
+            println!("Graph is empty (no entry point).");
+            return Ok(());
+        }
+        Some(Err(e)) => return Err(e.into()),
+        Some(Ok(ep)) => ep,
+    };
+
+    // BFS from the entry point to collect all reachable vertex IDs.
+    let mut reachable: HashSet<i64> = HashSet::new();
+    let mut queue: VecDeque<i64> = VecDeque::new();
+    reachable.insert(entry_point);
+    queue.push_back(entry_point);
+
+    while let Some(vertex_id) = queue.pop_front() {
+        let edges = match graph.edges(vertex_id) {
+            None => continue,
+            Some(Err(e)) => return Err(e.into()),
+            Some(Ok(edges)) => edges,
+        };
+        for neighbor in edges {
+            if reachable.insert(neighbor) {
+                queue.push_back(neighbor);
+            }
+        }
+    }
+
+    // Scan all records to count total vertices and collect a reservoir sample of unreachable ones.
+    // ENTRY_POINT_KEY (-1) holds entry point metadata, not a vertex; skip it.
+    let scan = txn.open_record_cursor(index.graph_table_name())?;
+    let mut total: usize = 0;
+    let mut unreachable_count: usize = 0;
+    let mut sample: Vec<i64> = Vec::with_capacity(args.sample_size);
+    let mut rng = Xoshiro128PlusPlus::seed_from_u64(0);
+
+    for result in scan {
+        let (key, _) = result?;
+        if key == ENTRY_POINT_KEY {
+            continue;
+        }
+        total += 1;
+        if !reachable.contains(&key) {
+            unreachable_count += 1;
+            if sample.len() < args.sample_size {
+                sample.push(key);
+            } else if args.sample_size > 0 {
+                let j = rng.random_range(0..unreachable_count);
+                if j < args.sample_size {
+                    sample[j] = key;
+                }
+            }
+        }
+    }
+
+    if unreachable_count == 0 {
+        println!("All {total} vertices are reachable from the entry point.");
+    } else {
+        println!(
+            "{unreachable_count} of {total} vertices ({:.2}%) are not reachable from the entry point.",
+            unreachable_count as f64 * 100.0 / total as f64,
+        );
+        if !sample.is_empty() {
+            sample.sort_unstable();
+            println!(
+                "Sample ({} of {unreachable_count}): {:?}",
+                sample.len(),
+                sample,
+            );
+        }
+    }
+
+    Ok(())
+}

--- a/et/src/vamana/init_index.rs
+++ b/et/src/vamana/init_index.rs
@@ -2,7 +2,7 @@ use std::{io, num::NonZero, sync::Arc};
 
 use clap::Args;
 use easy_tiger::vamana::{
-    wt::TableGraphVectorIndex, GraphConfig, GraphSearchParams, PatienceParams,
+    wt::TableGraphVectorIndex, EdgeType, GraphConfig, GraphSearchParams, PatienceParams,
 };
 use vectors::{F32VectorCoding, VectorSimilarity};
 use wt_mdb::Connection;
@@ -94,6 +94,7 @@ pub fn init_index(
                 }),
             },
             centroid: None,
+            edge_type: EdgeType::Undirected,
         },
         index_name,
     )

--- a/et/src/vamana/init_index.rs
+++ b/et/src/vamana/init_index.rs
@@ -2,12 +2,12 @@ use std::{io, num::NonZero, sync::Arc};
 
 use clap::Args;
 use easy_tiger::vamana::{
-    wt::TableGraphVectorIndex, EdgeType, GraphConfig, GraphSearchParams, PatienceParams,
+    wt::TableGraphVectorIndex, GraphConfig, GraphSearchParams, PatienceParams,
 };
 use vectors::{F32VectorCoding, VectorSimilarity};
 use wt_mdb::Connection;
 
-use crate::vamana::EdgePruningArgs;
+use crate::vamana::{EdgePruningArgs, EdgeTypeArg};
 
 use super::drop_index::drop_index;
 
@@ -53,6 +53,10 @@ pub struct InitIndexArgs {
     #[command(flatten)]
     pruning: EdgePruningArgs,
 
+    /// Whether the graph maintains directed or undirected edges.
+    #[arg(long, value_enum, default_value_t = EdgeTypeArg::Undirected)]
+    edge_type: EdgeTypeArg,
+
     /// If true, drop the named index if it exists and re-initialize.
     ///
     /// If false and the index already exists this command will fail.
@@ -94,7 +98,7 @@ pub fn init_index(
                 }),
             },
             centroid: None,
-            edge_type: EdgeType::Undirected,
+            edge_type: args.edge_type.into(),
         },
         index_name,
     )

--- a/src/vamana.rs
+++ b/src/vamana.rs
@@ -80,6 +80,16 @@ impl EdgePruningConfig {
     }
 }
 
+/// Whether the graph maintains directed or undirected edges.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub enum EdgeType {
+    /// Every edge A→B has a corresponding back edge B→A.
+    #[default]
+    Undirected,
+    /// Edges are one-way; no back edge is required.
+    Directed,
+}
+
 /// Configuration describing graph shape and construction. Used to read and mutate the graph.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GraphConfig {
@@ -115,6 +125,9 @@ pub struct GraphConfig {
     /// When present, this centroid is subtracted from vectors before encoding and is passed to all
     /// distance computation functions to apply the appropriate correction terms.
     pub centroid: Option<Vec<f32>>,
+    /// Whether this graph maintains directed or undirected edges.
+    #[serde(default)]
+    pub edge_type: EdgeType,
 }
 
 /// `GraphVectorIndex` is used to generate objects for graph navigation and mutation.

--- a/src/vamana.rs
+++ b/src/vamana.rs
@@ -226,7 +226,8 @@ pub trait GraphVectorStore {
 
     /// Create a new distance function that operates over vectors on this table.
     fn new_distance_function(&self) -> Box<dyn VectorDistance> {
-        self.format().distance_symmetric(self.similarity(), self.centroid())
+        self.format()
+            .distance_symmetric(self.similarity(), self.centroid())
     }
 
     /// Create a new coder for vectors of this type.
@@ -296,6 +297,42 @@ impl EdgeSetDistanceComputer {
             distance_fn,
             vectors,
         })
+    }
+
+    /// Produce an edge set computer from a list of unhydrated edges in a directed graph.
+    /// This will fetch the vector for each of the edge and compare it to the vertex vector.
+    /// Any missing vectors are dropped -- this may happen as deletes are not guaranteed to be
+    /// removed from the graph.
+    ///
+    /// Returns a list of neighbors with their distance relative to `vertex_vector` as well as a
+    /// computer.
+    pub(crate) fn from_directed_edges(
+        vertex_vector: &[u8],
+        store: &mut impl GraphVectorStore,
+        edges: &[i64],
+    ) -> Result<(Vec<Neighbor>, Self)> {
+        let distance_fn = store.new_distance_function();
+        let mut neighbors = Vec::with_capacity(edges.len());
+        let mut vectors = Vec::with_capacity(edges.len());
+        for e in edges {
+            let Some(vector) = store.get(*e).transpose()? else {
+                continue;
+            };
+            neighbors.push(Neighbor::new(
+                *e,
+                distance_fn.distance(vertex_vector, vector),
+            ));
+            vectors.push(vector.to_vec());
+        }
+        neighbors.sort_unstable();
+
+        Ok((
+            neighbors,
+            Self {
+                distance_fn,
+                vectors,
+            },
+        ))
     }
 
     pub fn distance(&self, i: usize, j: usize) -> f64 {

--- a/src/vamana/bulk.rs
+++ b/src/vamana/bulk.rs
@@ -33,7 +33,7 @@ use crate::{
     vamana::search::GraphSearcher,
     vamana::wt::{encode_graph_vertex, CursorVectorStore, TableGraphVectorIndex, ENTRY_POINT_KEY},
     vamana::{
-        prune_edges, select_pruned_edges, EdgeSetDistanceComputer, Graph, GraphConfig,
+        prune_edges, select_pruned_edges, EdgeSetDistanceComputer, EdgeType, Graph, GraphConfig,
         GraphVectorIndex, GraphVectorStore,
     },
     Neighbor,
@@ -238,9 +238,9 @@ where
     }
 
     fn insert_all<P: Fn(u64) + Send + Sync>(&self, progress: P) -> Result<()> {
-        // apply_mu is used to ensure that only one thread is mutating the graph at a time so we can maintain
-        // the "undirected graph" invariant. apply_mu contains the entry point vertex id and score against the
-        // centroid, we may update this if we find a closer point then reflect it back into entry_vertex.
+        // apply_mu stores the vertex closest to the centroid and its distance for use as an entry
+        // point. When building an undirected graph this Mutex is also used to ensure that only one
+        // thread is mutating the graph at a time.
         let distance_fn = self.index.high_fidelity_table().new_distance_function();
         let apply_mu = {
             let txn = self.connection.begin_transaction(None)?;
@@ -293,49 +293,14 @@ where
                     distance_fn.distance(&self.centroid, vectors.get(v as i64).unwrap()?)
                 };
 
-                // Add each edge to this vertex and a reciprocal edge to make the graph
-                // undirected. If an edge does not fit on either vertex, save it for later.
-                // We will prune any vertices in this state, but put together the pruned edge
-                // list outside of `apply_mu` to maximize concurrency.
-                loop {
-                    let mut entry_point = apply_mu.lock().unwrap();
-
-                    edges.retain(|&e| {
-                        let (mut iv, mut ev) = self.lock_edge(v, e.vertex() as usize);
-                        if iv.len() == iv.capacity() || ev.len() == ev.capacity() {
-                            true
-                        } else {
-                            // Another concurrent insertion may have added this edge already, so
-                            // skip it if that is the case. Compare by vertex id only: the same
-                            // vertex can appear with different distances (e.g. asymmetric vs
-                            // symmetric distance), and Neighbor equality includes distance.
-                            if !iv.iter().any(|n| n.vertex() == e.vertex()) {
-                                iv.push(e);
-                            }
-                            let backedge = Neighbor::new(v as i64, e.distance());
-                            if !ev.iter().any(|n| n.vertex() == v as i64) {
-                                ev.push(backedge);
-                            }
-                            false
-                        }
-                    });
-
-                    if edges.is_empty() {
-                        if centroid_distance < entry_point.1 {
-                            entry_point.0 = v as i64;
-                            entry_point.1 = centroid_distance;
-                            self.entry_vertex.store(v as i64, atomic::Ordering::SeqCst);
-                        }
-                        break;
+                match self.index.config().edge_type {
+                    EdgeType::Undirected => {
+                        self.insert_undirected(v, centroid_distance, &apply_mu, edges, &reader)?
                     }
-
-                    drop(entry_point);
-                    // Any edge still in the list is overful, so prune it.
-                    self.prune_and_apply(v, &mut reader, &apply_mu)?;
-                    for e in edges.iter() {
-                        self.prune_and_apply(e.vertex() as usize, &mut reader, &apply_mu)?;
+                    EdgeType::Directed => {
+                        self.insert_directed(v, edges, &reader, centroid_distance, &apply_mu)?
                     }
-                }
+                };
 
                 in_flight.remove(&v);
                 progress(1);
@@ -348,14 +313,25 @@ where
     ///
     /// This may prune edges and/or ensure graph connectivity.
     fn cleanup<P: Fn(u64) + Send + Sync>(&self, progress: P) -> Result<()> {
-        // synchronize application of changes to the graph.
-        // this is necessary to ensure the graph remains undirected.
-        let apply_mu = Mutex::new(());
-
         (0..self.limit).into_par_iter().try_for_each(|v| {
             let txn = self.connection.begin_transaction(None)?;
             let mut reader = BulkLoadGraphVectorIndexReader(self, &txn);
-            self.prune_and_apply(v, &mut reader, &apply_mu)?;
+            match self.index.config().edge_type {
+                EdgeType::Undirected => {
+                    // Synchronize application of changes to keep graph undirected.
+                    let apply_mu = Mutex::new(());
+                    self.prune_and_apply_undirected(v, &mut reader, &apply_mu)?
+                }
+                EdgeType::Directed => {
+                    let mut vertex = self.graph[v].write().unwrap();
+                    if vertex.len() > self.index.config().pruning.max_edges.get() {
+                        vertex.sort_unstable();
+                        let computer = EdgeSetDistanceComputer::new(&reader, &vertex)?;
+                        let keep = prune_edges(&mut vertex, &self.index.config().pruning, computer);
+                        vertex.truncate(keep);
+                    }
+                }
+            }
             progress(1);
             Ok::<_, wt_mdb::Error>(())
         })
@@ -502,10 +478,65 @@ where
         Ok(())
     }
 
-    fn prune_and_apply<T>(
+    fn insert_undirected(
         &self,
         vertex: usize,
-        reader: &mut BulkLoadGraphVectorIndexReader<'_, '_, D>,
+        centroid_distance: f64,
+        apply_mu: &Mutex<(i64, f64)>,
+        mut edges: Vec<Neighbor>,
+        reader: &impl GraphVectorIndex,
+    ) -> Result<()> {
+        // Add each edge to this vertex and a reciprocal edge to make the graph
+        // undirected. If an edge does not fit on either vertex, save it for later.
+        // We will prune any vertices in this state, but put together the pruned edge
+        // list outside of `apply_mu` to maximize concurrency.
+        loop {
+            let mut entry_point = apply_mu.lock().unwrap();
+
+            edges.retain(|&e| {
+                let (mut iv, mut ev) = self.lock_edge(vertex, e.vertex() as usize);
+                if iv.len() == iv.capacity() || ev.len() == ev.capacity() {
+                    true
+                } else {
+                    // Another concurrent insertion may have added this edge already, so
+                    // skip it if that is the case. Compare by vertex id only: the same
+                    // vertex can appear with different distances (e.g. asymmetric vs
+                    // symmetric distance), and Neighbor equality includes distance.
+                    if !iv.iter().any(|n| n.vertex() == e.vertex()) {
+                        iv.push(e);
+                    }
+                    let backedge = Neighbor::new(vertex as i64, e.distance());
+                    if !ev.iter().any(|n| n.vertex() == vertex as i64) {
+                        ev.push(backedge);
+                    }
+                    false
+                }
+            });
+
+            if edges.is_empty() {
+                if centroid_distance < entry_point.1 {
+                    entry_point.0 = vertex as i64;
+                    entry_point.1 = centroid_distance;
+                    self.entry_vertex
+                        .store(vertex as i64, atomic::Ordering::SeqCst);
+                }
+                break;
+            }
+
+            drop(entry_point);
+            // Any edge still in the list is overful, so prune it.
+            self.prune_and_apply_undirected(vertex, reader, &apply_mu)?;
+            for e in edges.iter() {
+                self.prune_and_apply_undirected(e.vertex() as usize, reader, &apply_mu)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn prune_and_apply_undirected<T>(
+        &self,
+        vertex: usize,
+        reader: &impl GraphVectorIndex,
         apply_mu: &Mutex<T>,
     ) -> Result<()> {
         // Get the set of edges to prune while only holding a read lock on the vertex.
@@ -575,6 +606,67 @@ where
             (self.graph[vertex0].write().unwrap(), g1)
         }
     }
+
+    fn insert_directed(
+        &self,
+        vertex: usize,
+        mut edges: Vec<Neighbor>,
+        reader: &impl GraphVectorIndex,
+        centroid_distance: f64,
+        entry_point: &Mutex<(i64, f64)>,
+    ) -> Result<()> {
+        let computer = EdgeSetDistanceComputer::new(reader, &edges)?;
+        let keep = prune_edges(&mut edges, &self.index.config().pruning, computer);
+        edges.truncate(keep);
+        // Note that we have to add the edges -- concurrent threads may have already inserted back
+        // edges to vertex.
+        self.add_edges_directed(vertex, &edges, reader)?;
+
+        // Insert back links to vertex.
+        for e in edges {
+            self.add_edges_directed(
+                e.vertex() as usize,
+                &[Neighbor::new(vertex as i64, e.distance())],
+                reader,
+            )?;
+        }
+
+        // Update entry point if we are closer.
+        {
+            let mut ep = entry_point.lock().unwrap();
+            if centroid_distance < ep.1 {
+                ep.0 = vertex as i64;
+                ep.1 = centroid_distance;
+                self.entry_vertex
+                    .store(vertex as i64, atomic::Ordering::SeqCst);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn add_edges_directed(
+        &self,
+        vertex: usize,
+        edges: &[Neighbor],
+        reader: &impl GraphVectorIndex,
+    ) -> Result<()> {
+        let mut vertex = self.graph[vertex].write().unwrap();
+        for e in edges {
+            // Skip any attempts to duplicate insert.
+            if vertex.iter().any(|f| f.vertex() == e.vertex()) {
+                continue;
+            }
+            vertex.push(*e);
+            if vertex.len() == vertex.capacity() {
+                vertex.sort_unstable();
+                let computer = EdgeSetDistanceComputer::new(reader, &vertex)?;
+                let keep = prune_edges(&mut vertex, &self.index.config().pruning, computer);
+                vertex.truncate(keep);
+            }
+        }
+        Ok(())
+    }
 }
 
 struct BulkLoadGraphVectorIndexReader<'a, 'b, D: Send>(&'a BulkLoadBuilder<D>, &'b Transaction);
@@ -600,8 +692,7 @@ impl<D: VectorStore<Elem = f32> + Send + Sync> GraphVectorIndex
     }
 
     fn nav_vectors(&self) -> Result<Self::VectorStore<'_>> {
-        let centroid: Option<Arc<[f32]>> =
-            self.config().centroid.as_deref().map(Arc::from);
+        let centroid: Option<Arc<[f32]>> = self.config().centroid.as_deref().map(Arc::from);
         if let Some(s) = self.0.quantized_vectors.as_ref() {
             Ok(BulkLoadGraphVectorStore::Memory(
                 s,

--- a/src/vamana/bulk.rs
+++ b/src/vamana/bulk.rs
@@ -315,12 +315,12 @@ where
     fn cleanup<P: Fn(u64) + Send + Sync>(&self, progress: P) -> Result<()> {
         (0..self.limit).into_par_iter().try_for_each(|v| {
             let txn = self.connection.begin_transaction(None)?;
-            let mut reader = BulkLoadGraphVectorIndexReader(self, &txn);
+            let reader = BulkLoadGraphVectorIndexReader(self, &txn);
             match self.index.config().edge_type {
                 EdgeType::Undirected => {
                     // Synchronize application of changes to keep graph undirected.
                     let apply_mu = Mutex::new(());
-                    self.prune_and_apply_undirected(v, &mut reader, &apply_mu)?
+                    self.prune_and_apply_undirected(v, &reader, &apply_mu)?
                 }
                 EdgeType::Directed => {
                     let mut vertex = self.graph[v].write().unwrap();
@@ -525,9 +525,9 @@ where
 
             drop(entry_point);
             // Any edge still in the list is overful, so prune it.
-            self.prune_and_apply_undirected(vertex, reader, &apply_mu)?;
+            self.prune_and_apply_undirected(vertex, reader, apply_mu)?;
             for e in edges.iter() {
-                self.prune_and_apply_undirected(e.vertex() as usize, reader, &apply_mu)?;
+                self.prune_and_apply_undirected(e.vertex() as usize, reader, apply_mu)?;
             }
         }
         Ok(())

--- a/src/vamana/mutate.rs
+++ b/src/vamana/mutate.rs
@@ -315,7 +315,7 @@ mod tests {
         mutate::{delete_vector, insert_vector, upsert_vector},
         search::GraphSearcher,
         wt::{TableGraphVectorIndex, TransactionGraphVectorIndex},
-        EdgePruningConfig, Graph, GraphConfig, GraphSearchParams, GraphVectorIndex,
+        EdgePruningConfig, EdgeType, Graph, GraphConfig, GraphSearchParams, GraphVectorIndex,
     };
 
     struct Fixture {
@@ -381,6 +381,7 @@ mod tests {
                         pruning: EdgePruningConfig::new(NonZero::new(4).unwrap()),
                         index_search_params: Self::search_params(),
                         centroid: None,
+                        edge_type: EdgeType::Undirected,
                     },
                     "test",
                 )

--- a/src/vamana/mutate.rs
+++ b/src/vamana/mutate.rs
@@ -1,9 +1,10 @@
 //! Tools for mutating a vamana graph vector index.
 use crate::vamana::{
-    prune_edges, search::GraphSearcher, EdgeSetDistanceComputer, Graph, GraphVectorIndex,
-    GraphVectorStore,
+    prune_edges, search::GraphSearcher, EdgePruningConfig, EdgeSetDistanceComputer, EdgeType,
+    Graph, GraphVectorIndex, GraphVectorStore,
 };
 use crate::Neighbor;
+use std::collections::{hash_map::Entry, HashMap};
 use vectors::VectorDistance;
 use wt_mdb::{Error, Result};
 
@@ -17,6 +18,13 @@ pub fn insert_vector(vector: &[f32], index: &impl GraphVectorIndex) -> Result<i6
 ///
 /// May return a non found error if `vertex_id` is not present in the index.
 pub fn delete_vector(vertex_id: i64, index: &impl GraphVectorIndex) -> Result<()> {
+    match index.config().edge_type {
+        EdgeType::Undirected => delete_vector_undirected(vertex_id, index),
+        EdgeType::Directed => delete_vector_directed(vertex_id, index),
+    }
+}
+
+fn delete_vector_undirected(vertex_id: i64, index: &impl GraphVectorIndex) -> Result<()> {
     let mut graph = index.graph()?;
     let mut vectors = index.high_fidelity_vectors()?;
     let distance_fn = vectors.new_distance_function();
@@ -80,6 +88,136 @@ pub fn delete_vector(vertex_id: i64, index: &impl GraphVectorIndex) -> Result<()
     Ok(())
 }
 
+/// Delete a vector in a directed graph.
+///
+/// This utilizes Inplace Delete (Algorithm 6) from https://www.vldb.org/pvldb/vol18/p5166-upreti.pdf
+fn delete_vector_directed(vertex_id: i64, index: &impl GraphVectorIndex) -> Result<()> {
+    let mut graph = index.graph()?;
+    let mut vectors = index.high_fidelity_vectors()?;
+    let distance_fn = vectors.new_distance_function();
+
+    let edges = graph.remove_vertex(vertex_id)?;
+    let vector = vectors
+        .get(vertex_id)
+        .expect("row exists")
+        .map(|v| v.to_vec())?;
+    index.nav_vectors()?.remove(vertex_id)?;
+    if let Some(vectors) = index.rerank_vectors() {
+        vectors?.remove(vertex_id)?;
+    }
+
+    // A candidate vertex to reprocess. Reprocess if there is an edge to vertex_id, saving all of
+    // the other edges, otherwise skip.
+    enum Vertex {
+        Skip,
+        Reprocess(Vec<i64>),
+    }
+
+    impl Vertex {
+        fn new(delete_vertex_id: i64, mut edges: Vec<i64>) -> Self {
+            if let Some(pos) = edges.iter().position(|e| *e == delete_vertex_id) {
+                edges.remove(pos);
+                Self::Reprocess(edges)
+            } else {
+                Self::Skip
+            }
+        }
+    }
+
+    // Cast a net looking for vertexes that reference vertex_id, searching within 2 hops.
+    let mut seen_vertexes: HashMap<i64, Vertex> = HashMap::new();
+    for v in edges.iter() {
+        let Some(vedges) = graph.edges(*v).transpose()?.map(|e| e.collect::<Vec<_>>()) else {
+            continue;
+        };
+        seen_vertexes
+            .entry(*v)
+            .or_insert_with(|| Vertex::new(vertex_id, vedges.clone()));
+        for vv in vedges.iter() {
+            if let Entry::Vacant(entry) = seen_vertexes.entry(*vv) {
+                let Some(vvedges) = graph.edges(*vv).transpose()?.map(|e| e.collect::<Vec<_>>())
+                else {
+                    continue;
+                };
+                entry.insert(Vertex::new(vertex_id, vvedges));
+            }
+        }
+    }
+
+    // Each vertex that I removed an edge from may get replacement edges
+    // Fetch these vectors since they will be used repeatedly.
+    let mut replacement_candidates = Vec::with_capacity(edges.len());
+    for e in edges {
+        if let Some(v) = vectors.get(e).transpose()? {
+            replacement_candidates.push((e, v.to_vec()));
+        }
+    }
+
+    // For each vertex that we removed vertex_id from, score all of the replacement candidates
+    // and select some of them into the edge set, pruning if needed.
+    let mut replacements = Vec::with_capacity(replacement_candidates.len());
+    for (id, vertex) in seen_vertexes.iter_mut() {
+        let Vertex::Reprocess(edges) = vertex else {
+            continue;
+        };
+        edges.sort_unstable();
+        replacements.clear();
+
+        let cvector = vectors.get(*id).expect("row exists")?.to_vec();
+        for (rid, rv) in replacement_candidates.iter() {
+            // Skip anything that exists already in the edge set.
+            if !edges.contains(rid) {
+                replacements.push(Neighbor::new(*rid, distance_fn.distance(&cvector, rv)));
+            }
+        }
+
+        if replacements.is_empty() {
+            continue;
+        }
+
+        if replacements.len() > 4 {
+            replacements.select_nth_unstable(3);
+        }
+        for c in replacements.iter().take(4).map(|n| n.vertex()) {
+            if let Err(i) = edges.binary_search(&c) {
+                edges.insert(i, c);
+            }
+        }
+
+        // If there are now too many edges, rehydrate the edge list and prune.
+        if edges.len() > index.config().pruning.max_edges.get() {
+            let (neighbors, keep) =
+                rehydrate_and_prune_directed(&cvector, &mut vectors, edges, &index.config().pruning)?;
+            edges.clear();
+            edges.extend(neighbors.iter().take(keep).map(Neighbor::vertex));
+        }
+
+        graph.set_edges(*id, edges.to_vec())?;
+    }
+
+    // Oh no, we've deleted the entry point! Find the closest point amongst the edges of this node
+    // to use as a new entry point.
+    // TODO: consider all of seen_vertexes instead since they pointed to the removed vertex.
+    if graph
+        .entry_point()
+        .expect("there was at least one vertex")?
+        == vertex_id
+    {
+        let mut neighbors = replacement_candidates
+            .iter()
+            .map(|(id, vec)| Neighbor::new(*id, distance_fn.distance(&vector, vec)))
+            .collect::<Vec<_>>();
+        neighbors.sort_unstable();
+        if let Some(ep_neighbor) = neighbors.first() {
+            graph.set_entry_point(ep_neighbor.vertex())?
+        } else {
+            graph.remove_entry_point()?
+        }
+    }
+
+    Ok(())
+}
+
 /// Upsert vector with the externally assigned `vertex_id`.
 pub fn upsert_vector(vertex_id: i64, vector: &[f32], index: &impl GraphVectorIndex) -> Result<()> {
     let mut graph = index.graph()?;
@@ -130,26 +268,45 @@ fn insert_internal(vertex_id: i64, vector: &[f32], index: &impl GraphVectorIndex
     }
 
     let mut vectors = index.high_fidelity_vectors()?;
-    let distance_fn = vectors.new_distance_function();
     let mut pruned_edges = vec![];
     for src_vertex_id in candidate_edges.into_iter().map(|n| n.vertex()) {
         let edges = insert_edge_directed(
             index,
             &mut graph,
             &mut vectors,
-            distance_fn.as_ref(),
             src_vertex_id,
             vertex_id,
             &mut pruned_edges,
         )?;
         graph.set_edges(src_vertex_id, edges)?;
 
-        for (src_vertex_id, dst_vertex_id) in pruned_edges.drain(..) {
-            remove_edge_directed(&mut graph, src_vertex_id, dst_vertex_id)?;
+        if index.config().edge_type == EdgeType::Undirected {
+            for (src_vertex_id, dst_vertex_id) in pruned_edges.drain(..) {
+                remove_edge_directed(&mut graph, src_vertex_id, dst_vertex_id)?;
+            }
         }
     }
 
     Ok(())
+}
+
+/// Rehydrates `edges` as neighbors with distances from `vertex_vector`, skipping any dangling
+/// edges, and prunes if needed. Returns `(neighbors, keep)` where `neighbors[..keep]` are the
+/// selected edges in ascending distance order and `neighbors[keep..]` are the pruned ones.
+fn rehydrate_and_prune_directed(
+    vertex_vector: &[u8],
+    vectors: &mut impl GraphVectorStore,
+    edges: &[i64],
+    config: &EdgePruningConfig,
+) -> Result<(Vec<Neighbor>, usize)> {
+    let (mut neighbors, computer) =
+        EdgeSetDistanceComputer::from_directed_edges(vertex_vector, vectors, edges)?;
+    let keep = if neighbors.len() > config.max_edges.get() {
+        prune_edges(&mut neighbors, config, computer)
+    } else {
+        neighbors.len()
+    };
+    Ok((neighbors, keep))
 }
 
 /// Attempt to insert a directed edge from `src_vertex_id` to `dst_vertex_id` and return the set of
@@ -159,12 +316,10 @@ fn insert_internal(vertex_id: i64, vector: &[f32], index: &impl GraphVectorIndex
 /// exceed max_edges then the edges are pruned according to policy. This process may result in the
 /// inserted edges being dropped. Pruning will also fill `pruned_edges` with any back edges that
 /// need to be removed to maintain an undirected graph.
-#[allow(clippy::too_many_arguments)]
 fn insert_edge_directed(
     index: &impl GraphVectorIndex,
     graph: &mut impl Graph,
     vectors: &mut impl GraphVectorStore,
-    distance_fn: &dyn VectorDistance,
     src_vertex_id: i64,
     dst_vertex_id: i64,
     pruned_edges: &mut Vec<(i64, i64)>,
@@ -185,25 +340,10 @@ fn insert_edge_directed(
         .get(src_vertex_id)
         .expect("row exists")
         .map(|v| v.to_vec())?;
-    let mut neighbors = edges
-        .iter()
-        .map(|e| {
-            vectors
-                .get(*e)
-                .unwrap_or(Err(Error::not_found_error()))
-                .map(|dst| Neighbor::new(*e, distance_fn.distance(&src_vector, dst)))
-        })
-        .collect::<Result<Vec<Neighbor>>>()?;
-    neighbors.sort();
-    let edge_set_distance_computer = EdgeSetDistanceComputer::new(index, &neighbors)?;
-    let selected_len = prune_edges(
-        &mut neighbors,
-        &index.config().pruning,
-        edge_set_distance_computer,
-    );
-    // Ensure the graph is undirected by removing links from pruned edges back to this node.
+    let (neighbors, selected_len) =
+        rehydrate_and_prune_directed(&src_vector, vectors, &edges, &index.config().pruning)?;
     for v in neighbors.iter().skip(selected_len).map(Neighbor::vertex) {
-        pruned_edges.push((v, src_vertex_id))
+        pruned_edges.push((v, src_vertex_id));
     }
     edges.clear();
     edges.extend(neighbors.iter().take(selected_len).map(Neighbor::vertex));
@@ -271,7 +411,6 @@ fn cross_link_peer_vertices(
             index,
             graph,
             vectors,
-            distance_fn,
             src_vertex_id,
             dst_vertex_id,
             &mut pruned_edges,
@@ -280,7 +419,6 @@ fn cross_link_peer_vertices(
             index,
             graph,
             vectors,
-            distance_fn,
             dst_vertex_id,
             src_vertex_id,
             &mut pruned_edges,
@@ -567,6 +705,251 @@ mod tests {
 
         assert_eq!(fixture.search(&[0.0, 0.0]), Ok(vec![1, 2, 3, 5, 4, 0]));
 
+        Ok(())
+    }
+
+    struct DirectedFixture {
+        index: Arc<TableGraphVectorIndex>,
+        conn: Arc<Connection>,
+        _dir: tempfile::TempDir,
+    }
+
+    impl DirectedFixture {
+        fn search_params() -> GraphSearchParams {
+            GraphSearchParams {
+                beam_width: NonZero::new(16).unwrap(),
+                num_rerank: 16,
+                patience: None,
+            }
+        }
+
+        fn new_txn_index(&self) -> TransactionGraphVectorIndex {
+            TransactionGraphVectorIndex::new(
+                self.index.clone(),
+                self.conn.begin_transaction(None).unwrap(),
+            )
+        }
+
+        fn insert_many(&self, vectors: &[[f32; 2]]) -> Result<Vec<i64>> {
+            let index = self.new_txn_index();
+            vectors
+                .iter()
+                .map(|v| insert_vector(v.as_ref(), &index))
+                .collect::<Result<Vec<_>>>()
+                .and_then(|ids| index.commit(None).map(|_| ids))
+        }
+
+        fn search(&self, query: &[f32]) -> Result<Vec<i64>> {
+            let mut searcher = GraphSearcher::new(Self::search_params());
+            let reader = self.new_txn_index();
+            searcher
+                .search(query, &reader)
+                .map(|neighbors| neighbors.into_iter().map(|n| n.vertex()).collect())
+        }
+    }
+
+    impl Default for DirectedFixture {
+        fn default() -> Self {
+            let dir = tempfile::TempDir::new().unwrap();
+            let conn = Connection::open(
+                dir.path().to_str().unwrap(),
+                Some(
+                    wt_mdb::connection::OptionsBuilder::default()
+                        .create()
+                        .into(),
+                ),
+            )
+            .unwrap();
+            let index = Arc::new(
+                TableGraphVectorIndex::init_index(
+                    &conn,
+                    GraphConfig {
+                        dimensions: NonZero::new(2).unwrap(),
+                        similarity: VectorSimilarity::Euclidean,
+                        nav_format: F32VectorCoding::BinaryQuantized,
+                        rerank_format: Some(F32VectorCoding::F32),
+                        pruning: EdgePruningConfig::new(NonZero::new(4).unwrap()),
+                        index_search_params: Self::search_params(),
+                        centroid: None,
+                        edge_type: EdgeType::Directed,
+                    },
+                    "test",
+                )
+                .unwrap(),
+            );
+            Self {
+                _dir: dir,
+                conn,
+                index,
+            }
+        }
+    }
+
+    #[test]
+    fn directed_empty_graph() -> Result<()> {
+        let fixture = DirectedFixture::default();
+
+        let reader = fixture.new_txn_index();
+        assert_eq!(reader.graph()?.entry_point(), None);
+        let mut searcher = GraphSearcher::new(DirectedFixture::search_params());
+        assert_eq!(searcher.search(&[0.5, -0.5], &reader), Ok(vec![]));
+        Ok(())
+    }
+
+    #[test]
+    fn directed_insert_one() -> Result<()> {
+        let fixture = DirectedFixture::default();
+
+        let index = fixture.new_txn_index();
+        let id = insert_vector(&[0.0, 0.0], &index)?;
+        index.commit(None)?;
+
+        assert_eq!(id, 0);
+        assert_eq!(fixture.new_txn_index().graph()?.entry_point(), Some(Ok(id)));
+        assert_eq!(fixture.search(&[1.0, 1.0]), Ok(vec![id]));
+        Ok(())
+    }
+
+    #[test]
+    fn directed_insert_two() -> Result<()> {
+        let fixture = DirectedFixture::default();
+
+        fixture.insert_many(&[[0.0, 0.0], [0.5, 0.5]])?;
+        assert_eq!(fixture.search(&[1.0, 1.0]), Ok(vec![1, 0]));
+        Ok(())
+    }
+
+    // Verify that inserting a vertex also adds best-effort back edges to its chosen neighbors.
+    #[test]
+    fn directed_back_edges_added_on_insert() -> Result<()> {
+        let fixture = DirectedFixture::default();
+
+        let ids = fixture.insert_many(&[[0.0, 0.0], [1.0, 1.0]])?;
+
+        let reader = fixture.new_txn_index();
+        let mut graph = reader.graph()?;
+        let edges_0: Vec<i64> = graph.edges(ids[0]).unwrap()?.collect();
+        let edges_1: Vec<i64> = graph.edges(ids[1]).unwrap()?.collect();
+        // vertex 1 was inserted second and selects vertex 0 as a forward edge.
+        assert!(
+            edges_1.contains(&ids[0]),
+            "vertex 1 should have a forward edge to vertex 0"
+        );
+        // vertex 0 should have received a back edge to vertex 1.
+        assert!(
+            edges_0.contains(&ids[1]),
+            "vertex 0 should have received a back edge to vertex 1"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn directed_insert_to_prune() -> Result<()> {
+        let fixture = DirectedFixture::default();
+
+        fixture.insert_many(&[
+            [0.0, 0.0],
+            [0.1, 0.1],
+            [-0.1, 0.1],
+            [0.1, -0.1],
+            [-0.2, -0.2],
+            [-0.1, -0.1],
+        ])?;
+
+        assert_eq!(fixture.search(&[0.0, 0.0]), Ok(vec![0, 1, 2, 3, 5, 4]));
+        Ok(())
+    }
+
+    #[test]
+    fn directed_delete_one() -> Result<()> {
+        let fixture = DirectedFixture::default();
+
+        let vertex_ids = fixture.insert_many(&[[0.0, 0.0], [0.5, 0.5], [1.0, 1.0]])?;
+        let txn_index = fixture.new_txn_index();
+        delete_vector(vertex_ids[1], &txn_index)?;
+        txn_index.commit(None)?;
+
+        assert_eq!(
+            fixture.search(&[0.0, 0.0])?,
+            vertex_ids
+                .iter()
+                .copied()
+                .filter(|i| *i != vertex_ids[1])
+                .collect::<Vec<_>>()
+        );
+        Ok(())
+    }
+
+    // Delete a hub vertex and verify the graph remains fully searchable.
+    #[test]
+    fn directed_delete_relink() -> Result<()> {
+        let fixture = DirectedFixture::default();
+
+        fixture.insert_many(&[
+            [0.0, 0.0],
+            [0.1, 0.1],
+            [-0.1, 0.1],
+            [0.1, -0.1],
+            [-0.2, -0.2],
+            [-0.1, -0.1],
+        ])?;
+        assert_eq!(fixture.search(&[0.0, 0.0]), Ok(vec![0, 1, 2, 3, 5, 4]));
+
+        let txn_index = fixture.new_txn_index();
+        delete_vector(1, &txn_index)?;
+        txn_index.commit(None)?;
+
+        assert_eq!(fixture.search(&[0.0, 0.0]), Ok(vec![0, 2, 3, 5, 4]));
+        Ok(())
+    }
+
+    #[test]
+    fn directed_delete_entry_point() -> Result<()> {
+        let fixture = DirectedFixture::default();
+
+        let txn_index = fixture.new_txn_index();
+        let entry_id = insert_vector(&[0.0, 0.0], &txn_index)?;
+        let next_entry_id = insert_vector(&[0.5, 0.5], &txn_index)?;
+        insert_vector(&[1.0, 1.0], &txn_index)?;
+
+        delete_vector(entry_id, &txn_index)?;
+        assert_eq!(txn_index.graph()?.entry_point(), Some(Ok(next_entry_id)));
+        txn_index.commit(None)?;
+
+        assert_eq!(fixture.search(&[0.0, 0.0])?, vec![1, 2]);
+        Ok(())
+    }
+
+    #[test]
+    fn directed_delete_only_point() -> Result<()> {
+        let fixture = DirectedFixture::default();
+
+        let txn_index = fixture.new_txn_index();
+        let id = insert_vector(&[0.0, 0.0], &txn_index)?;
+        txn_index.commit(None)?;
+        assert_eq!(fixture.search(&[0.0, 0.0])?, vec![id]);
+
+        let txn_index = fixture.new_txn_index();
+        delete_vector(id, &txn_index)?;
+        txn_index.commit(None)?;
+        assert_eq!(fixture.search(&[0.0, 0.0])?, Vec::<i64>::new());
+        Ok(())
+    }
+
+    #[test]
+    fn directed_upsert() -> Result<()> {
+        let fixture = DirectedFixture::default();
+
+        let vertex_ids = fixture.insert_many(&[[0.0, 0.0], [0.5, 0.5], [1.0, 1.0]])?;
+        assert_eq!(fixture.search(&[0.0, 0.0]), Ok(vec![0, 1, 2]));
+
+        let txn_index = fixture.new_txn_index();
+        upsert_vector(vertex_ids[0], &[2.0, 2.0], &txn_index)?;
+        txn_index.commit(None)?;
+
+        // vertex 0 moved far away; vertex 1 is now nearest to [0.0, 0.0]
+        let results = fixture.search(&[0.0, 0.0])?;
+        assert_eq!(results[0], vertex_ids[1]);
         Ok(())
     }
 }

--- a/src/vamana/search.rs
+++ b/src/vamana/search.rs
@@ -21,6 +21,8 @@ pub struct GraphSearchStats {
     pub visited: usize,
     /// Total number of candidates visited that did not match the filter predicate.
     pub filtered: usize,
+    /// Number of candidates skipped due to a stale edge in a directed graph.
+    pub skipped: usize,
 }
 
 impl Add for GraphSearchStats {
@@ -32,6 +34,7 @@ impl Add for GraphSearchStats {
             candidates_added: self.candidates_added + rhs.candidates_added,
             visited: self.visited + rhs.visited,
             filtered: self.filtered + rhs.filtered,
+            skipped: self.skipped + rhs.skipped,
         }
     }
 }
@@ -82,6 +85,7 @@ pub struct GraphSearcher {
     candidates_added: usize,
     visited: usize,
     filtered: usize,
+    skipped: usize,
 }
 
 impl GraphSearcher {
@@ -100,6 +104,7 @@ impl GraphSearcher {
             candidates_added: 0,
             visited: 0,
             filtered: 0,
+            skipped: 0,
         }
     }
 
@@ -115,6 +120,7 @@ impl GraphSearcher {
             candidates_added: self.candidates_added,
             visited: self.visited,
             filtered: self.filtered,
+            skipped: self.skipped,
         }
     }
 
@@ -279,7 +285,10 @@ impl GraphSearcher {
                 if !self.seen.insert(edge) {
                     continue;
                 }
-                let vec = nav.get(edge).unwrap_or(Err(Error::not_found_error()))?;
+                let Some(vec) = nav.get(edge).transpose()? else {
+                    self.skipped += 1;
+                    continue;
+                };
                 if self
                     .candidates
                     .add_unvisited(Neighbor::new(edge, nav_query.distance(vec)))

--- a/src/vamana/search.rs
+++ b/src/vamana/search.rs
@@ -177,11 +177,11 @@ impl GraphSearcher {
                     .get(vertex_id)
                     .unwrap_or(Err(Error::not_found_error()))?
                     .to_vec();
-                Some(
-                    vectors
-                        .format()
-                        .query_distance_symmetric(vectors.similarity(), query, vectors.centroid()),
-                )
+                Some(vectors.format().query_distance_symmetric(
+                    vectors.similarity(),
+                    query,
+                    vectors.centroid(),
+                ))
             } else {
                 None
             }
@@ -720,7 +720,10 @@ mod test {
         )
     }
 
-    fn build_test_graph_with_centroid(max_edges: usize, centroid: Vec<f32>) -> TestGraphVectorIndex {
+    fn build_test_graph_with_centroid(
+        max_edges: usize,
+        centroid: Vec<f32>,
+    ) -> TestGraphVectorIndex {
         let dim_values = [-0.25, -0.125, 0.125, 0.25];
         TestGraphVectorIndex::new_with_centroid(
             NonZero::new(max_edges).unwrap(),

--- a/src/vamana/search.rs
+++ b/src/vamana/search.rs
@@ -456,7 +456,7 @@ mod test {
     use wt_mdb::{Error, Result};
 
     use crate::vamana::{
-        EdgePruningConfig, Graph, GraphConfig, GraphVectorIndex, GraphVectorStore,
+        EdgePruningConfig, EdgeType, Graph, GraphConfig, GraphVectorIndex, GraphVectorStore,
     };
     use crate::Neighbor;
 
@@ -528,6 +528,7 @@ mod test {
                     patience: None,
                 },
                 centroid,
+                edge_type: EdgeType::Undirected,
             };
             Self { data: rep, config }
         }

--- a/src/vamana/wt.rs
+++ b/src/vamana/wt.rs
@@ -194,8 +194,10 @@ impl GraphVectorTable {
     }
 
     pub fn new_coder(&self) -> Box<dyn F32VectorCoder> {
-        self.format
-            .coder(self.similarity, self.centroid.as_deref().map(|c| c.to_vec()))
+        self.format.coder(
+            self.similarity,
+            self.centroid.as_deref().map(|c| c.to_vec()),
+        )
     }
 
     pub fn new_distance_function(&self) -> Box<dyn VectorDistance> {
@@ -399,9 +401,14 @@ impl GraphVectorIndex for TransactionGraphVectorIndex {
 
     fn rerank_vectors(&self) -> Option<Result<Self::VectorStore<'_>>> {
         self.index.rerank_table().map(|t| {
-            self.transaction
-                .open_record_cursor(t.name())
-                .map(|c| CursorVectorStore::new(c, self.index.config().similarity, t.format(), t.centroid().map(Arc::from)))
+            self.transaction.open_record_cursor(t.name()).map(|c| {
+                CursorVectorStore::new(
+                    c,
+                    self.index.config().similarity,
+                    t.format(),
+                    t.centroid().map(Arc::from),
+                )
+            })
         })
     }
 }


### PR DESCRIPTION
Allow specifying a directed graph mode where edges don't have to be reciprocal.

This makes everything simpler except for deletions. Use one of the DiskANN algorithms for deletions where we examine all two hop neighbors to figure out if they are affected by this deletion, which aligns well with RNG pruning.

On the voyage 3.5 dbpedia data set this results in slightly lower recall (0.969399 vs 0.971998) but is slightly faster to build and results in fewer candidates during search which lowers costs. This might be in part a result of reachability issues detected by the new tool added. Reachability rate is pretty small (31 of ~1.9M) but still exists which is bad.