### PR TITLE
Utilities for measuring spann head indexing techniques

### DIFF
--- a/et/Cargo.toml
+++ b/et/Cargo.toml
@@ -14,6 +14,8 @@ histogram = "0.11.3"
 indicatif = { version = "0.17.8", features = ["rayon"] }
 memmap2 = { version = "0.9.5", features = ["stable_deref_trait"] }
 rand = "0.9.1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 rand_xoshiro = "0.7.0"
 rayon = "1.10.0"
 stable_deref_trait = "1.2.0"

--- a/et/src/flat.rs
+++ b/et/src/flat.rs
@@ -1,0 +1,72 @@
+mod drop_index;
+mod init_index;
+mod insert_vectors;
+mod search;
+
+use std::{io, num::NonZero, sync::Arc};
+
+use clap::{Args, Subcommand};
+use easy_tiger::vamana::wt::read_app_metadata;
+use serde::{Deserialize, Serialize};
+use vectors::{F32VectorCoding, VectorSimilarity};
+use wt_mdb::Connection;
+
+use crate::wt_args::WiredTigerArgs;
+use drop_index::drop_index;
+use init_index::{InitIndexArgs, init_index};
+use insert_vectors::{InsertVectorsArgs, insert_vectors};
+use search::{SearchArgs, search};
+
+#[derive(Serialize, Deserialize)]
+pub(super) struct FlatIndexConfig {
+    pub(super) dimensions: NonZero<usize>,
+    pub(super) similarity: VectorSimilarity,
+    pub(super) format: F32VectorCoding,
+}
+
+fn flat_table_name(index_name: &str) -> String {
+    format!("{index_name}_flat")
+}
+
+fn open_config(connection: &Arc<Connection>, table_name: &str) -> io::Result<FlatIndexConfig> {
+    let txn = connection.begin_transaction(None)?;
+    let metadata = read_app_metadata(&txn, table_name)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "flat index table not found"))??;
+    serde_json::from_str(&metadata)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+}
+
+#[derive(Args)]
+pub struct FlatArgs {
+    #[command(flatten)]
+    wt: WiredTigerArgs,
+
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+pub enum Command {
+    /// Initialize a new flat index.
+    InitIndex(InitIndexArgs),
+    /// Remove an existing flat index.
+    DropIndex,
+    /// Insert vectors into an existing flat index.
+    InsertVectors(InsertVectorsArgs),
+    /// Search a flat index exhaustively.
+    Search(SearchArgs),
+}
+
+pub fn flat_command(args: FlatArgs) -> io::Result<()> {
+    let cmd_connection = args.wt.open_connection()?;
+    let connection = Arc::clone(&cmd_connection);
+    let index_name = args.wt.index_name();
+    match args.command {
+        Command::InitIndex(args) => init_index(connection, index_name, args),
+        Command::DropIndex => drop_index(connection, index_name),
+        Command::InsertVectors(args) => insert_vectors(connection, index_name, args),
+        Command::Search(args) => search(connection, index_name, args),
+    }?;
+    cmd_connection.checkpoint()?;
+    Ok(())
+}

--- a/et/src/flat/drop_index.rs
+++ b/et/src/flat/drop_index.rs
@@ -1,0 +1,14 @@
+use std::{io, sync::Arc};
+
+use wt_mdb::{Connection, connection::DropOptionsBuilder};
+
+use super::flat_table_name;
+
+pub fn drop_index(connection: Arc<Connection>, index_name: &str) -> io::Result<()> {
+    connection
+        .drop_table(
+            &flat_table_name(index_name),
+            Some(DropOptionsBuilder::default().set_force().into()),
+        )
+        .map_err(io::Error::from)
+}

--- a/et/src/flat/init_index.rs
+++ b/et/src/flat/init_index.rs
@@ -1,0 +1,56 @@
+use std::{io, num::NonZero, sync::Arc};
+
+use clap::Args;
+use vectors::{F32VectorCoding, VectorSimilarity};
+use wt_mdb::{Connection, connection::{CreateOptionsBuilder, DropOptionsBuilder}};
+
+use super::{FlatIndexConfig, flat_table_name};
+
+#[derive(Args)]
+pub struct InitIndexArgs {
+    /// Number of dimensions in input vectors.
+    #[arg(short, long)]
+    dimensions: NonZero<usize>,
+    /// Similarity function to use for vector scoring.
+    #[arg(short, long, value_enum)]
+    similarity: VectorSimilarity,
+    /// Encoding format for stored vectors.
+    #[arg(short, long)]
+    format: F32VectorCoding,
+    /// If true, drop any existing table with the same name before creating.
+    #[arg(long, default_value_t = false)]
+    drop_tables: bool,
+}
+
+pub fn init_index(
+    connection: Arc<Connection>,
+    index_name: &str,
+    args: InitIndexArgs,
+) -> io::Result<()> {
+    let table_name = flat_table_name(index_name);
+    if args.drop_tables {
+        connection
+            .drop_table(
+                &table_name,
+                Some(DropOptionsBuilder::default().set_force().into()),
+            )
+            .map_err(io::Error::from)?;
+    }
+
+    let config = FlatIndexConfig {
+        dimensions: args.dimensions,
+        similarity: args.similarity,
+        format: args.format,
+    };
+    let metadata = serde_json::to_string(&config).expect("serializable config");
+    connection
+        .create_table(
+            &table_name,
+            Some(
+                CreateOptionsBuilder::default()
+                    .app_metadata(&metadata)
+                    .into(),
+            ),
+        )
+        .map_err(io::Error::from)
+}

--- a/et/src/flat/insert_vectors.rs
+++ b/et/src/flat/insert_vectors.rs
@@ -1,0 +1,89 @@
+use std::{fs::File, io, num::NonZero, path::PathBuf, sync::Arc};
+
+use clap::Args;
+use easy_tiger::input::{DerefVectorStore, VectorStore};
+use wt_mdb::Connection;
+
+use crate::ui::progress_bar;
+
+use super::{flat_table_name, open_config};
+
+#[derive(Args)]
+pub struct InsertVectorsArgs {
+    /// Path to the input vectors to insert (little-endian f32).
+    #[arg(short, long)]
+    f32_vectors: PathBuf,
+    /// Index of the first vector to insert.
+    #[arg(long, default_value_t = 0)]
+    start: usize,
+    /// Number of vectors to insert. If unset, inserts all vectors from --start to end of file.
+    #[arg(short, long)]
+    count: Option<NonZero<usize>>,
+    /// Number of vectors to insert in each transaction batch.
+    #[arg(long, default_value_t = NonZero::new(256).unwrap())]
+    batch_size: NonZero<usize>,
+}
+
+pub fn insert_vectors(
+    connection: Arc<Connection>,
+    index_name: &str,
+    args: InsertVectorsArgs,
+) -> io::Result<()> {
+    let table_name = flat_table_name(index_name);
+    let config = open_config(&connection, &table_name)?;
+
+    let f32_vectors = DerefVectorStore::new(
+        unsafe { memmap2::Mmap::map(&File::open(args.f32_vectors)?)? },
+        config.dimensions,
+    )?;
+    f32_vectors.data().advise(memmap2::Advice::Sequential)?;
+
+    if args.start > f32_vectors.len() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "--start {} exceeds vector file length {}",
+                args.start,
+                f32_vectors.len()
+            ),
+        ));
+    }
+    let count = args
+        .count
+        .map(|c| c.get())
+        .unwrap_or(f32_vectors.len() - args.start);
+    let end = args.start + count;
+    if end > f32_vectors.len() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "requested range {}..{} exceeds vector file length {}",
+                args.start,
+                end,
+                f32_vectors.len()
+            ),
+        ));
+    }
+
+    let coder = config.format.coder(config.similarity, None);
+    let batch_size = args.batch_size.get();
+    let progress = progress_bar(count, "inserting vectors");
+
+    for batch_start in (args.start..end).step_by(batch_size) {
+        let batch_end = (batch_start + batch_size).min(end);
+        let txn = connection.begin_transaction(None)?;
+        {
+            let mut cursor = txn.open_record_cursor(&table_name)?;
+            for i in batch_start..batch_end {
+                let vector: &[f32] = &f32_vectors[i];
+                let encoded = coder.encode(vector);
+                cursor.set(i as i64, encoded.as_slice())?;
+            }
+        }
+        txn.commit(None)?;
+        progress.inc((batch_end - batch_start) as u64);
+    }
+
+    progress.finish();
+    Ok(())
+}

--- a/et/src/flat/search.rs
+++ b/et/src/flat/search.rs
@@ -1,0 +1,219 @@
+use std::{
+    collections::BinaryHeap,
+    fs::File,
+    io,
+    num::NonZero,
+    ops::Add,
+    path::PathBuf,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use clap::Args;
+use easy_tiger::{Neighbor, input::{DerefVectorStore, VectorStore}};
+use memmap2::Mmap;
+use vectors::QueryVectorDistance;
+use wt_mdb::Connection;
+
+use crate::{
+    recall::{RecallArgs, RecallComputer},
+    ui::progress_bar,
+    wt_stats::WiredTigerConnectionStats,
+};
+
+use super::{FlatIndexConfig, flat_table_name, open_config};
+
+#[derive(Args)]
+pub struct SearchArgs {
+    /// Path to query vectors (little-endian f32).
+    #[arg(short, long)]
+    query_vectors: PathBuf,
+    /// Number of nearest neighbors to return per query.
+    #[arg(short, long)]
+    k: NonZero<usize>,
+    /// Maximum number of queries to run. If unset, run all queries in the vector file.
+    #[arg(short, long)]
+    limit: Option<usize>,
+
+    #[command(flatten)]
+    recall: RecallArgs,
+
+    #[arg(long, default_value = "1")]
+    warmup_iters: usize,
+    #[arg(long, default_value = "2")]
+    test_iters: usize,
+}
+
+pub fn search(connection: Arc<Connection>, index_name: &str, args: SearchArgs) -> io::Result<()> {
+    let table_name = flat_table_name(index_name);
+    let config = open_config(&connection, &table_name)?;
+
+    let query_vectors = DerefVectorStore::new(
+        unsafe { Mmap::map(&File::open(args.query_vectors)?)? },
+        config.dimensions,
+    )?;
+    let limit = args.limit.unwrap_or(query_vectors.len()).min(query_vectors.len());
+
+    let recall_computer = RecallComputer::from_args(args.recall, config.similarity)?;
+    if let Some(computer) = recall_computer.as_ref() {
+        if computer.neighbors_len() < limit {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "neighbors must have at least as many rows as queries ({} vs {})",
+                    computer.neighbors_len(),
+                    limit,
+                ),
+            ));
+        }
+    }
+
+    if args.warmup_iters > 0 {
+        search_phase(
+            "warmup",
+            args.warmup_iters,
+            limit,
+            args.k,
+            &query_vectors,
+            &table_name,
+            &connection,
+            &config,
+            recall_computer.as_ref(),
+        )?;
+    }
+
+    if args.test_iters > 0 {
+        let stats = search_phase(
+            "test",
+            args.test_iters,
+            limit,
+            args.k,
+            &query_vectors,
+            &table_name,
+            &connection,
+            &config,
+            recall_computer.as_ref(),
+        )?;
+
+        println!(
+            "queries {} avg duration {:0.6}s max duration {:0.6}s",
+            stats.count,
+            stats.total_duration.as_secs_f64() / stats.count as f64,
+            stats.max_duration.as_secs_f64(),
+        );
+
+        let wt_stats = WiredTigerConnectionStats::try_from(&connection)?;
+        println!(
+            "WT {:15} bytes read on {:12} lookups",
+            wt_stats.read_bytes, wt_stats.read_ios
+        );
+
+        if let Some((computer, mean_recall)) = recall_computer.zip(stats.mean_recall()) {
+            println!("{}: {:0.6}", computer.label(), mean_recall);
+        }
+    }
+
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn search_phase<Q: Send + Sync>(
+    name: &'static str,
+    iters: usize,
+    limit: usize,
+    k: NonZero<usize>,
+    query_vectors: &DerefVectorStore<f32, Q>,
+    table_name: &str,
+    connection: &Arc<Connection>,
+    config: &FlatIndexConfig,
+    recall_computer: Option<&RecallComputer>,
+) -> io::Result<AggregateSearchStats> {
+    use rayon::prelude::*;
+
+    let query_indices = (0..limit).cycle().take(iters * limit).collect::<Vec<_>>();
+    let progress = progress_bar(query_indices.len(), name);
+    let stats = query_indices
+        .into_par_iter()
+        .map(|qi| {
+            let query: &[f32] = &query_vectors[qi];
+            let distance_fn = config
+                .format
+                .query_distance_asymmetric(config.similarity, query, None);
+            let txn = connection.begin_transaction(None)?;
+            let cursor = txn.open_record_cursor(table_name)?;
+
+            let start = Instant::now();
+            let results = exhaustive_search(k, cursor, distance_fn.as_ref())?;
+            let duration = Instant::now() - start;
+            progress.inc(1);
+            Ok::<_, io::Error>(AggregateSearchStats::new(
+                duration,
+                recall_computer.map(|r| r.compute_recall(qi, &results)),
+            ))
+        })
+        .try_reduce(AggregateSearchStats::default, |a, b| Ok(a + b))?;
+    progress.finish_using_style();
+    Ok(stats)
+}
+
+fn exhaustive_search(
+    k: NonZero<usize>,
+    mut cursor: wt_mdb::RecordCursorGuard<'_>,
+    distance_fn: &dyn QueryVectorDistance,
+) -> io::Result<Vec<Neighbor>> {
+    // Max-heap bounded to k: when full, pop the worst if a new candidate is better.
+    let mut heap: BinaryHeap<Neighbor> = BinaryHeap::with_capacity(k.get() + 1);
+    for entry in cursor.by_ref() {
+        let (record_id, bytes) = entry.map_err(io::Error::from)?;
+        let dist = distance_fn.distance(&bytes);
+        let candidate = Neighbor::new(record_id, dist);
+        heap.push(candidate);
+        if heap.len() > k.get() {
+            heap.pop();
+        }
+    }
+    let mut results: Vec<Neighbor> = heap.into_sorted_vec();
+    results.sort_unstable();
+    Ok(results)
+}
+
+#[derive(Default)]
+struct AggregateSearchStats {
+    count: usize,
+    total_duration: Duration,
+    max_duration: Duration,
+    sum_recall: Option<f64>,
+}
+
+impl AggregateSearchStats {
+    fn new(duration: Duration, recall: Option<f64>) -> Self {
+        Self {
+            count: 1,
+            total_duration: duration,
+            max_duration: duration,
+            sum_recall: recall,
+        }
+    }
+
+    fn mean_recall(&self) -> Option<f64> {
+        self.sum_recall.map(|s| s / self.count as f64)
+    }
+}
+
+impl Add<AggregateSearchStats> for AggregateSearchStats {
+    type Output = AggregateSearchStats;
+
+    fn add(self, rhs: AggregateSearchStats) -> Self::Output {
+        Self {
+            count: self.count + rhs.count,
+            total_duration: self.total_duration + rhs.total_duration,
+            max_duration: self.max_duration.max(rhs.max_duration),
+            sum_recall: self
+                .sum_recall
+                .zip(rhs.sum_recall)
+                .map(|(a, b)| a + b)
+                .or(self.sum_recall)
+                .or(rhs.sum_recall),
+        }
+    }
+}

--- a/et/src/main.rs
+++ b/et/src/main.rs
@@ -1,4 +1,5 @@
 mod compute_neighbors;
+mod flat;
 mod generate;
 mod neighbor_util;
 mod quantization;
@@ -13,6 +14,7 @@ use std::io::{self};
 
 use clap::{Parser, Subcommand};
 use compute_neighbors::{ComputeNeighborsArgs, compute_neighbors};
+use flat::{FlatArgs, flat_command};
 use generate::{GenerateArgs, generate};
 use quantization::{QuantizationArgs, quantization};
 use spann::{SpannArgs, spann_command};
@@ -29,6 +31,8 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
+    /// Perform flat (exhaustive) index operations.
+    Flat(FlatArgs),
     /// Perform SPANN index operations.
     Spann(SpannArgs),
     /// Perform Vamana/DiskANN index operations.
@@ -55,6 +59,7 @@ fn main() -> io::Result<()> {
 
     let cli = Cli::parse();
     match cli.command {
+        Commands::Flat(args) => flat_command(args),
         Commands::Spann(args) => spann_command(args),
         Commands::Vamana(args) => vamana_command(args),
         Commands::ComputeNeighbors(args) => compute_neighbors(args),

--- a/et/src/spann.rs
+++ b/et/src/spann.rs
@@ -1,6 +1,7 @@
 mod bulk_load;
 mod centroid_stats;
 mod drop_index;
+mod export_head;
 mod init_index;
 mod insert_vectors;
 mod rebalance;
@@ -15,6 +16,7 @@ use crate::wt_args::WiredTigerArgs;
 use bulk_load::{BulkLoadArgs, bulk_load};
 use centroid_stats::centroid_stats;
 use drop_index::drop_index;
+use export_head::{ExportHeadArgs, export_head};
 use init_index::{InitIndexArgs, init_index};
 use insert_vectors::{InsertVectorsArgs, insert_vectors};
 use rebalance::{RebalanceArgs, rebalance};
@@ -42,6 +44,8 @@ pub enum Command {
     Search(SearchArgs),
     /// Print centroid assignment statistics.
     CentroidStats,
+    /// Export centroid vectors from the head index as little-endian f32 values.
+    ExportHead(ExportHeadArgs),
     /// Rebalance the SPANN index.
     Rebalance(RebalanceArgs),
     /// Remove an existing index.
@@ -60,6 +64,7 @@ pub fn spann_command(args: SpannArgs) -> io::Result<()> {
         Command::InsertVectors(args) => insert_vectors(connection, index_name, args),
         Command::Search(args) => search(connection, index_name, args),
         Command::CentroidStats => centroid_stats(connection, index_name),
+        Command::ExportHead(args) => export_head(connection, index_name, args),
         Command::Rebalance(args) => rebalance(connection, index_name, args),
         Command::DropIndex => drop_index(connection, index_name),
         Command::VerifyPrimaryAssignments => verify_primary_assignments(connection, index_name),

--- a/et/src/spann/export_head.rs
+++ b/et/src/spann/export_head.rs
@@ -1,0 +1,50 @@
+use std::{
+    fs::File,
+    io::{self, BufWriter, Write},
+    path::PathBuf,
+    sync::Arc,
+};
+
+use clap::Args;
+use easy_tiger::spann::{TableIndex, TransactionIndex};
+use wt_mdb::Connection;
+
+#[derive(Args)]
+pub struct ExportHeadArgs {
+    /// Output file to write centroid vectors as little-endian f32 values.
+    #[arg(short, long)]
+    output: PathBuf,
+}
+
+pub fn export_head(
+    connection: Arc<Connection>,
+    index_name: &str,
+    args: ExportHeadArgs,
+) -> io::Result<()> {
+    let index = Arc::new(TableIndex::from_db(&connection, index_name)?);
+    let txn_idx = TransactionIndex::new(&index, connection.begin_transaction(None)?);
+
+    let hf_table = txn_idx.head().index().high_fidelity_table();
+    let coder = hf_table.new_coder();
+    let table_name = hf_table.name().to_owned();
+
+    let cursor = txn_idx
+        .head()
+        .transaction()
+        .open_record_cursor(&table_name)?;
+
+    let mut out = BufWriter::new(File::create(&args.output)?);
+    for item in cursor {
+        let (key, encoded) = item?;
+        if key < 0 {
+            // Skip the entry point record stored at key -1.
+            continue;
+        }
+        let decoded = coder.decode(&encoded);
+        for &x in decoded.iter() {
+            out.write_all(&x.to_le_bytes())?;
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Add a tool to extract the head index as a flat vector file. This makes it easy to reuse all the other tooling this repo already has  to measure different techniques for querying the head index.

Add a "flat" index implementation on top of WT as a baseline. I suspect that this drowns in WiredTiger overhead and is not very representative but it is a mutable index and comparing to a flat file seems unfair.