### PR TITLE
Make wgpu optional

### DIFF
--- a/et/Cargo.toml
+++ b/et/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2024"
 [dependencies]
 bytemuck = { version = "1.23.1", features = ["derive"] }
 clap = { version = "4.5.20", features = ["derive"] }
-pollster = "0.4"
-wgpu = "29.0.1"
+pollster = { version = "0.4", optional = true }
+wgpu = { version = "29.0.1", optional = true }
 crossbeam-utils = "0.8.21"
 easy_tiger = { path = "../" }
 histogram = "0.11.3"
@@ -28,3 +28,4 @@ wt_sys = { path = "../wt_sys" }
 
 [features]
 serial_search = []
+wgpu = ["dep:wgpu", "dep:pollster"]

--- a/et/src/compute_neighbors/mod.rs
+++ b/et/src/compute_neighbors/mod.rs
@@ -1,4 +1,5 @@
 mod cpu;
+#[cfg(feature = "wgpu")]
 mod gpu;
 
 use std::{io, num::NonZero, path::PathBuf};
@@ -44,11 +45,11 @@ pub struct ComputeNeighborsArgs {
 }
 
 pub fn compute_neighbors(args: ComputeNeighborsArgs) -> io::Result<()> {
+    #[cfg(feature = "wgpu")]
     if let Some(adapter) = gpu::try_adapter()
         && !args.force_cpu
     {
-        gpu::run(adapter, &args)
-    } else {
-        cpu::run(&args)
+        return gpu::run(adapter, &args);
     }
+    cpu::run(&args)
 }

--- a/et/src/main.rs
+++ b/et/src/main.rs
@@ -38,7 +38,7 @@ enum Commands {
     /// Perform Vamana/DiskANN index operations.
     Vamana(VamanaArgs),
     /// Compute the top k neighbors for a set of queries against a set of document vectors.
-    /// Uses GPU acceleration via wgpu if a suitable adapter is available, otherwise CPU.
+    /// Uses GPU acceleration via wgpu if the `wgpu` feature is enabled and a suitable adapter is available, otherwise CPU.
     ComputeNeighbors(ComputeNeighborsArgs),
     /// Quantization related utilities.
     Quantization(QuantizationArgs),
@@ -47,15 +47,14 @@ enum Commands {
 }
 
 fn main() -> io::Result<()> {
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            EnvFilter::builder()
-                .with_default_directive(LevelFilter::INFO.into())
-                .from_env_lossy()
-                .add_directive("wgpu_core=warn".parse().unwrap())
-                .add_directive("wgpu_hal=warn".parse().unwrap()),
-        )
-        .init();
+    let filter = EnvFilter::builder()
+        .with_default_directive(LevelFilter::INFO.into())
+        .from_env_lossy();
+    #[cfg(feature = "wgpu")]
+    let filter = filter
+        .add_directive("wgpu_core=warn".parse().unwrap())
+        .add_directive("wgpu_hal=warn".parse().unwrap());
+    tracing_subscriber::fmt().with_env_filter(filter).init();
 
     let cli = Cli::parse();
     match cli.command {


### PR DESCRIPTION
I don't use the gpu integration frequently as it's only for exhaustive search. Make it a feature so I only have to compile it when I plan to use it.