### PR TITLE
Introduce mutation routines for posting blocks

### DIFF
--- a/src/posting_block.rs
+++ b/src/posting_block.rs
@@ -68,15 +68,33 @@ impl<'a> PostingBlock<'a> {
     }
 }
 
+// XXX this proposal cannot distinguish between an update and a clean entry.
+#[derive(Debug, Clone)]
+struct BuilderEntry {
+    id: i64,
+    // usize::MAX for an insert of a new entry.
+    base_index: usize,
+    // Empty to indicate a delete.
+    vector: Vec<u8>,
+    // True if this entry has been modified.
+    dirty: bool,
+}
+
+impl BuilderEntry {
+    fn vector_tuple(&self) -> Option<(i64, &[u8])> {
+        if !self.vector.is_empty() {
+            Some((self.id, self.vector.as_slice()))
+        } else {
+            None
+        }
+    }
+}
+
 /// Builder for a block of vector posting data.
 ///
 /// Vectors are expected to be fixed size but the format of the data is otherwise undefined.
 #[derive(Debug, Clone, Default)]
-pub struct PostingBlockBuilder {
-    entries: Vec<(i64, Vec<u8>)>,
-    initial_entries: usize,
-    dirty: Vec<i64>,
-}
+pub struct PostingBlockBuilder(Vec<BuilderEntry>);
 
 // XXX this all needs docs.
 impl PostingBlockBuilder {
@@ -84,72 +102,142 @@ impl PostingBlockBuilder {
         Self::default()
     }
 
-    fn from_entries(entries: Vec<(i64, Vec<u8>)>) -> Self {
-        Self {
-            initial_entries: entries.len(),
-            entries,
-            dirty: vec![],
-        }
-    }
-
-    pub fn iter(&self) -> impl ExactSizeIterator<Item = (i64, &[u8])> {
-        self.entries.iter().map(|(i, v)| (*i, v.as_slice()))
+    pub fn iter(&self) -> impl Iterator<Item = (i64, &[u8])> {
+        self.0.iter().filter_map(BuilderEntry::vector_tuple)
     }
 
     pub fn lookup(&self, id: i64) -> Option<&[u8]> {
-        self.entries
-            .binary_search_by_key(&id, |(i, _)| *i)
-            .map(|i| self.entries[i].1.as_slice())
+        self.0
+            .binary_search_by_key(&id, |e| e.id)
+            .map(|i| self.0[i].vector.as_slice())
             .ok()
+            .filter(|v| !v.is_empty())
     }
 
     pub fn upsert(&mut self, id: i64, vector: impl Into<Vec<u8>>) {
-        match self.entries.binary_search_by_key(&id, |(i, _)| *i) {
-            Ok(i) => self.entries[i].1 = vector.into(),
-            Err(i) => self.entries.insert(i, (id, vector.into())),
+        match self.0.binary_search_by_key(&id, |e| e.id) {
+            Ok(i) => {
+                let e = &mut self.0[i];
+                e.vector = vector.into();
+                e.dirty = true;
+            }
+            Err(i) => {
+                self.0.insert(
+                    i,
+                    BuilderEntry {
+                        id,
+                        base_index: usize::MAX,
+                        vector: vector.into(),
+                        dirty: true,
+                    },
+                );
+            }
         }
-        self.mark_dirty(id);
     }
 
     pub fn delete(&mut self, id: i64) {
-        if let Ok(i) = self.entries.binary_search_by_key(&id, |(i, _)| *i) {
-            self.entries.remove(i);
-            self.mark_dirty(id);
+        if let Ok(i) = self.0.binary_search_by_key(&id, |e| e.id) {
+            let e = &mut self.0[i];
+            e.vector.clear();
+            e.dirty = e.base_index != usize::MAX;
         }
     }
 
     pub fn len(&self) -> usize {
-        self.entries.len()
+        self.0.len()
     }
 
     pub fn is_empty(&self) -> bool {
-        self.entries.is_empty()
+        self.0.is_empty()
     }
 
-    // XXX tri-state encode:
-    // * If it's empty, should result in the key being removed.
-    // * If there are too many mutations (~10% of max(entries, dirty)) then flush completely and set
-    // * Otherwise produce a diff.
-    //
-    // I think the state I have is sufficient to decide between 2 and 3.
-
-    fn mark_dirty(&mut self, id: i64) {
-        if let Err(i) = self.dirty.binary_search(&id) {
-            self.dirty.insert(i, id);
+    pub fn build(self) -> EncodedPostingBlock {
+        if self.is_empty() {
+            return EncodedPostingBlock::Remove;
         }
+
+        let vector_len = self.0[0].vector.len();
+        let mut out = vec![0u8; self.len() * (std::mem::size_of::<i64>() + vector_len)];
+        let (ids_out, vectors_out) = out.split_at_mut(self.len() * std::mem::size_of::<i64>());
+        let out_it = ids_out
+            .as_chunks_mut::<{ std::mem::size_of::<i64>() }>()
+            .0
+            .iter_mut()
+            .zip(vectors_out.chunks_mut(vector_len));
+        for (i, o) in self.iter().zip(out_it) {
+            *o.0 = i.0.to_le_bytes();
+            o.1.copy_from_slice(&i.1);
+        }
+        EncodedPostingBlock::Replace(out)
     }
 }
 
 impl<B: Into<Vec<u8>>> FromIterator<(i64, B)> for PostingBlockBuilder {
     fn from_iter<T: IntoIterator<Item = (i64, B)>>(iter: T) -> Self {
-        let entries = iter.into_iter().map(|(id, v)| (id, v.into())).collect();
-        Self::from_entries(entries)
+        Self(
+            iter.into_iter()
+                .enumerate()
+                .map(|(i, (id, v))| BuilderEntry {
+                    id: id,
+                    base_index: i,
+                    vector: v.into(),
+                    dirty: false,
+                })
+                .collect(),
+        )
     }
 }
 
 impl From<PostingBlock<'_>> for PostingBlockBuilder {
     fn from(value: PostingBlock<'_>) -> Self {
         Self::from_iter(value.iter())
+    }
+}
+
+/// An encoded posting block produced by [`PostingBlockBuilder`].
+///
+/// This may represent a remove, set/overwrite, or a delta/modify call.
+#[derive(Debug, Clone)]
+pub enum EncodedPostingBlock {
+    /// This block no longer contains any postings so remove it.
+    Remove,
+    /// Replace the contents of this block with a different value.
+    Replace(Vec<u8>),
+}
+
+enum PostingDelta {
+    Upsert(usize, [u8; 8], Vec<u8>),
+    Delete(usize),
+}
+
+pub struct PostingBlockDelta(Vec<PostingDelta>);
+
+impl PostingBlockDelta {
+    fn from_builder(builder: PostingBlockBuilder) -> Self {
+        // XXX the indexes are wrong here.
+        // i need to track the base index and the output index.
+        // i need to distinguish between insert and update
+        // * inserts only need to know the next output index.
+        // * updates and deletes need to track where base_index is in the output
+        PostingBlockDelta(
+            builder
+                .0
+                .into_iter()
+                .filter(|e| e.dirty)
+                .map(|e| {
+                    if e.vector.is_empty() {
+                        assert_ne!(e.base_index, usize::MAX);
+                        PostingDelta::Delete(e.base_index)
+                    } else {
+                        PostingDelta::Upsert(e.base_index, e.id.to_le_bytes(), e.vector)
+                    }
+                })
+                .collect(),
+        )
+    }
+
+    pub fn value_deltas(&self) -> Vec<wt_mdb::session::ValueDelta<'_>> {
+        todo!()
     }
 }
 

--- a/src/posting_block.rs
+++ b/src/posting_block.rs
@@ -6,16 +6,132 @@
 //! block is inferred from the byte size of the block. Identifiers are stored before the rest of
 //! the vector to allow mutation without having to visit every byte in the block.
 
+use std::collections::BTreeMap;
+
 use vectors::F32VectorCoder;
+
+/// Internal model for handling pre-encoded blocks.
+///
+/// This is created with a fixed raw block length and vector length, validates settings, and
+/// provides routines to examine the raw block data without maintaing a slice reference.
+#[derive(Debug, Copy, Clone)]
+struct PostingBlockMeta {
+    raw_len: usize,
+    len: usize,
+    id_split: usize,
+    vector_len: usize,
+}
+
+impl PostingBlockMeta {
+    /// Create a new meta with a raw block length and a fixed vector length.
+    ///
+    /// Returns `None` if `raw_len` doesn't divide evenly into entries.
+    fn new(raw_len: usize, vector_len: usize) -> Option<Self> {
+        let entry_len = vector_len + std::mem::size_of::<i64>();
+        if raw_len.is_multiple_of(entry_len) {
+            let len = raw_len / entry_len;
+            let id_split = len * std::mem::size_of::<i64>();
+            Some(Self {
+                raw_len,
+                len,
+                id_split,
+                vector_len,
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Presents ids as a slice of 8 byte entries.
+    ///
+    /// Each entry is a little-endian encoded `i64`. Entries are not guaranteed to be aligned.
+    ///
+    /// *Panics* if `raw_block` is not the same size as `raw_len` passed at construction.
+    #[inline]
+    fn raw_ids<'b>(&self, raw_block: &'b [u8]) -> &'b [[u8; 8]] {
+        assert_eq!(self.raw_len, raw_block.len());
+        &raw_block.as_chunks::<{ std::mem::size_of::<i64>() }>().0[..self.len]
+    }
+
+    /// Iterator over ids in `raw_block`
+    ///
+    /// *Panics* if `raw_block` is not the same size as `raw_len` passed at construction.
+    #[inline]
+    fn id_iter<'b>(&self, raw_block: &'b [u8]) -> impl ExactSizeIterator<Item = i64> + 'b {
+        self.raw_ids(raw_block)
+            .iter()
+            .copied()
+            .map(i64::from_le_bytes)
+    }
+
+    /// Iterator over vectors in `raw_block`
+    ///
+    /// *Panics* if `raw_block` is not the same size as `raw_len` passed at construction.
+    #[inline]
+    fn vector_iter<'b>(&self, raw_block: &'b [u8]) -> impl ExactSizeIterator<Item = &'b [u8]> {
+        assert_eq!(self.raw_len, raw_block.len());
+        raw_block[self.id_split..].chunks(self.vector_len)
+    }
+
+    /// Iterator over (id, vector) in `raw_block`.
+    ///
+    /// *Panics* if `raw_block` is not the same size as `raw_len` passed at construction.
+    #[inline]
+    fn block_iter<'b>(
+        &self,
+        raw_block: &'b [u8],
+    ) -> impl ExactSizeIterator<Item = (i64, &'b [u8])> {
+        self.id_iter(raw_block).zip(self.vector_iter(raw_block))
+    }
+
+    /// Lookup `id` in `raw_block`, returning the vector if present.
+    #[inline]
+    fn lookup<'b>(&self, raw_block: &'b [u8], id: i64) -> Option<&'b [u8]> {
+        let i = self
+            .raw_ids(raw_block)
+            .binary_search_by_key(&id, |r| i64::from_le_bytes(*r))
+            .ok()?;
+        Some(self.vector_index(raw_block, i))
+    }
+
+    /// Read the vector in `raw_block` at `index`.
+    ///
+    /// *Panics* if `raw_block` is not the same size as `raw_len` passed at construction or if
+    /// `i >= len`.
+    fn vector_index<'b>(&self, raw_block: &'b [u8], i: usize) -> &'b [u8] {
+        assert_eq!(self.raw_len, raw_block.len());
+        let offset = self.id_split + i * self.vector_len;
+        &raw_block[offset..(offset + self.vector_len)]
+    }
+
+    fn encode_block(
+        vector_len: usize,
+        it: impl ExactSizeIterator<Item = (i64, impl AsRef<[u8]>)>,
+    ) -> Vec<u8> {
+        let id_split = it.len() * std::mem::size_of::<i64>();
+        let mut out = vec![0u8; id_split + vector_len * it.len()];
+        let (id_out, vector_out) = out.split_at_mut(id_split);
+        let oit = id_out
+            .as_chunks_mut::<{ std::mem::size_of::<i64>() }>()
+            .0
+            .iter_mut()
+            .zip(vector_out.chunks_mut(vector_len));
+        for (i, o) in it.zip(oit) {
+            *o.0 = i.0.to_le_bytes();
+            assert_eq!(i.1.as_ref().len(), vector_len);
+            o.1.copy_from_slice(i.1.as_ref());
+        }
+        out
+    }
+}
 
 /// A view over a block of vector posting data: (id, vector) tuples.
 ///
 /// Vectors are expected to be fixed size but the format of the data is otherwise undefined.
 #[derive(Debug, Clone)]
 pub struct PostingBlock<'a> {
-    ids: &'a [[u8; 8]],
-    vectors: &'a [u8],
-    vector_len: usize,
+    data: &'a [u8],
+    meta: PostingBlockMeta,
 }
 
 impl<'a> PostingBlock<'a> {
@@ -23,227 +139,126 @@ impl<'a> PostingBlock<'a> {
     ///
     /// Returns `None` if the input data length does not align with an integer entry count.
     pub fn new(data: &'a [u8], vector_len: usize) -> Option<Self> {
-        let entry_len = vector_len + std::mem::size_of::<i64>();
-        if !data.len().is_multiple_of(entry_len) {
-            return None;
-        }
-        let len = data.len() / entry_len;
-        let split = len * std::mem::size_of::<i64>();
-        let (ids, vectors) = data.split_at(split);
-        Some(Self {
-            ids: ids.as_chunks::<{ std::mem::size_of::<i64>() }>().0,
-            vectors,
-            vector_len,
-        })
+        let meta = PostingBlockMeta::new(data.len(), vector_len)?;
+        Some(Self { data, meta })
     }
 
     /// Return an iterator over the vectors in the posting block and their ids.
     pub fn iter(&self) -> impl ExactSizeIterator<Item = (i64, &'a [u8])> {
-        self.ids
-            .iter()
-            .copied()
-            .map(i64::from_le_bytes)
-            .zip(self.vectors.chunks(self.vector_len))
+        self.meta.block_iter(self.data)
     }
 
     /// Lookup a vector by `id`, returning `None` if `id` is not present in the block.
     pub fn lookup(&self, id: i64) -> Option<&[u8]> {
-        self.ids
-            .binary_search(&id.to_le_bytes())
-            .map(|i| {
-                let start = self.vector_len * i;
-                let end = start + self.vector_len;
-                &self.vectors[start..end]
-            })
-            .ok()
+        self.meta.lookup(self.data, id)
     }
 
     /// Return the number of entries in the block.
     pub fn len(&self) -> usize {
-        self.ids.len()
+        self.meta.len
     }
 
     pub fn is_empty(&self) -> bool {
-        self.ids.is_empty()
+        self.meta.len == 0
     }
 }
 
-// XXX this proposal cannot distinguish between an update and a clean entry.
-#[derive(Debug, Clone)]
-struct BuilderEntry {
-    id: i64,
-    // usize::MAX for an insert of a new entry.
-    base_index: usize,
-    // Empty to indicate a delete.
-    vector: Vec<u8>,
-    // True if this entry has been modified.
-    dirty: bool,
+enum EntrySource {
+    /// Index into the base block's entry array.
+    Base(usize),
+    /// Owned encoded vector bytes for a new or replaced entry.
+    New(Vec<u8>),
 }
 
-impl BuilderEntry {
-    fn vector_tuple(&self) -> Option<(i64, &[u8])> {
-        if !self.vector.is_empty() {
-            Some((self.id, self.vector.as_slice()))
-        } else {
-            None
+/// A mutable posting block that can be seeded from an existing block and mutated via inserts and
+/// removals. The original data is preserved so callers can produce a diff (e.g. via
+/// `wiredtiger_calc_modify`) against the serialized result.
+pub struct PostingBlockMut {
+    /// Base block we are working off of. May be empty.
+    base_data: Vec<u8>,
+    /// Metadata for base block.
+    base_meta: PostingBlockMeta,
+    /// Current entries sorted by id. Start pre-populated from base block.
+    entries: BTreeMap<i64, EntrySource>,
+}
+
+impl PostingBlockMut {
+    /// Create a new mutable block where each vector is expected be `vector_len` bytes.
+    pub fn new(vector_len: usize) -> Self {
+        Self {
+            base_data: vec![],
+            base_meta: PostingBlockMeta::new(0, vector_len).expect("0 divides evenly"),
+            entries: BTreeMap::new(),
         }
     }
-}
 
-/// Builder for a block of vector posting data.
-///
-/// Vectors are expected to be fixed size but the format of the data is otherwise undefined.
-#[derive(Debug, Clone, Default)]
-pub struct PostingBlockBuilder(Vec<BuilderEntry>);
-
-// XXX this all needs docs.
-impl PostingBlockBuilder {
-    pub fn new() -> Self {
-        Self::default()
+    /// Create a mutable block pre-populated with data from `block`.
+    pub fn from_block(block: &PostingBlock<'_>) -> Self {
+        let entries = block
+            .meta
+            .id_iter(block.data)
+            .enumerate()
+            .map(|(i, id)| (id, EntrySource::Base(i)))
+            .collect();
+        Self {
+            base_data: block.data.to_vec(),
+            base_meta: block.meta,
+            entries,
+        }
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = (i64, &[u8])> {
-        self.0.iter().filter_map(BuilderEntry::vector_tuple)
+    /// Return an iterator over the current postings in the block.
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = (i64, &[u8])> {
+        self.entries.iter().map(|(&id, e)| (id, self.get_vector(e)))
     }
 
+    /// Lookup the vector for the given `id`, returning `None` if not found.
     pub fn lookup(&self, id: i64) -> Option<&[u8]> {
-        self.0
-            .binary_search_by_key(&id, |e| e.id)
-            .map(|i| self.0[i].vector.as_slice())
-            .ok()
-            .filter(|v| !v.is_empty())
+        let e = self.entries.get(&id)?;
+        Some(self.get_vector(e))
     }
 
-    pub fn upsert(&mut self, id: i64, vector: impl Into<Vec<u8>>) {
-        match self.0.binary_search_by_key(&id, |e| e.id) {
-            Ok(i) => {
-                let e = &mut self.0[i];
-                e.vector = vector.into();
-                e.dirty = true;
-            }
-            Err(i) => {
-                self.0.insert(
-                    i,
-                    BuilderEntry {
-                        id,
-                        base_index: usize::MAX,
-                        vector: vector.into(),
-                        dirty: true,
-                    },
-                );
-            }
-        }
+    /// Insert or replace the entry for `id`.
+    ///
+    /// *Panics* if `vector.into().len()` is not the vector length passed at construction.
+    pub fn insert(&mut self, id: i64, vector: impl Into<Vec<u8>>) {
+        let vector = vector.into();
+        assert_eq!(vector.len(), self.base_meta.vector_len);
+        self.entries.insert(id, EntrySource::New(vector));
     }
 
-    pub fn delete(&mut self, id: i64) {
-        if let Ok(i) = self.0.binary_search_by_key(&id, |e| e.id) {
-            let e = &mut self.0[i];
-            e.vector.clear();
-            // XXX I should remove the value entirely if base_index is unset.
-            // it will make it easier to fix up later.
-            e.dirty = e.base_index != usize::MAX;
-        }
+    /// Remove the entry for `id`, returning `true` if it was present.
+    pub fn remove(&mut self, id: i64) -> bool {
+        self.entries.remove(&id).is_some()
     }
 
+    /// The original block data passed to [`PostingBlockMut::from_block`], or an empty slice for
+    /// blocks created with [`PostingBlockMut::new`].
+    ///
+    /// This information can be used to create deltas for binary blocks.
+    pub fn base_block(&self) -> &[u8] {
+        &self.base_data
+    }
+
+    /// Serialize the current state of the block into the same layout as [`PostingBlock`].
+    pub fn serialize(&self) -> Vec<u8> {
+        PostingBlockMeta::encode_block(self.base_meta.vector_len, self.iter())
+    }
+
+    /// Return the number of entries in the block.
     pub fn len(&self) -> usize {
-        self.0.len()
+        self.entries.len()
     }
 
     pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
+        self.entries.is_empty()
     }
 
-    pub fn build(self) -> EncodedPostingBlock {
-        if self.is_empty() {
-            return EncodedPostingBlock::Remove;
+    fn get_vector<'a>(&'a self, entry: &'a EntrySource) -> &'a [u8] {
+        match entry {
+            EntrySource::Base(i) => self.base_meta.vector_index(&self.base_data, *i),
+            EntrySource::New(v) => v.as_slice(),
         }
-
-        let vector_len = self.0[0].vector.len();
-        let mut out = vec![0u8; self.len() * (std::mem::size_of::<i64>() + vector_len)];
-        let (ids_out, vectors_out) = out.split_at_mut(self.len() * std::mem::size_of::<i64>());
-        let out_it = ids_out
-            .as_chunks_mut::<{ std::mem::size_of::<i64>() }>()
-            .0
-            .iter_mut()
-            .zip(vectors_out.chunks_mut(vector_len));
-        for (i, o) in self.iter().zip(out_it) {
-            *o.0 = i.0.to_le_bytes();
-            o.1.copy_from_slice(&i.1);
-        }
-        EncodedPostingBlock::Replace(out)
-    }
-}
-
-impl<B: Into<Vec<u8>>> FromIterator<(i64, B)> for PostingBlockBuilder {
-    fn from_iter<T: IntoIterator<Item = (i64, B)>>(iter: T) -> Self {
-        Self(
-            iter.into_iter()
-                .enumerate()
-                .map(|(i, (id, v))| BuilderEntry {
-                    id: id,
-                    base_index: i,
-                    vector: v.into(),
-                    dirty: false,
-                })
-                .collect(),
-        )
-    }
-}
-
-impl From<PostingBlock<'_>> for PostingBlockBuilder {
-    fn from(value: PostingBlock<'_>) -> Self {
-        Self::from_iter(value.iter())
-    }
-}
-
-/// An encoded posting block produced by [`PostingBlockBuilder`].
-///
-/// This may represent a remove, set/overwrite, or a delta/modify call.
-#[derive(Debug, Clone)]
-pub enum EncodedPostingBlock {
-    /// This block no longer contains any postings so remove it.
-    Remove,
-    /// Replace the contents of this block with a different value.
-    Replace(Vec<u8>),
-}
-
-enum PostingDelta {
-    Upsert(usize, [u8; 8], Vec<u8>),
-    Delete(usize),
-}
-
-pub struct PostingBlockDelta(Vec<PostingDelta>);
-
-impl PostingBlockDelta {
-    fn from_builder(builder: PostingBlockBuilder) -> Self {
-        // XXX the indexes are wrong here.
-        // i need to track the base index and the output index.
-        // i need to distinguish between insert and update
-        // * inserts only need to know the next output index.
-        // * updates and deletes need to track where base_index is in the output
-        // XXX is it easier if I iterate over every entry?
-        // delete => delete at current index, do not increment index.
-        // insert => insert at current index, increment index.
-        // update => replace at current index, increment index.
-        PostingBlockDelta(
-            builder
-                .0
-                .into_iter()
-                .filter(|e| e.dirty)
-                .map(|e| {
-                    if e.vector.is_empty() {
-                        assert_ne!(e.base_index, usize::MAX);
-                        PostingDelta::Delete(e.base_index)
-                    } else {
-                        PostingDelta::Upsert(e.base_index, e.id.to_le_bytes(), e.vector)
-                    }
-                })
-                .collect(),
-        )
-    }
-
-    pub fn value_deltas(&self) -> Vec<wt_mdb::session::ValueDelta<'_>> {
-        todo!()
     }
 }
 
@@ -254,20 +269,11 @@ pub fn encode_f32(
     coder: &dyn F32VectorCoder,
     dim: usize,
 ) -> Vec<u8> {
-    let ids_len = std::mem::size_of::<i64>() * vectors.len();
-    let vec_len = coder.byte_len(dim);
-    let mut out = vec![0u8; ids_len + vectors.len() * vec_len];
-    let (out_ids, out_vecs) = out.split_at_mut(ids_len);
-    let out_it = out_ids
-        .as_chunks_mut::<{ std::mem::size_of::<i64>() }>()
-        .0
-        .iter_mut()
-        .zip(out_vecs.chunks_mut(vec_len));
-    for (i, o) in vectors.zip(out_it) {
-        *o.0 = i.0.to_le_bytes();
-        coder.encode_to(i.1.as_ref(), o.1);
-    }
-    out
+    let vector_len = coder.byte_len(dim);
+    PostingBlockMeta::encode_block(
+        vector_len,
+        vectors.map(|(id, v)| (id, coder.encode(v.as_ref()))),
+    )
 }
 
 /// Return the expected `leaf_page_max` and `leaf_value_max` sizes that should be used in

--- a/src/posting_block.rs
+++ b/src/posting_block.rs
@@ -281,3 +281,244 @@ pub fn encode_f32(
 pub fn leaf_page_max(block_size: usize, vector_len: usize, allocation_size: usize) -> usize {
     (block_size * (vector_len + std::mem::size_of::<i64>())).next_multiple_of(allocation_size)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build raw posting block bytes from sorted `(id, vector)` pairs with the same layout used
+    /// by `PostingBlockMeta::encode_block`: all ids first, then all vectors.
+    fn make_block_data(entries: &[(i64, &[u8])]) -> Vec<u8> {
+        let n = entries.len();
+        let vector_len = entries.first().map_or(0, |(_, v)| v.len());
+        let id_split = n * 8;
+        let mut out = vec![0u8; id_split + vector_len * n];
+        let (id_out, vector_out) = out.split_at_mut(id_split);
+        for (i, (id, vec)) in entries.iter().enumerate() {
+            id_out[i * 8..(i + 1) * 8].copy_from_slice(&id.to_le_bytes());
+            vector_out[i * vector_len..(i + 1) * vector_len].copy_from_slice(vec);
+        }
+        out
+    }
+
+    // --- PostingBlock ---
+
+    #[test]
+    fn posting_block_empty() {
+        let block = PostingBlock::new(&[], 4).unwrap();
+        assert_eq!(block.len(), 0);
+        assert!(block.is_empty());
+        assert_eq!(block.iter().count(), 0);
+        assert_eq!(block.lookup(1), None);
+    }
+
+    #[test]
+    fn posting_block_invalid_alignment() {
+        // entry_len = 4 + 8 = 12; 5 is not a multiple of 12
+        assert!(PostingBlock::new(&[0u8; 5], 4).is_none());
+        assert!(PostingBlock::new(&[0u8; 11], 4).is_none());
+        assert!(PostingBlock::new(&[0u8; 13], 4).is_none());
+    }
+
+    #[test]
+    fn posting_block_single_entry() {
+        let data = make_block_data(&[(42, &[1, 2, 3, 4])]);
+        let block = PostingBlock::new(&data, 4).unwrap();
+        assert_eq!(block.len(), 1);
+        assert!(!block.is_empty());
+        let entries: Vec<_> = block.iter().collect();
+        assert_eq!(entries, [(42, &[1u8, 2, 3, 4][..])]);
+    }
+
+    #[test]
+    fn posting_block_multiple_entries() {
+        let data = make_block_data(&[
+            (1, &[10, 11, 12, 13]),
+            (5, &[20, 21, 22, 23]),
+            (10, &[30, 31, 32, 33]),
+        ]);
+        let block = PostingBlock::new(&data, 4).unwrap();
+        assert_eq!(block.len(), 3);
+        let entries: Vec<_> = block.iter().collect();
+        assert_eq!(entries[0], (1, &[10u8, 11, 12, 13][..]));
+        assert_eq!(entries[1], (5, &[20u8, 21, 22, 23][..]));
+        assert_eq!(entries[2], (10, &[30u8, 31, 32, 33][..]));
+    }
+
+    #[test]
+    fn posting_block_lookup_found() {
+        let data = make_block_data(&[(1, &[10, 11, 12, 13]), (5, &[20, 21, 22, 23])]);
+        let block = PostingBlock::new(&data, 4).unwrap();
+        assert_eq!(block.lookup(1), Some(&[10u8, 11, 12, 13][..]));
+        assert_eq!(block.lookup(5), Some(&[20u8, 21, 22, 23][..]));
+    }
+
+    #[test]
+    fn posting_block_lookup_not_found() {
+        let data = make_block_data(&[(1, &[10, 11, 12, 13])]);
+        let block = PostingBlock::new(&data, 4).unwrap();
+        assert_eq!(block.lookup(0), None);
+        assert_eq!(block.lookup(2), None);
+    }
+
+    #[test]
+    fn posting_block_negative_ids() {
+        let data = make_block_data(&[(-10, &[1, 2, 3, 4]), (-1, &[5, 6, 7, 8])]);
+        let block = PostingBlock::new(&data, 4).unwrap();
+        assert_eq!(block.lookup(-10), Some(&[1u8, 2, 3, 4][..]));
+        assert_eq!(block.lookup(-1), Some(&[5u8, 6, 7, 8][..]));
+        assert_eq!(block.lookup(0), None);
+    }
+
+    // --- PostingBlockMut ---
+
+    #[test]
+    fn posting_block_mut_new_empty() {
+        let mb = PostingBlockMut::new(4);
+        assert_eq!(mb.len(), 0);
+        assert!(mb.is_empty());
+        assert_eq!(mb.iter().count(), 0);
+        assert_eq!(mb.base_block(), &[] as &[u8]);
+    }
+
+    #[test]
+    fn posting_block_mut_insert_single() {
+        let mut mb = PostingBlockMut::new(4);
+        mb.insert(42, vec![1, 2, 3, 4]);
+        assert_eq!(mb.len(), 1);
+        assert!(!mb.is_empty());
+        assert_eq!(mb.lookup(42), Some(&[1u8, 2, 3, 4][..]));
+        assert_eq!(mb.lookup(0), None);
+    }
+
+    #[test]
+    fn posting_block_mut_insert_sorted_by_id() {
+        let mut mb = PostingBlockMut::new(4);
+        mb.insert(5, vec![5, 5, 5, 5]);
+        mb.insert(1, vec![1, 1, 1, 1]);
+        mb.insert(3, vec![3, 3, 3, 3]);
+        let ids: Vec<i64> = mb.iter().map(|(id, _)| id).collect();
+        assert_eq!(ids, [1, 3, 5]);
+    }
+
+    #[test]
+    fn posting_block_mut_insert_replaces_existing() {
+        let mut mb = PostingBlockMut::new(4);
+        mb.insert(1, vec![1, 1, 1, 1]);
+        mb.insert(1, vec![9, 9, 9, 9]);
+        assert_eq!(mb.len(), 1);
+        assert_eq!(mb.lookup(1), Some(&[9u8, 9, 9, 9][..]));
+    }
+
+    #[test]
+    fn posting_block_mut_remove_existing() {
+        let mut mb = PostingBlockMut::new(4);
+        mb.insert(1, vec![1, 2, 3, 4]);
+        assert!(mb.remove(1));
+        assert_eq!(mb.len(), 0);
+        assert_eq!(mb.lookup(1), None);
+    }
+
+    #[test]
+    fn posting_block_mut_remove_missing_returns_false() {
+        let mut mb = PostingBlockMut::new(4);
+        mb.insert(1, vec![1, 2, 3, 4]);
+        assert!(!mb.remove(2));
+        assert_eq!(mb.len(), 1);
+    }
+
+    #[test]
+    fn posting_block_mut_from_block_inherits_entries() {
+        let data = make_block_data(&[(1, &[10, 11, 12, 13]), (5, &[20, 21, 22, 23])]);
+        let block = PostingBlock::new(&data, 4).unwrap();
+        let mb = PostingBlockMut::from_block(&block);
+        assert_eq!(mb.len(), 2);
+        assert_eq!(mb.lookup(1), Some(&[10u8, 11, 12, 13][..]));
+        assert_eq!(mb.lookup(5), Some(&[20u8, 21, 22, 23][..]));
+        assert_eq!(mb.base_block(), &data[..]);
+    }
+
+    #[test]
+    fn posting_block_mut_from_block_then_insert() {
+        let data = make_block_data(&[(1, &[10, 11, 12, 13])]);
+        let block = PostingBlock::new(&data, 4).unwrap();
+        let mut mb = PostingBlockMut::from_block(&block);
+        mb.insert(3, vec![30, 31, 32, 33]);
+        assert_eq!(mb.len(), 2);
+        let entries: Vec<_> = mb.iter().collect();
+        assert_eq!(entries[0], (1, &[10u8, 11, 12, 13][..]));
+        assert_eq!(entries[1], (3, &[30u8, 31, 32, 33][..]));
+    }
+
+    #[test]
+    fn posting_block_mut_from_block_then_remove() {
+        let data = make_block_data(&[(1, &[10, 11, 12, 13]), (5, &[20, 21, 22, 23])]);
+        let block = PostingBlock::new(&data, 4).unwrap();
+        let mut mb = PostingBlockMut::from_block(&block);
+        assert!(mb.remove(1));
+        assert_eq!(mb.len(), 1);
+        assert_eq!(mb.lookup(1), None);
+        assert_eq!(mb.lookup(5), Some(&[20u8, 21, 22, 23][..]));
+    }
+
+    #[test]
+    fn posting_block_mut_from_block_replace_base_entry() {
+        let data = make_block_data(&[(1, &[10, 11, 12, 13]), (5, &[20, 21, 22, 23])]);
+        let block = PostingBlock::new(&data, 4).unwrap();
+        let mut mb = PostingBlockMut::from_block(&block);
+        mb.insert(1, vec![99, 99, 99, 99]);
+        assert_eq!(mb.len(), 2);
+        assert_eq!(mb.lookup(1), Some(&[99u8, 99, 99, 99][..]));
+        assert_eq!(mb.lookup(5), Some(&[20u8, 21, 22, 23][..]));
+    }
+
+    #[test]
+    fn posting_block_mut_serialize_empty() {
+        let mb = PostingBlockMut::new(4);
+        let serialized = mb.serialize();
+        assert!(serialized.is_empty());
+        assert!(PostingBlock::new(&serialized, 4).unwrap().is_empty());
+    }
+
+    #[test]
+    fn posting_block_mut_serialize_roundtrip() {
+        let mut mb = PostingBlockMut::new(4);
+        mb.insert(5, vec![5, 6, 7, 8]);
+        mb.insert(1, vec![1, 2, 3, 4]);
+        mb.insert(3, vec![3, 4, 5, 6]);
+        let serialized = mb.serialize();
+        let block = PostingBlock::new(&serialized, 4).unwrap();
+        assert_eq!(block.len(), 3);
+        let entries: Vec<_> = block.iter().collect();
+        assert_eq!(entries[0], (1, &[1u8, 2, 3, 4][..]));
+        assert_eq!(entries[1], (3, &[3u8, 4, 5, 6][..]));
+        assert_eq!(entries[2], (5, &[5u8, 6, 7, 8][..]));
+    }
+
+    #[test]
+    fn posting_block_mut_serialize_matches_base_when_unmodified() {
+        let data = make_block_data(&[(1, &[10, 11, 12, 13]), (5, &[20, 21, 22, 23])]);
+        let block = PostingBlock::new(&data, 4).unwrap();
+        let mb = PostingBlockMut::from_block(&block);
+        assert_eq!(mb.serialize(), data);
+    }
+
+    #[test]
+    #[should_panic]
+    fn posting_block_mut_insert_wrong_vector_len_panics() {
+        let mut mb = PostingBlockMut::new(4);
+        mb.insert(1, vec![1, 2, 3]); // one byte short
+    }
+
+    // --- leaf_page_max ---
+
+    #[test]
+    fn leaf_page_max_rounds_up_to_allocation_size() {
+        // entry_len = 4 + 8 = 12; 1 * 12 = 12 → rounds up to 512
+        assert_eq!(leaf_page_max(1, 4, 512), 512);
+        // 100 * 12 = 1200 → rounds up to 1536 (3 * 512)
+        assert_eq!(leaf_page_max(100, 4, 512), 1536);
+        // Already a multiple: 128 * 8 = 1024 → stays 1024
+        assert_eq!(leaf_page_max(128, 0, 1024), 1024);
+    }
+}

--- a/src/posting_block.rs
+++ b/src/posting_block.rs
@@ -510,6 +510,96 @@ mod tests {
         mb.insert(1, vec![1, 2, 3]); // one byte short
     }
 
+    // --- encode_f32 ---
+
+    fn decode_f32_vec(bytes: &[u8]) -> Vec<f32> {
+        bytes
+            .chunks(4)
+            .map(|c| f32::from_le_bytes(c.try_into().unwrap()))
+            .collect()
+    }
+
+    #[test]
+    fn encode_f32_empty_produces_empty_bytes() {
+        let coder = vectors::F32VectorCoding::F32.coder(vectors::VectorSimilarity::Euclidean, None);
+        let input: Vec<(i64, Vec<f32>)> = vec![];
+        let result = encode_f32(input.into_iter(), coder.as_ref(), 4);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn encode_f32_single_entry_roundtrip() {
+        let coder = vectors::F32VectorCoding::F32.coder(vectors::VectorSimilarity::Euclidean, None);
+        let input = vec![(1i64, vec![1.0f32, 2.0, 3.0, 4.0])];
+        let result = encode_f32(input.into_iter(), coder.as_ref(), 4);
+        let block = PostingBlock::new(&result, coder.byte_len(4)).unwrap();
+        assert_eq!(block.len(), 1);
+        let (id, vec_bytes) = block.iter().next().unwrap();
+        assert_eq!(id, 1);
+        assert_eq!(decode_f32_vec(vec_bytes), [1.0, 2.0, 3.0, 4.0]);
+    }
+
+    #[test]
+    fn encode_f32_multiple_entries_roundtrip() {
+        let coder = vectors::F32VectorCoding::F32.coder(vectors::VectorSimilarity::Euclidean, None);
+        let input = vec![
+            (1i64, vec![1.0f32, 0.0, 0.0, 0.0]),
+            (5i64, vec![0.0, 2.0, 0.0, 0.0]),
+            (10i64, vec![0.0, 0.0, 3.0, 0.0]),
+        ];
+        let result = encode_f32(input.into_iter(), coder.as_ref(), 4);
+        let block = PostingBlock::new(&result, coder.byte_len(4)).unwrap();
+        assert_eq!(block.len(), 3);
+        let entries: Vec<_> = block.iter().collect();
+        assert_eq!(entries[0].0, 1);
+        assert_eq!(decode_f32_vec(entries[0].1), [1.0, 0.0, 0.0, 0.0]);
+        assert_eq!(entries[1].0, 5);
+        assert_eq!(decode_f32_vec(entries[1].1), [0.0, 2.0, 0.0, 0.0]);
+        assert_eq!(entries[2].0, 10);
+        assert_eq!(decode_f32_vec(entries[2].1), [0.0, 0.0, 3.0, 0.0]);
+    }
+
+    #[test]
+    fn encode_f32_output_length_matches_entry_count() {
+        let coder = vectors::F32VectorCoding::F32.coder(vectors::VectorSimilarity::Euclidean, None);
+        let n = 5usize;
+        let input: Vec<(i64, Vec<f32>)> = (0..n as i64).map(|i| (i, vec![i as f32; 4])).collect();
+        let result = encode_f32(input.into_iter(), coder.as_ref(), 4);
+        assert_eq!(result.len(), n * (coder.byte_len(4) + std::mem::size_of::<i64>()));
+    }
+
+    #[test]
+    fn encode_f32_cosine_normalizes_stored_vector() {
+        let coder = vectors::F32VectorCoding::F32.coder(vectors::VectorSimilarity::Cosine, None);
+        // l2 norm = 5.0 → after normalization: [0.6, 0.8, 0.0, 0.0]
+        let input = vec![(1i64, vec![3.0f32, 4.0, 0.0, 0.0])];
+        let result = encode_f32(input.into_iter(), coder.as_ref(), 4);
+        let block = PostingBlock::new(&result, coder.byte_len(4)).unwrap();
+        let (_, vec_bytes) = block.iter().next().unwrap();
+        let decoded = decode_f32_vec(vec_bytes);
+        let norm_sq: f32 = decoded.iter().map(|x| x * x).sum();
+        assert!((norm_sq - 1.0).abs() < 1e-6, "expected unit norm, got norm_sq={norm_sq}");
+        assert!((decoded[0] - 0.6).abs() < 1e-6, "decoded[0]={}", decoded[0]);
+        assert!((decoded[1] - 0.8).abs() < 1e-6, "decoded[1]={}", decoded[1]);
+    }
+
+    #[test]
+    fn encode_f32_lookup_on_result() {
+        let coder = vectors::F32VectorCoding::F32.coder(vectors::VectorSimilarity::Euclidean, None);
+        let input = vec![
+            (1i64, vec![1.0f32, 0.0, 0.0, 0.0]),
+            (3i64, vec![0.0, 1.0, 0.0, 0.0]),
+            (7i64, vec![0.0, 0.0, 1.0, 0.0]),
+        ];
+        let result = encode_f32(input.into_iter(), coder.as_ref(), 4);
+        let block = PostingBlock::new(&result, coder.byte_len(4)).unwrap();
+        assert!(block.lookup(1).is_some());
+        assert!(block.lookup(3).is_some());
+        assert!(block.lookup(7).is_some());
+        assert!(block.lookup(2).is_none());
+        assert_eq!(decode_f32_vec(block.lookup(3).unwrap()), [0.0, 1.0, 0.0, 0.0]);
+    }
+
     // --- leaf_page_max ---
 
     #[test]

--- a/src/posting_block.rs
+++ b/src/posting_block.rs
@@ -8,6 +8,9 @@
 
 use vectors::F32VectorCoder;
 
+/// A view over a block of vector posting data: (id, vector) tuples.
+///
+/// Vectors are expected to be fixed size but the format of the data is otherwise undefined.
 #[derive(Debug, Clone)]
 pub struct PostingBlock<'a> {
     ids: &'a [[u8; 8]],
@@ -41,6 +44,112 @@ impl<'a> PostingBlock<'a> {
             .copied()
             .map(i64::from_le_bytes)
             .zip(self.vectors.chunks(self.vector_len))
+    }
+
+    /// Lookup a vector by `id`, returning `None` if `id` is not present in the block.
+    pub fn lookup(&self, id: i64) -> Option<&[u8]> {
+        self.ids
+            .binary_search(&id.to_le_bytes())
+            .map(|i| {
+                let start = self.vector_len * i;
+                let end = start + self.vector_len;
+                &self.vectors[start..end]
+            })
+            .ok()
+    }
+
+    /// Return the number of entries in the block.
+    pub fn len(&self) -> usize {
+        self.ids.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.ids.is_empty()
+    }
+}
+
+/// Builder for a block of vector posting data.
+///
+/// Vectors are expected to be fixed size but the format of the data is otherwise undefined.
+#[derive(Debug, Clone, Default)]
+pub struct PostingBlockBuilder {
+    entries: Vec<(i64, Vec<u8>)>,
+    initial_entries: usize,
+    dirty: Vec<i64>,
+}
+
+// XXX this all needs docs.
+impl PostingBlockBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn from_entries(entries: Vec<(i64, Vec<u8>)>) -> Self {
+        Self {
+            initial_entries: entries.len(),
+            entries,
+            dirty: vec![],
+        }
+    }
+
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = (i64, &[u8])> {
+        self.entries.iter().map(|(i, v)| (*i, v.as_slice()))
+    }
+
+    pub fn lookup(&self, id: i64) -> Option<&[u8]> {
+        self.entries
+            .binary_search_by_key(&id, |(i, _)| *i)
+            .map(|i| self.entries[i].1.as_slice())
+            .ok()
+    }
+
+    pub fn upsert(&mut self, id: i64, vector: impl Into<Vec<u8>>) {
+        match self.entries.binary_search_by_key(&id, |(i, _)| *i) {
+            Ok(i) => self.entries[i].1 = vector.into(),
+            Err(i) => self.entries.insert(i, (id, vector.into())),
+        }
+        self.mark_dirty(id);
+    }
+
+    pub fn delete(&mut self, id: i64) {
+        if let Ok(i) = self.entries.binary_search_by_key(&id, |(i, _)| *i) {
+            self.entries.remove(i);
+            self.mark_dirty(id);
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    // XXX tri-state encode:
+    // * If it's empty, should result in the key being removed.
+    // * If there are too many mutations (~10% of max(entries, dirty)) then flush completely and set
+    // * Otherwise produce a diff.
+    //
+    // I think the state I have is sufficient to decide between 2 and 3.
+
+    fn mark_dirty(&mut self, id: i64) {
+        if let Err(i) = self.dirty.binary_search(&id) {
+            self.dirty.insert(i, id);
+        }
+    }
+}
+
+impl<B: Into<Vec<u8>>> FromIterator<(i64, B)> for PostingBlockBuilder {
+    fn from_iter<T: IntoIterator<Item = (i64, B)>>(iter: T) -> Self {
+        let entries = iter.into_iter().map(|(id, v)| (id, v.into())).collect();
+        Self::from_entries(entries)
+    }
+}
+
+impl From<PostingBlock<'_>> for PostingBlockBuilder {
+    fn from(value: PostingBlock<'_>) -> Self {
+        Self::from_iter(value.iter())
     }
 }
 

--- a/src/posting_block.rs
+++ b/src/posting_block.rs
@@ -139,6 +139,8 @@ impl PostingBlockBuilder {
         if let Ok(i) = self.0.binary_search_by_key(&id, |e| e.id) {
             let e = &mut self.0[i];
             e.vector.clear();
+            // XXX I should remove the value entirely if base_index is unset.
+            // it will make it easier to fix up later.
             e.dirty = e.base_index != usize::MAX;
         }
     }
@@ -219,6 +221,10 @@ impl PostingBlockDelta {
         // i need to distinguish between insert and update
         // * inserts only need to know the next output index.
         // * updates and deletes need to track where base_index is in the output
+        // XXX is it easier if I iterate over every entry?
+        // delete => delete at current index, do not increment index.
+        // insert => insert at current index, increment index.
+        // update => replace at current index, increment index.
         PostingBlockDelta(
             builder
                 .0


### PR DESCRIPTION
Posting blocks can be created empty or on top of an existing block. Existing blocks are copied and retained which makes it easier to produce diffs to avoid write amplification when modifying a block.