### PR TITLE
Implement posting blocks for flat indexes

### DIFF
--- a/et/src/flat/init_index.rs
+++ b/et/src/flat/init_index.rs
@@ -3,7 +3,7 @@ use std::{io, num::NonZero, sync::Arc};
 use clap::Args;
 use easy_tiger::flat::{self, FlatIndexConfig};
 use vectors::{F32VectorCoding, VectorSimilarity};
-use wt_mdb::{Connection, connection::DropOptionsBuilder};
+use wt_mdb::{connection::DropOptionsBuilder, Connection};
 
 #[derive(Args)]
 pub struct InitIndexArgs {
@@ -16,6 +16,9 @@ pub struct InitIndexArgs {
     /// Encoding format for stored vectors.
     #[arg(short, long)]
     format: F32VectorCoding,
+    /// Maximum number of postings per block.
+    #[arg(long)]
+    block_size: NonZero<usize>,
     /// If true, drop any existing table with the same name before creating.
     #[arg(long, default_value_t = false)]
     drop_tables: bool,
@@ -38,6 +41,7 @@ pub fn init_index(
         dimensions: args.dimensions,
         similarity: args.similarity,
         format: args.format,
+        block_size: args.block_size,
     };
     flat::init_index(&connection, index_name, &config)
 }

--- a/et/src/flat/insert_vectors.rs
+++ b/et/src/flat/insert_vectors.rs
@@ -4,6 +4,7 @@ use clap::Args;
 use easy_tiger::{
     flat,
     input::{DerefVectorStore, VectorStore},
+    posting_block,
 };
 use wt_mdb::Connection;
 
@@ -20,9 +21,6 @@ pub struct InsertVectorsArgs {
     /// Number of vectors to insert. If unset, inserts all vectors from --start to end of file.
     #[arg(short, long)]
     count: Option<NonZero<usize>>,
-    /// Number of vectors to insert in each transaction batch.
-    #[arg(long, default_value_t = NonZero::new(256).unwrap())]
-    batch_size: NonZero<usize>,
 }
 
 pub fn insert_vectors(
@@ -67,20 +65,19 @@ pub fn insert_vectors(
     }
 
     let coder = config.format.coder(config.similarity, None);
-    let batch_size = args.batch_size.get();
+    let batch_size = config.block_size.get();
     let progress = progress_bar(count, "inserting vectors");
 
     for batch_start in (args.start..end).step_by(batch_size) {
         let batch_end = (batch_start + batch_size).min(end);
+        let block = posting_block::encode_f32(
+            (batch_start..batch_end).map(|i| (i as i64, &f32_vectors[i])),
+            coder.as_ref(),
+            config.dimensions.get(),
+        );
         let txn = connection.begin_transaction(None)?;
-        {
-            let mut cursor = txn.open_record_cursor(&table_name)?;
-            for i in batch_start..batch_end {
-                let vector: &[f32] = &f32_vectors[i];
-                let encoded = coder.encode(vector);
-                cursor.set(i as i64, encoded.as_slice())?;
-            }
-        }
+        txn.open_record_cursor(&table_name)?
+            .set(batch_end as i64, &block)?;
         txn.commit(None)?;
         progress.inc((batch_end - batch_start) as u64);
     }

--- a/et/src/flat/search.rs
+++ b/et/src/flat/search.rs
@@ -132,6 +132,10 @@ fn search_phase<Q: Send + Sync>(
 ) -> io::Result<AggregateSearchStats> {
     use rayon::prelude::*;
 
+    let vector_len = config
+        .format
+        .coder(config.similarity, None)
+        .byte_len(config.dimensions.get());
     let query_indices = (0..limit).cycle().take(iters * limit).collect::<Vec<_>>();
     let progress = progress_bar(query_indices.len(), name);
     let stats = query_indices
@@ -146,7 +150,7 @@ fn search_phase<Q: Send + Sync>(
             let cursor = txn.open_record_cursor(table_name)?;
 
             let start = Instant::now();
-            let results = exhaustive_search(k, cursor, distance_fn.as_ref())?;
+            let results = exhaustive_search(cursor, vector_len, distance_fn.as_ref(), k)?;
             let duration = Instant::now() - start;
             progress.inc(1);
             Ok::<_, io::Error>(AggregateSearchStats::new(

--- a/src/flat.rs
+++ b/src/flat.rs
@@ -7,8 +7,8 @@ use std::{io, num::NonZero, sync::Arc};
 use serde::{Deserialize, Serialize};
 use vectors::{F32VectorCoding, VectorSimilarity};
 use wt_mdb::{
-    Connection,
     connection::{CreateOptionsBuilder, DropOptions},
+    Connection,
 };
 
 use crate::vamana::wt::read_app_metadata;
@@ -19,6 +19,7 @@ pub struct FlatIndexConfig {
     pub dimensions: NonZero<usize>,
     pub similarity: VectorSimilarity,
     pub format: F32VectorCoding,
+    pub block_size: NonZero<usize>,
 }
 
 /// Returns the WiredTiger table name for a flat index.
@@ -40,12 +41,22 @@ pub fn init_index(
     index_name: &str,
     config: &FlatIndexConfig,
 ) -> io::Result<()> {
+    let leaf_page_size = crate::posting_block::leaf_page_max(
+        config.block_size.get(),
+        config
+            .format
+            .coder(config.similarity, None)
+            .byte_len(config.dimensions.get()),
+        4096,
+    ) as u32;
     connection
         .create_table(
             &table_name(index_name),
             Some(
                 CreateOptionsBuilder::default()
                     .app_metadata(&serde_json::to_string(config)?)
+                    .leaf_page_max(leaf_page_size)
+                    .leaf_value_max(leaf_page_size)
                     .into(),
             ),
         )

--- a/src/flat/search.rs
+++ b/src/flat/search.rs
@@ -5,30 +5,35 @@ use std::{io, num::NonZero};
 use vectors::QueryVectorDistance;
 use wt_mdb::RecordCursorGuard;
 
+use crate::posting_block::PostingBlock;
 use crate::Neighbor;
 
 /// Search `cursor` exhaustively and return the `k` nearest neighbors by `distance_fn`.
 pub fn exhaustive_search(
-    k: NonZero<usize>,
     mut cursor: RecordCursorGuard<'_>,
+    vector_len: usize,
     distance_fn: &dyn QueryVectorDistance,
+    k: NonZero<usize>,
 ) -> io::Result<Vec<Neighbor>> {
     // Accumulate the top k values. When the buffer is full we select the top N and store a min
     // competitive result to act as a ratchet. This is much cheaper than a heap.
     let mut results = Vec::with_capacity(k.get() * 2);
     let mut min_competitive = Neighbor::new(i64::MAX, f64::MAX);
     while let Some(entry) = unsafe { cursor.next_unsafe() } {
-        let (record_id, bytes) = entry.map_err(io::Error::from)?;
-        let dist = distance_fn.distance(bytes);
-        let candidate = Neighbor::new(record_id, dist);
-        if candidate > min_competitive {
-            continue;
-        }
-        results.push(candidate);
-        if results.len() == results.capacity() {
-            results.select_nth_unstable(k.get());
-            min_competitive = results[k.get()];
-            results.truncate(k.get());
+        let (_, block_bytes) = entry.map_err(io::Error::from)?;
+        let block = PostingBlock::new(block_bytes, vector_len).expect("valid block");
+        for (id, vector) in block.iter() {
+            let dist = distance_fn.distance(vector);
+            let candidate = Neighbor::new(id, dist);
+            if candidate > min_competitive {
+                continue;
+            }
+            results.push(candidate);
+            if results.len() == results.capacity() {
+                results.select_nth_unstable(k.get());
+                min_competitive = results[k.get()];
+                results.truncate(k.get());
+            }
         }
     }
     results.sort_unstable();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 pub mod flat;
 pub mod input;
 pub mod kmeans;
-mod posting_block;
+pub mod posting_block;
 pub mod spann;
 pub mod vamana;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod flat;
 pub mod input;
 pub mod kmeans;
+mod posting_block;
 pub mod spann;
 pub mod vamana;
 

--- a/src/posting_block.rs
+++ b/src/posting_block.rs
@@ -1,0 +1,74 @@
+//! Format for a block of vector postings.
+//!
+//! Each posting consists of a 64-bit identifier and a fixed byte size vector.
+//!
+//! Within each block the identifier and vector are fixed size, so the number of entries in the
+//! block is inferred from the byte size of the block. Identifiers are stored before the rest of
+//! the vector to allow mutation without having to visit every byte in the block.
+
+#[derive(Debug, Clone)]
+pub struct PostingBlock<'a> {
+    ids: &'a [[u8; 8]],
+    vectors: &'a [u8],
+    vector_len: usize,
+}
+
+impl<'a> PostingBlock<'a> {
+    /// Create a new posting block from some input where each vector fills `vector_len` bytes.
+    ///
+    /// Returns `None` if the input data length does not align with an integer entry count.
+    pub fn new(data: &'a [u8], vector_len: usize) -> Option<Self> {
+        let entry_len = vector_len + std::mem::size_of::<u64>();
+        if data.len() % entry_len == 0 {
+            return None;
+        }
+        let len = data.len() / entry_len;
+        let split = len * std::mem::size_of::<u64>();
+        let (ids, vectors) = data.split_at(split);
+        Some(Self {
+            ids: ids.as_chunks::<{ std::mem::size_of::<u64>() }>().0,
+            vectors,
+            vector_len,
+        })
+    }
+
+    /// Return an iterator over the vectors in the posting block and their ids.
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = (u64, &'a [u8])> {
+        self.ids
+            .iter()
+            .copied()
+            .map(u64::from_le_bytes)
+            .zip(self.vectors.chunks(self.vector_len))
+    }
+}
+
+/// Encode vectors each of `vector_len` bytes along with their identifiers to a vec of bytes.
+fn encode_to<'a>(
+    vectors: impl ExactSizeIterator<Item = (u64, &'a [u8])>,
+    vector_len: usize,
+    out: &mut Vec<u8>,
+) {
+    let ids_len = vectors.len() * std::mem::size_of::<u64>();
+    out.resize(ids_len + vectors.len() * vector_len, 0);
+    let (ids_out, vectors_out) = out.split_at_mut(ids_len);
+    let out_it = ids_out
+        .as_chunks_mut::<{ std::mem::size_of::<u64>() }>()
+        .0
+        .iter_mut()
+        .zip(vectors_out.chunks_mut(vector_len));
+    for (v, o) in vectors.zip(out_it) {
+        *o.0 = v.0.to_le_bytes();
+        o.1.copy_from_slice(v.1);
+    }
+}
+
+/// Encode vectors each of `vector_len` bytes along with their identifiers to a vec of bytes.
+fn encode<'a>(
+    vectors: impl ExactSizeIterator<Item = (u64, &'a [u8])>,
+    vector_len: usize,
+) -> Vec<u8> {
+    let len = vectors.len() * (vector_len + std::mem::size_of::<u64>());
+    let mut out = Vec::with_capacity(len);
+    encode_to(vectors, vector_len, &mut out);
+    out
+}

--- a/src/posting_block.rs
+++ b/src/posting_block.rs
@@ -6,6 +6,8 @@
 //! block is inferred from the byte size of the block. Identifiers are stored before the rest of
 //! the vector to allow mutation without having to visit every byte in the block.
 
+use vectors::F32VectorCoder;
+
 #[derive(Debug, Clone)]
 pub struct PostingBlock<'a> {
     ids: &'a [[u8; 8]],
@@ -18,57 +20,55 @@ impl<'a> PostingBlock<'a> {
     ///
     /// Returns `None` if the input data length does not align with an integer entry count.
     pub fn new(data: &'a [u8], vector_len: usize) -> Option<Self> {
-        let entry_len = vector_len + std::mem::size_of::<u64>();
-        if data.len() % entry_len == 0 {
+        let entry_len = vector_len + std::mem::size_of::<i64>();
+        if !data.len().is_multiple_of(entry_len) {
             return None;
         }
         let len = data.len() / entry_len;
-        let split = len * std::mem::size_of::<u64>();
+        let split = len * std::mem::size_of::<i64>();
         let (ids, vectors) = data.split_at(split);
         Some(Self {
-            ids: ids.as_chunks::<{ std::mem::size_of::<u64>() }>().0,
+            ids: ids.as_chunks::<{ std::mem::size_of::<i64>() }>().0,
             vectors,
             vector_len,
         })
     }
 
     /// Return an iterator over the vectors in the posting block and their ids.
-    pub fn iter(&self) -> impl ExactSizeIterator<Item = (u64, &'a [u8])> {
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = (i64, &'a [u8])> {
         self.ids
             .iter()
             .copied()
-            .map(u64::from_le_bytes)
+            .map(i64::from_le_bytes)
             .zip(self.vectors.chunks(self.vector_len))
     }
 }
 
-/// Encode vectors each of `vector_len` bytes along with their identifiers to a vec of bytes.
-fn encode_to<'a>(
-    vectors: impl ExactSizeIterator<Item = (u64, &'a [u8])>,
-    vector_len: usize,
-    out: &mut Vec<u8>,
-) {
-    let ids_len = vectors.len() * std::mem::size_of::<u64>();
-    out.resize(ids_len + vectors.len() * vector_len, 0);
-    let (ids_out, vectors_out) = out.split_at_mut(ids_len);
-    let out_it = ids_out
-        .as_chunks_mut::<{ std::mem::size_of::<u64>() }>()
+/// Encode a series of input `(id, float vector)` tuples where each vector is of `dim` length using
+/// `coder` and pack them into a posting block.
+pub fn encode_f32(
+    vectors: impl ExactSizeIterator<Item = (i64, impl AsRef<[f32]>)>,
+    coder: &dyn F32VectorCoder,
+    dim: usize,
+) -> Vec<u8> {
+    let ids_len = std::mem::size_of::<i64>() * vectors.len();
+    let vec_len = coder.byte_len(dim);
+    let mut out = vec![0u8; ids_len + vectors.len() * vec_len];
+    let (out_ids, out_vecs) = out.split_at_mut(ids_len);
+    let out_it = out_ids
+        .as_chunks_mut::<{ std::mem::size_of::<i64>() }>()
         .0
         .iter_mut()
-        .zip(vectors_out.chunks_mut(vector_len));
-    for (v, o) in vectors.zip(out_it) {
-        *o.0 = v.0.to_le_bytes();
-        o.1.copy_from_slice(v.1);
+        .zip(out_vecs.chunks_mut(vec_len));
+    for (i, o) in vectors.zip(out_it) {
+        *o.0 = i.0.to_le_bytes();
+        coder.encode_to(i.1.as_ref(), o.1);
     }
+    out
 }
 
-/// Encode vectors each of `vector_len` bytes along with their identifiers to a vec of bytes.
-fn encode<'a>(
-    vectors: impl ExactSizeIterator<Item = (u64, &'a [u8])>,
-    vector_len: usize,
-) -> Vec<u8> {
-    let len = vectors.len() * (vector_len + std::mem::size_of::<u64>());
-    let mut out = Vec::with_capacity(len);
-    encode_to(vectors, vector_len, &mut out);
-    out
+/// Return the expected `leaf_page_max` and `leaf_value_max` sizes that should be used in
+/// WiredTiger given a maximum block size, the length of each vector, and WT's allocation size.
+pub fn leaf_page_max(block_size: usize, vector_len: usize, allocation_size: usize) -> usize {
+    (block_size * (vector_len + std::mem::size_of::<i64>())).next_multiple_of(allocation_size)
 }


### PR DESCRIPTION
Add posting blocks that contain a series of (id, vector) tuples and are stored in the table based on the last entry that appears in the block. This should allow for random access patterns (easy seek-to-vector-block) and support more advanced operations in the future including merge/split and modify.

The motivation for this change is that iterating over individual key/value pairs can use 50% of the CPU in flat indexes. This is obviously not acceptable. Batching values and tuning WT leaf page sizes to essentially pack a single page on our own greatly improves performance, at the cost of no longer being able to perform pinpoint mutations without conflicts.