### PR TITLE
Factor flat index support out into the library

### DIFF
--- a/et/src/flat.rs
+++ b/et/src/flat.rs
@@ -25,15 +25,14 @@ pub(super) struct FlatIndexConfig {
 }
 
 fn flat_table_name(index_name: &str) -> String {
-    format!("{index_name}_flat")
+    index_name.to_string()
 }
 
 fn open_config(connection: &Arc<Connection>, table_name: &str) -> io::Result<FlatIndexConfig> {
     let txn = connection.begin_transaction(None)?;
     let metadata = read_app_metadata(&txn, table_name)
         .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "flat index table not found"))??;
-    serde_json::from_str(&metadata)
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+    serde_json::from_str(&metadata).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
 }
 
 #[derive(Args)]

--- a/et/src/flat.rs
+++ b/et/src/flat.rs
@@ -3,37 +3,15 @@ mod init_index;
 mod insert_vectors;
 mod search;
 
-use std::{io, num::NonZero, sync::Arc};
+use std::{io, sync::Arc};
 
 use clap::{Args, Subcommand};
-use easy_tiger::vamana::wt::read_app_metadata;
-use serde::{Deserialize, Serialize};
-use vectors::{F32VectorCoding, VectorSimilarity};
-use wt_mdb::Connection;
 
 use crate::wt_args::WiredTigerArgs;
 use drop_index::drop_index;
 use init_index::{InitIndexArgs, init_index};
 use insert_vectors::{InsertVectorsArgs, insert_vectors};
 use search::{SearchArgs, search};
-
-#[derive(Serialize, Deserialize)]
-pub(super) struct FlatIndexConfig {
-    pub(super) dimensions: NonZero<usize>,
-    pub(super) similarity: VectorSimilarity,
-    pub(super) format: F32VectorCoding,
-}
-
-fn flat_table_name(index_name: &str) -> String {
-    index_name.to_string()
-}
-
-fn open_config(connection: &Arc<Connection>, table_name: &str) -> io::Result<FlatIndexConfig> {
-    let txn = connection.begin_transaction(None)?;
-    let metadata = read_app_metadata(&txn, table_name)
-        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "flat index table not found"))??;
-    serde_json::from_str(&metadata).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
-}
 
 #[derive(Args)]
 pub struct FlatArgs {

--- a/et/src/flat/drop_index.rs
+++ b/et/src/flat/drop_index.rs
@@ -1,14 +1,12 @@
 use std::{io, sync::Arc};
 
+use easy_tiger::flat;
 use wt_mdb::{Connection, connection::DropOptionsBuilder};
 
-use super::flat_table_name;
-
 pub fn drop_index(connection: Arc<Connection>, index_name: &str) -> io::Result<()> {
-    connection
-        .drop_table(
-            &flat_table_name(index_name),
-            Some(DropOptionsBuilder::default().set_force().into()),
-        )
-        .map_err(io::Error::from)
+    flat::drop_index(
+        &connection,
+        index_name,
+        Some(DropOptionsBuilder::default().set_force().into()),
+    )
 }

--- a/et/src/flat/init_index.rs
+++ b/et/src/flat/init_index.rs
@@ -1,10 +1,9 @@
 use std::{io, num::NonZero, sync::Arc};
 
 use clap::Args;
+use easy_tiger::flat::{self, FlatIndexConfig};
 use vectors::{F32VectorCoding, VectorSimilarity};
-use wt_mdb::{Connection, connection::{CreateOptionsBuilder, DropOptionsBuilder}};
-
-use super::{FlatIndexConfig, flat_table_name};
+use wt_mdb::{Connection, connection::DropOptionsBuilder};
 
 #[derive(Args)]
 pub struct InitIndexArgs {
@@ -27,14 +26,12 @@ pub fn init_index(
     index_name: &str,
     args: InitIndexArgs,
 ) -> io::Result<()> {
-    let table_name = flat_table_name(index_name);
     if args.drop_tables {
-        connection
-            .drop_table(
-                &table_name,
-                Some(DropOptionsBuilder::default().set_force().into()),
-            )
-            .map_err(io::Error::from)?;
+        flat::drop_index(
+            &connection,
+            index_name,
+            Some(DropOptionsBuilder::default().set_force().into()),
+        )?;
     }
 
     let config = FlatIndexConfig {
@@ -42,15 +39,5 @@ pub fn init_index(
         similarity: args.similarity,
         format: args.format,
     };
-    let metadata = serde_json::to_string(&config).expect("serializable config");
-    connection
-        .create_table(
-            &table_name,
-            Some(
-                CreateOptionsBuilder::default()
-                    .app_metadata(&metadata)
-                    .into(),
-            ),
-        )
-        .map_err(io::Error::from)
+    flat::init_index(&connection, index_name, &config)
 }

--- a/et/src/flat/insert_vectors.rs
+++ b/et/src/flat/insert_vectors.rs
@@ -1,12 +1,13 @@
 use std::{fs::File, io, num::NonZero, path::PathBuf, sync::Arc};
 
 use clap::Args;
-use easy_tiger::input::{DerefVectorStore, VectorStore};
+use easy_tiger::{
+    flat,
+    input::{DerefVectorStore, VectorStore},
+};
 use wt_mdb::Connection;
 
 use crate::ui::progress_bar;
-
-use super::{flat_table_name, open_config};
 
 #[derive(Args)]
 pub struct InsertVectorsArgs {
@@ -29,8 +30,8 @@ pub fn insert_vectors(
     index_name: &str,
     args: InsertVectorsArgs,
 ) -> io::Result<()> {
-    let table_name = flat_table_name(index_name);
-    let config = open_config(&connection, &table_name)?;
+    let config = flat::open_config(&connection, index_name)?;
+    let table_name = flat::table_name(index_name);
 
     let f32_vectors = DerefVectorStore::new(
         unsafe { memmap2::Mmap::map(&File::open(args.f32_vectors)?)? },

--- a/et/src/flat/search.rs
+++ b/et/src/flat/search.rs
@@ -1,7 +1,7 @@
+use core::f64;
 use std::{
-    collections::BinaryHeap,
     fs::File,
-    io,
+    i64, io,
     num::NonZero,
     ops::Add,
     path::PathBuf,
@@ -10,7 +10,10 @@ use std::{
 };
 
 use clap::Args;
-use easy_tiger::{Neighbor, input::{DerefVectorStore, VectorStore}};
+use easy_tiger::{
+    Neighbor,
+    input::{DerefVectorStore, VectorStore},
+};
 use memmap2::Mmap;
 use vectors::QueryVectorDistance;
 use wt_mdb::Connection;
@@ -52,7 +55,10 @@ pub fn search(connection: Arc<Connection>, index_name: &str, args: SearchArgs) -
         unsafe { Mmap::map(&File::open(args.query_vectors)?)? },
         config.dimensions,
     )?;
-    let limit = args.limit.unwrap_or(query_vectors.len()).min(query_vectors.len());
+    let limit = args
+        .limit
+        .unwrap_or(query_vectors.len())
+        .min(query_vectors.len());
 
     let recall_computer = RecallComputer::from_args(args.recall, config.similarity)?;
     if let Some(computer) = recall_computer.as_ref() {
@@ -136,9 +142,10 @@ fn search_phase<Q: Send + Sync>(
         .into_par_iter()
         .map(|qi| {
             let query: &[f32] = &query_vectors[qi];
-            let distance_fn = config
-                .format
-                .query_distance_asymmetric(config.similarity, query, None);
+            let distance_fn =
+                config
+                    .format
+                    .query_distance_asymmetric(config.similarity, query, None);
             let txn = connection.begin_transaction(None)?;
             let cursor = txn.open_record_cursor(table_name)?;
 
@@ -161,19 +168,27 @@ fn exhaustive_search(
     mut cursor: wt_mdb::RecordCursorGuard<'_>,
     distance_fn: &dyn QueryVectorDistance,
 ) -> io::Result<Vec<Neighbor>> {
-    // Max-heap bounded to k: when full, pop the worst if a new candidate is better.
-    let mut heap: BinaryHeap<Neighbor> = BinaryHeap::with_capacity(k.get() + 1);
-    for entry in cursor.by_ref() {
+    // Accumulate the top k values. When the buffer is full we select the top N and store a min
+    // competitive result to act as a ratchet. This is _much_ cheaper than a heap, especially since
+    // we aren't going to do anything meaningful with the heap.
+    let mut results = Vec::with_capacity(k.get() * 2);
+    let mut min_competitive = Neighbor::new(i64::MAX, f64::MAX);
+    while let Some(entry) = unsafe { cursor.next_unsafe() } {
         let (record_id, bytes) = entry.map_err(io::Error::from)?;
         let dist = distance_fn.distance(&bytes);
         let candidate = Neighbor::new(record_id, dist);
-        heap.push(candidate);
-        if heap.len() > k.get() {
-            heap.pop();
+        if candidate > min_competitive {
+            continue;
+        }
+        results.push(candidate);
+        if results.len() == results.capacity() {
+            results.select_nth_unstable(k.get());
+            min_competitive = results[k.get()];
+            results.truncate(k.get());
         }
     }
-    let mut results: Vec<Neighbor> = heap.into_sorted_vec();
     results.sort_unstable();
+    results.truncate(k.get());
     Ok(results)
 }
 

--- a/et/src/flat/search.rs
+++ b/et/src/flat/search.rs
@@ -1,7 +1,6 @@
-use core::f64;
 use std::{
     fs::File,
-    i64, io,
+    io,
     num::NonZero,
     ops::Add,
     path::PathBuf,
@@ -11,11 +10,10 @@ use std::{
 
 use clap::Args;
 use easy_tiger::{
-    Neighbor,
+    flat::{self, search::exhaustive_search, FlatIndexConfig},
     input::{DerefVectorStore, VectorStore},
 };
 use memmap2::Mmap;
-use vectors::QueryVectorDistance;
 use wt_mdb::Connection;
 
 use crate::{
@@ -23,8 +21,6 @@ use crate::{
     ui::progress_bar,
     wt_stats::WiredTigerConnectionStats,
 };
-
-use super::{FlatIndexConfig, flat_table_name, open_config};
 
 #[derive(Args)]
 pub struct SearchArgs {
@@ -48,8 +44,8 @@ pub struct SearchArgs {
 }
 
 pub fn search(connection: Arc<Connection>, index_name: &str, args: SearchArgs) -> io::Result<()> {
-    let table_name = flat_table_name(index_name);
-    let config = open_config(&connection, &table_name)?;
+    let config = flat::open_config(&connection, index_name)?;
+    let table_name = flat::table_name(index_name);
 
     let query_vectors = DerefVectorStore::new(
         unsafe { Mmap::map(&File::open(args.query_vectors)?)? },
@@ -161,35 +157,6 @@ fn search_phase<Q: Send + Sync>(
         .try_reduce(AggregateSearchStats::default, |a, b| Ok(a + b))?;
     progress.finish_using_style();
     Ok(stats)
-}
-
-fn exhaustive_search(
-    k: NonZero<usize>,
-    mut cursor: wt_mdb::RecordCursorGuard<'_>,
-    distance_fn: &dyn QueryVectorDistance,
-) -> io::Result<Vec<Neighbor>> {
-    // Accumulate the top k values. When the buffer is full we select the top N and store a min
-    // competitive result to act as a ratchet. This is _much_ cheaper than a heap, especially since
-    // we aren't going to do anything meaningful with the heap.
-    let mut results = Vec::with_capacity(k.get() * 2);
-    let mut min_competitive = Neighbor::new(i64::MAX, f64::MAX);
-    while let Some(entry) = unsafe { cursor.next_unsafe() } {
-        let (record_id, bytes) = entry.map_err(io::Error::from)?;
-        let dist = distance_fn.distance(&bytes);
-        let candidate = Neighbor::new(record_id, dist);
-        if candidate > min_competitive {
-            continue;
-        }
-        results.push(candidate);
-        if results.len() == results.capacity() {
-            results.select_nth_unstable(k.get());
-            min_competitive = results[k.get()];
-            results.truncate(k.get());
-        }
-    }
-    results.sort_unstable();
-    results.truncate(k.get());
-    Ok(results)
 }
 
 #[derive(Default)]

--- a/src/flat.rs
+++ b/src/flat.rs
@@ -1,0 +1,64 @@
+//! A flat (exhaustive) vector index backed by WiredTiger.
+
+pub mod search;
+
+use std::{io, num::NonZero, sync::Arc};
+
+use serde::{Deserialize, Serialize};
+use vectors::{F32VectorCoding, VectorSimilarity};
+use wt_mdb::{
+    Connection,
+    connection::{CreateOptionsBuilder, DropOptions},
+};
+
+use crate::vamana::wt::read_app_metadata;
+
+/// Configuration for a flat vector index.
+#[derive(Serialize, Deserialize, Clone)]
+pub struct FlatIndexConfig {
+    pub dimensions: NonZero<usize>,
+    pub similarity: VectorSimilarity,
+    pub format: F32VectorCoding,
+}
+
+/// Returns the WiredTiger table name for a flat index.
+pub fn table_name(index_name: &str) -> String {
+    index_name.to_string()
+}
+
+/// Reads the config for an existing flat index from the database.
+pub fn open_config(connection: &Arc<Connection>, index_name: &str) -> io::Result<FlatIndexConfig> {
+    let txn = connection.begin_transaction(None)?;
+    let metadata = read_app_metadata(&txn, &table_name(index_name))
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "flat index table not found"))??;
+    serde_json::from_str(&metadata).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+}
+
+/// Creates a new flat index table and stores `config` in its app metadata.
+pub fn init_index(
+    connection: &Arc<Connection>,
+    index_name: &str,
+    config: &FlatIndexConfig,
+) -> io::Result<()> {
+    connection
+        .create_table(
+            &table_name(index_name),
+            Some(
+                CreateOptionsBuilder::default()
+                    .app_metadata(&serde_json::to_string(config)?)
+                    .into(),
+            ),
+        )
+        .map_err(io::Error::from)
+}
+
+/// Drops the table backing a flat index.
+pub fn drop_index(
+    connection: &Arc<Connection>,
+    index_name: &str,
+    options: Option<DropOptions>,
+) -> io::Result<()> {
+    connection
+        .drop_table(&table_name(index_name), options)
+        .map_err(io::Error::from)
+}

--- a/src/flat/search.rs
+++ b/src/flat/search.rs
@@ -1,0 +1,37 @@
+//! Exhaustive (flat) vector search.
+
+use std::{io, num::NonZero};
+
+use vectors::QueryVectorDistance;
+use wt_mdb::RecordCursorGuard;
+
+use crate::Neighbor;
+
+/// Search `cursor` exhaustively and return the `k` nearest neighbors by `distance_fn`.
+pub fn exhaustive_search(
+    k: NonZero<usize>,
+    mut cursor: RecordCursorGuard<'_>,
+    distance_fn: &dyn QueryVectorDistance,
+) -> io::Result<Vec<Neighbor>> {
+    // Accumulate the top k values. When the buffer is full we select the top N and store a min
+    // competitive result to act as a ratchet. This is much cheaper than a heap.
+    let mut results = Vec::with_capacity(k.get() * 2);
+    let mut min_competitive = Neighbor::new(i64::MAX, f64::MAX);
+    while let Some(entry) = unsafe { cursor.next_unsafe() } {
+        let (record_id, bytes) = entry.map_err(io::Error::from)?;
+        let dist = distance_fn.distance(bytes);
+        let candidate = Neighbor::new(record_id, dist);
+        if candidate > min_competitive {
+            continue;
+        }
+        results.push(candidate);
+        if results.len() == results.capacity() {
+            results.select_nth_unstable(k.get());
+            min_competitive = results[k.get()];
+            results.truncate(k.get());
+        }
+    }
+    results.sort_unstable();
+    results.truncate(k.get());
+    Ok(results)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 //! another table as a projection of vector data from that source. Underneath a
 //! graph-based DiskANN index is used to serve vector similarity queries.
 
+pub mod flat;
 pub mod input;
 pub mod kmeans;
 pub mod spann;


### PR DESCRIPTION
This was all inline in `et` but it may be useful as a separate concept/stalking horse.

Make search about 20% faster:
* Alias memory in WT cache instead of copying it.
* Top K accumulates with periodic pruning and a min competitive result check. This is faster than a heap, and we aren't going to use any intermediate heap state.