### PR TITLE
Write SPANN postings in blocks

### DIFF
--- a/et/src/spann/bulk_load.rs
+++ b/et/src/spann/bulk_load.rs
@@ -5,11 +5,12 @@ use easy_tiger::{
     input::{DerefVectorStore, SubsetViewVectorStore, VectorStore},
     kmeans::{HierarchicalKMeansParams, Params, hierarchical_kmeans},
     spann::{
-        IndexConfig, ReplicaSelectionAlgorithm, TableIndex,
+        IndexConfig, PostingKey, ReplicaSelectionAlgorithm, TableIndex,
         bulk::{
             assign_to_centroids, load_centroid_stats, load_centroids, load_postings,
             load_raw_vectors,
         },
+        postings::RowPostingsMut,
     },
     vamana::{
         GraphConfig, GraphSearchParams, PatienceParams,
@@ -273,13 +274,20 @@ pub fn bulk_load(
     {
         let posting_count = centroid_assignments.iter().map(|c| c.len()).sum::<usize>();
         let progress = progress_bar(posting_count, "tail load postings");
-        load_postings(
-            index.as_ref(),
-            &connection,
-            &centroid_assignments,
-            &f32_vectors,
-            |i| progress.inc(i),
-        )?;
+        let txn = connection.begin_transaction(None)?;
+        {
+            let cursor =
+                txn.open_cursor::<PostingKey, Vec<u8>>(index.postings_table_name())?;
+            let mut postings = RowPostingsMut::new(cursor);
+            load_postings(
+                index.as_ref(),
+                &mut postings,
+                &centroid_assignments,
+                &f32_vectors,
+                |i| progress.inc(i),
+            )?;
+        }
+        txn.commit(None)?;
     }
 
     Ok(())

--- a/et/src/spann/bulk_load.rs
+++ b/et/src/spann/bulk_load.rs
@@ -5,12 +5,12 @@ use easy_tiger::{
     input::{DerefVectorStore, SubsetViewVectorStore, VectorStore},
     kmeans::{HierarchicalKMeansParams, Params, hierarchical_kmeans},
     spann::{
-        IndexConfig, PostingKey, ReplicaSelectionAlgorithm, TableIndex,
+        IndexConfig, ReplicaSelectionAlgorithm, TableIndex,
         bulk::{
             assign_to_centroids, load_centroid_stats, load_centroids, load_postings,
             load_raw_vectors,
         },
-        postings::RowPostingsMut,
+        postings::BlockPostingsMut,
     },
     vamana::{
         GraphConfig, GraphSearchParams, PatienceParams,
@@ -277,8 +277,8 @@ pub fn bulk_load(
         let txn = connection.begin_transaction(None)?;
         {
             let cursor =
-                txn.open_cursor::<PostingKey, Vec<u8>>(index.postings_table_name())?;
-            let mut postings = RowPostingsMut::new(cursor);
+                txn.open_cursor::<u32, Vec<u8>>(index.postings_table_name())?;
+            let mut postings = BlockPostingsMut::new(cursor, index.posting_vector_len());
             load_postings(
                 index.as_ref(),
                 &mut postings,

--- a/et/src/spann/insert_vectors.rs
+++ b/et/src/spann/insert_vectors.rs
@@ -4,8 +4,9 @@ use clap::Args;
 use easy_tiger::{
     input::{DerefVectorStore, VectorStore},
     spann::{
-        CentroidAssignment, PostingKey, TableIndex, TransactionIndex,
+        CentroidAssignment, TableIndex, TransactionIndex,
         centroid_stats::{CentroidAssignmentUpdater, CentroidStats},
+        postings::BlockPostingsMut,
         rebalance::{BalanceSummary, RebalanceStats, merge_centroid, split_centroid},
     },
     vamana::search::GraphSearcher,
@@ -238,9 +239,10 @@ fn insert_batch(
     );
     progress.set_message("writing postings");
     let mut assignment_updater = CentroidAssignmentUpdater::new(&txn_idx)?;
-    let mut posting_cursor = txn_idx
+    let posting_cursor = txn_idx
         .transaction()
-        .open_cursor::<PostingKey, Vec<u8>>(index.postings_table_name())?;
+        .open_cursor::<u32, Vec<u8>>(index.postings_table_name())?;
+    let mut postings = BlockPostingsMut::new(posting_cursor, index.posting_vector_len());
     let mut rerank_cursor = if rerank_coder.is_some() {
         Some(
             txn_idx
@@ -255,11 +257,7 @@ fn insert_batch(
         assignment_updater.insert(i as i64, assignment.to_formatted_ref())?;
 
         for (_, centroid_id) in assignment.iter() {
-            let key = PostingKey {
-                centroid_id,
-                record_id: i as i64,
-            };
-            posting_cursor.set(key, &posting_vector)?;
+            postings.insert(centroid_id, i as i64, &posting_vector)?;
         }
 
         if let Some((cursor, vector)) = rerank_cursor.as_mut().zip(rerank_vector) {
@@ -267,9 +265,10 @@ fn insert_batch(
         }
     }
 
+    postings.flush()?;
     assignment_updater.flush()?;
     drop(assignment_updater);
-    drop(posting_cursor);
+    drop(postings);
     drop(rerank_cursor);
     txn_idx.commit(Some(CommitTransactionOptions::with_commit_timestamp(
         timestamp.next(),

--- a/et/src/spann/search.rs
+++ b/et/src/spann/search.rs
@@ -14,8 +14,8 @@ use clap::Args;
 use easy_tiger::{
     input::{DerefVectorStore, VectorStore},
     spann::{
-        PostingKey, TableIndex, TransactionIndex,
-        postings::RowPostingsMut,
+        TableIndex, TransactionIndex,
+        postings::BlockPostingsMut,
         search::{
             CentroidSelector, CentroidSelectorAlgorithm, SearchParams, SearchStats, Searcher,
         },
@@ -261,8 +261,8 @@ impl SearcherState {
         let reader = TransactionIndex::new(&self.index, self.connection.begin_transaction(None)?);
         let cursor = reader
             .transaction()
-            .open_cursor::<PostingKey, Vec<u8>>(self.index.postings_table_name())?;
-        let mut postings = RowPostingsMut::new(cursor);
+            .open_cursor::<u32, Vec<u8>>(self.index.postings_table_name())?;
+        let mut postings = BlockPostingsMut::new(cursor, self.index.posting_vector_len());
         let start = Instant::now();
         let results = self.searcher.search(query, &reader, &mut postings)?;
         let duration = Instant::now() - start;

--- a/et/src/spann/search.rs
+++ b/et/src/spann/search.rs
@@ -15,7 +15,6 @@ use easy_tiger::{
     input::{DerefVectorStore, VectorStore},
     spann::{
         TableIndex, TransactionIndex,
-        postings::BlockPostingsMut,
         search::{
             CentroidSelector, CentroidSelectorAlgorithm, SearchParams, SearchStats, Searcher,
         },
@@ -259,12 +258,11 @@ impl SearcherState {
         recall_computer: Option<&RecallComputer>,
     ) -> io::Result<AggregateSearchStats> {
         let reader = TransactionIndex::new(&self.index, self.connection.begin_transaction(None)?);
-        let cursor = reader
+        let mut posting_cursor = reader
             .transaction()
             .open_cursor::<u32, Vec<u8>>(self.index.postings_table_name())?;
-        let mut postings = BlockPostingsMut::new(cursor, self.index.posting_vector_len());
         let start = Instant::now();
-        let results = self.searcher.search(query, &reader, &mut postings)?;
+        let results = self.searcher.search(query, &reader, &mut posting_cursor)?;
         let duration = Instant::now() - start;
         Ok(AggregateSearchStats::new(
             duration,

--- a/et/src/spann/search.rs
+++ b/et/src/spann/search.rs
@@ -14,7 +14,8 @@ use clap::Args;
 use easy_tiger::{
     input::{DerefVectorStore, VectorStore},
     spann::{
-        TableIndex, TransactionIndex,
+        PostingKey, TableIndex, TransactionIndex,
+        postings::RowPostingsMut,
         search::{
             CentroidSelector, CentroidSelectorAlgorithm, SearchParams, SearchStats, Searcher,
         },
@@ -258,8 +259,12 @@ impl SearcherState {
         recall_computer: Option<&RecallComputer>,
     ) -> io::Result<AggregateSearchStats> {
         let reader = TransactionIndex::new(&self.index, self.connection.begin_transaction(None)?);
+        let cursor = reader
+            .transaction()
+            .open_cursor::<PostingKey, Vec<u8>>(self.index.postings_table_name())?;
+        let mut postings = RowPostingsMut::new(cursor);
         let start = Instant::now();
-        let results = self.searcher.search(query, &reader)?;
+        let results = self.searcher.search(query, &reader, &mut postings)?;
         let duration = Instant::now() - start;
         Ok(AggregateSearchStats::new(
             duration,

--- a/src/spann.rs
+++ b/src/spann.rs
@@ -168,6 +168,11 @@ impl TableIndex {
             .coder(self.head_config().config().similarity, None)
     }
 
+    pub fn posting_vector_len(&self) -> usize {
+        self.new_posting_coder()
+            .byte_len(self.head_config().config().dimensions.get())
+    }
+
     pub fn from_db(connection: &Arc<Connection>, index_name: &str) -> io::Result<Self> {
         let head = Arc::new(TableGraphVectorIndex::from_db(
             connection,
@@ -237,7 +242,7 @@ impl TableIndex {
             &table_names.postings,
             Some(
                 CreateOptionsBuilder::default()
-                    .key_format::<PostingKey>()
+                    .key_format::<u32>()
                     .value_format::<Vec<u8>>()
                     .app_metadata(&serde_json::to_string(&spann_config)?)
                     .into(),

--- a/src/spann.rs
+++ b/src/spann.rs
@@ -5,6 +5,7 @@
 
 pub mod bulk;
 pub mod centroid_stats;
+pub mod postings;
 pub mod rebalance;
 pub mod search;
 

--- a/src/spann.rs
+++ b/src/spann.rs
@@ -212,6 +212,8 @@ impl TableIndex {
         head_config: GraphConfig,
         spann_config: IndexConfig,
     ) -> io::Result<Self> {
+        let head_similarity = head_config.similarity;
+        let head_dimensions = head_config.dimensions;
         let head = Arc::new(TableGraphVectorIndex::init_index(
             connection,
             head_config,
@@ -238,6 +240,15 @@ impl TableIndex {
                     .into(),
             ),
         )?;
+        let posting_vector_len = spann_config
+            .posting_coder
+            .coder(head_similarity, None)
+            .byte_len(head_dimensions.get());
+        let leaf_page_size = crate::posting_block::leaf_page_max(
+            spann_config.max_centroid_len,
+            posting_vector_len,
+            4096,
+        ) as u32;
         connection.create_table(
             &table_names.postings,
             Some(
@@ -245,6 +256,8 @@ impl TableIndex {
                     .key_format::<u32>()
                     .value_format::<Vec<u8>>()
                     .app_metadata(&serde_json::to_string(&spann_config)?)
+                    .leaf_page_max(leaf_page_size)
+                    .leaf_value_max(leaf_page_size)
                     .into(),
             ),
         )?;

--- a/src/spann/bulk.rs
+++ b/src/spann/bulk.rs
@@ -3,14 +3,14 @@ use std::{cell::RefCell, sync::Arc};
 use crate::{
     input::VectorStore,
     spann::{
-        centroid_stats::CentroidCounts, select_centroids, CentroidAssignment,
-        CentroidAssignmentType, PostingKey, TableIndex,
+        centroid_stats::CentroidCounts, postings::PostingsMut, select_centroids, CentroidAssignment,
+        CentroidAssignmentType, TableIndex,
     },
     vamana::{search::GraphSearcher, wt::TransactionGraphVectorIndex},
 };
 use rayon::prelude::*;
 use thread_local::ThreadLocal;
-use wt_mdb::{connection::CreateOptionsBuilder, session::Formatted, Connection, Result};
+use wt_mdb::{session::Formatted, Connection, Result};
 
 /// Assign all the vectors to one or more centroids in the head index. This performs the same search
 /// and pruning as [`super::TransactionIndex`] does.
@@ -104,28 +104,23 @@ pub fn load_centroid_stats(
     Ok(())
 }
 
-/// Bulk load entries for each of the posting keys into the database.
+/// Load entries for each of the posting keys into `postings`.
 ///
-/// This runs in a single thread, reading the vector for each posting, quantizing it, and uploading
-/// it into a table. Bulk upload ensures that all posting entries belonging to each centroid appear
-/// contiguously on disk, whereas iterative insertion may "split up" a centroid as it splits leaf
-/// pages. Bulk uploading also avoids checkpointing.
+/// Vectors are encoded in parallel batches and inserted in (centroid_id, record_id) order, which
+/// allows implementations backed by sorted storage to place each centroid's entries contiguously.
+/// Callers must call [`PostingsMut::flush`] (or ensure `postings` does so on drop) to commit
+/// changes, though `load_postings` calls it internally before returning.
 pub fn load_postings(
     index: &TableIndex,
-    connection: &Arc<Connection>,
+    postings: &mut impl PostingsMut,
     centroid_assignments: &[CentroidAssignment],
     vectors: &(impl VectorStore<Elem = f32> + Send + Sync),
     progress: impl Fn(u64) + Send + Sync,
 ) -> Result<()> {
-    let mut posting_keys: Vec<PostingKey> = centroid_assignments
+    let mut posting_keys: Vec<(u32, i64)> = centroid_assignments
         .into_par_iter()
         .enumerate()
-        .flat_map_iter(|(i, a)| {
-            a.iter().map(move |(_, c)| PostingKey {
-                centroid_id: c,
-                record_id: i as i64,
-            })
-        })
+        .flat_map_iter(|(i, a)| a.iter().map(move |(_, c)| (c, i as i64)))
         .collect();
     posting_keys.par_sort_unstable();
 
@@ -133,13 +128,6 @@ pub fn load_postings(
         .config()
         .posting_coder
         .coder(index.head_config().config().similarity, None);
-    let mut bulk_cursor = connection.new_bulk_load_cursor::<PostingKey, Vec<u8>>(
-        &index.table_names.postings,
-        Some(
-            CreateOptionsBuilder::default()
-                .app_metadata(&serde_json::to_string(&index.config).unwrap()),
-        ),
-    )?;
     // Encode in batches to avoid single-threading encoding work. If the vectors are backed by mmap
     // this will also allow us to parallelize IO.
     let mut encoded_buffer =
@@ -148,15 +136,15 @@ pub fn load_postings(
         encoded_buffer
             .par_iter_mut()
             .zip(batch)
-            .for_each(|(buf, pk)| {
-                coder.encode_to(&vectors[pk.record_id as usize], buf);
+            .for_each(|(buf, &(_, record_id))| {
+                coder.encode_to(&vectors[record_id as usize], buf);
             });
-        for (pk, buf) in batch.iter().zip(encoded_buffer.iter()) {
-            bulk_cursor.append(*pk, buf)?;
+        for (&(centroid_id, record_id), buf) in batch.iter().zip(encoded_buffer.iter()) {
+            postings.insert(centroid_id, record_id, buf)?;
         }
         progress(batch.len() as u64);
     }
-    Ok(())
+    postings.flush()
 }
 
 /// Bulk load raw vector data into the raw vectors table for re-ranking.

--- a/src/spann/bulk.rs
+++ b/src/spann/bulk.rs
@@ -3,7 +3,7 @@ use std::{cell::RefCell, sync::Arc};
 use crate::{
     input::VectorStore,
     spann::{
-        centroid_stats::CentroidCounts, postings::PostingsMut, select_centroids, CentroidAssignment,
+        centroid_stats::CentroidCounts, postings::BlockPostingsMut, select_centroids, CentroidAssignment,
         CentroidAssignmentType, TableIndex,
     },
     vamana::{search::GraphSearcher, wt::TransactionGraphVectorIndex},
@@ -112,7 +112,7 @@ pub fn load_centroid_stats(
 /// changes, though `load_postings` calls it internally before returning.
 pub fn load_postings(
     index: &TableIndex,
-    postings: &mut impl PostingsMut,
+    postings: &mut BlockPostingsMut<'_>,
     centroid_assignments: &[CentroidAssignment],
     vectors: &(impl VectorStore<Elem = f32> + Send + Sync),
     progress: impl Fn(u64) + Send + Sync,

--- a/src/spann/postings.rs
+++ b/src/spann/postings.rs
@@ -1,0 +1,187 @@
+//! Trait and implementations for mutating SPANN postings.
+
+use std::collections::HashMap;
+
+use wt_mdb::{Error, Result, TypedCursorGuard};
+
+use crate::posting_block::{PostingBlock, PostingBlockMut};
+
+use super::PostingKey;
+
+/// Interface for applying batched mutations to SPANN postings.
+///
+/// Callers issue any number of inserts, removals, and drains then call [`PostingsMut::flush`] once
+/// to commit all pending changes to storage.
+pub trait PostingsMut {
+    /// Insert or update the posting for `(centroid_id, record_id)`.
+    fn insert(&mut self, centroid_id: u32, record_id: i64, vector: &[u8]) -> Result<()>;
+
+    /// Remove the posting for `(centroid_id, record_id)`.
+    ///
+    /// Not-found is silently ignored.
+    fn remove(&mut self, centroid_id: u32, record_id: i64) -> Result<()>;
+
+    /// Remove all postings for `centroid_id` and return them as `(record_id, vector)` pairs.
+    fn drain(&mut self, centroid_id: u32) -> Result<Vec<(i64, Vec<u8>)>>;
+
+    /// Read all postings for `centroid_id` without removing them.
+    ///
+    /// This is transactional -- it reflects all mutations made to each centroid.
+    fn read_centroid(&mut self, centroid_id: u32) -> Result<Vec<(i64, Vec<u8>)>>;
+
+    /// Write all buffered changes to storage.
+    fn flush(&mut self) -> Result<()>;
+}
+
+/// Posting mutations backed by the row-per-vector table format.
+///
+/// Each `(centroid_id, record_id)` pair occupies its own WiredTiger row. Mutations go to storage
+/// immediately; [`flush`][PostingsMut::flush] is a no-op.
+pub struct RowPostingsMut<'a> {
+    cursor: TypedCursorGuard<'a, PostingKey, Vec<u8>>,
+}
+
+impl<'a> RowPostingsMut<'a> {
+    pub fn new(cursor: TypedCursorGuard<'a, PostingKey, Vec<u8>>) -> Self {
+        Self { cursor }
+    }
+}
+
+impl PostingsMut for RowPostingsMut<'_> {
+    fn insert(&mut self, centroid_id: u32, record_id: i64, vector: &[u8]) -> Result<()> {
+        self.cursor.set(
+            PostingKey {
+                centroid_id,
+                record_id,
+            },
+            vector,
+        )
+    }
+
+    fn remove(&mut self, centroid_id: u32, record_id: i64) -> Result<()> {
+        self.cursor
+            .remove(PostingKey {
+                centroid_id,
+                record_id,
+            })
+            .or_else(|e| {
+                if e == Error::not_found_error() {
+                    Ok(())
+                } else {
+                    Err(e)
+                }
+            })
+    }
+
+    fn drain(&mut self, centroid_id: u32) -> Result<Vec<(i64, Vec<u8>)>> {
+        let mut vectors = vec![];
+        self.cursor
+            .set_bounds(PostingKey::centroid_range(centroid_id))?;
+        while let Some(r) = self.cursor.next() {
+            let (key, vector) = r?;
+            vectors.push((key.record_id, vector));
+            self.cursor.remove(key)?;
+        }
+        self.cursor.reset()?;
+        Ok(vectors)
+    }
+
+    fn read_centroid(&mut self, centroid_id: u32) -> Result<Vec<(i64, Vec<u8>)>> {
+        let mut entries = vec![];
+        self.cursor
+            .set_bounds(PostingKey::centroid_range(centroid_id))?;
+        while let Some(r) = self.cursor.next() {
+            let (key, vector) = r?;
+            entries.push((key.record_id, vector));
+        }
+        self.cursor.reset()?;
+        Ok(entries)
+    }
+
+    fn flush(&mut self) -> Result<()> {
+        Ok(())
+    }
+}
+
+/// Posting mutations backed by a centroid-keyed [`PostingBlock`] table.
+///
+/// Each centroid maps to a single row whose value is a serialized [`PostingBlock`] containing all
+/// vectors assigned to that centroid. Modified blocks are held in memory and written to storage
+/// only when [`flush`][PostingsMut::flush] is called.
+pub struct BlockPostingsMut<'a> {
+    cursor: TypedCursorGuard<'a, u32, Vec<u8>>,
+    vector_len: usize,
+    dirty: HashMap<u32, PostingBlockMut>,
+}
+
+impl<'a> BlockPostingsMut<'a> {
+    pub fn new(cursor: TypedCursorGuard<'a, u32, Vec<u8>>, vector_len: usize) -> Self {
+        Self {
+            cursor,
+            vector_len,
+            dirty: HashMap::new(),
+        }
+    }
+
+    fn load_or_create(&mut self, centroid_id: u32) -> Result<&mut PostingBlockMut> {
+        if !self.dirty.contains_key(&centroid_id) {
+            let block = match self.cursor.seek_exact(centroid_id) {
+                Some(r) => {
+                    let data = r?;
+                    let pb = PostingBlock::new(&data, self.vector_len)
+                        .ok_or_else(|| Error::WiredTiger(wt_mdb::WiredTigerError::Generic))?;
+                    PostingBlockMut::from_block(&pb)
+                }
+                None => PostingBlockMut::new(self.vector_len),
+            };
+            self.dirty.insert(centroid_id, block);
+        }
+        Ok(self.dirty.get_mut(&centroid_id).unwrap())
+    }
+}
+
+impl PostingsMut for BlockPostingsMut<'_> {
+    fn insert(&mut self, centroid_id: u32, record_id: i64, vector: &[u8]) -> Result<()> {
+        self.load_or_create(centroid_id)?
+            .insert(record_id, vector.to_vec());
+        Ok(())
+    }
+
+    fn remove(&mut self, centroid_id: u32, record_id: i64) -> Result<()> {
+        self.load_or_create(centroid_id)?.remove(record_id);
+        Ok(())
+    }
+
+    fn drain(&mut self, centroid_id: u32) -> Result<Vec<(i64, Vec<u8>)>> {
+        let vector_len = self.vector_len;
+        let block = self.load_or_create(centroid_id)?;
+        let entries = block.iter().map(|(id, v)| (id, v.to_vec())).collect();
+        *block = PostingBlockMut::new(vector_len);
+        Ok(entries)
+    }
+
+    fn read_centroid(&mut self, centroid_id: u32) -> Result<Vec<(i64, Vec<u8>)>> {
+        Ok(self
+            .load_or_create(centroid_id)?
+            .iter()
+            .map(|(id, v)| (id, v.to_vec()))
+            .collect())
+    }
+
+    fn flush(&mut self) -> Result<()> {
+        for (centroid_id, block) in self.dirty.drain() {
+            if block.is_empty() {
+                self.cursor.remove(centroid_id).or_else(|e| {
+                    if e == Error::not_found_error() {
+                        Ok(())
+                    } else {
+                        Err(e)
+                    }
+                })?;
+            } else {
+                self.cursor.set(centroid_id, block.serialize().as_slice())?;
+            }
+        }
+        Ok(())
+    }
+}

--- a/src/spann/postings.rs
+++ b/src/spann/postings.rs
@@ -84,7 +84,7 @@ impl<'a> BlockPostingsMut<'a> {
             let base = block.base_block();
             if !base.is_empty() {
                 let max_diff = base.len() * 15 / 100;
-                if let Some(mut deltas) = self.cursor.calculate_modifications(
+                if let Some(deltas) = self.cursor.calculate_modifications(
                     base,
                     &new_serialized,
                     max_diff,
@@ -92,7 +92,7 @@ impl<'a> BlockPostingsMut<'a> {
                 ) {
                     // SAFETY: modify_buf[..n] holds WT_MODIFY entries whose data pointers
                     // point into new_serialized, which remains alive for this call.
-                    unsafe { self.cursor.modify_unsafe(centroid_id, &mut deltas)? };
+                    unsafe { self.cursor.modify_unsafe(centroid_id, deltas)? };
                     continue;
                 }
             }
@@ -109,7 +109,7 @@ impl<'a> BlockPostingsMut<'a> {
                     Some(r) => {
                         let data = r?;
                         let pb = PostingBlock::new(&data, self.vector_len)
-                            .ok_or_else(|| Error::WiredTiger(wt_mdb::WiredTigerError::Generic))?;
+                            .ok_or(Error::WiredTiger(wt_mdb::WiredTigerError::Generic))?;
                         PostingBlockMut::from_block(&pb)
                     }
                     None => PostingBlockMut::new(self.vector_len),

--- a/src/spann/postings.rs
+++ b/src/spann/postings.rs
@@ -1,4 +1,4 @@
-//! Trait and implementations for mutating SPANN postings.
+//! Block-based posting storage for SPANN.
 
 use std::collections::{
     hash_map::Entry::{Occupied, Vacant},
@@ -9,108 +9,11 @@ use wt_mdb::{Error, Result, TypedCursorGuard};
 
 use crate::posting_block::{PostingBlock, PostingBlockMut};
 
-use super::PostingKey;
-
-/// Interface for applying batched mutations to SPANN postings.
-///
-/// Callers issue any number of inserts, removals, and drains then call [`PostingsMut::flush`] once
-/// to commit all pending changes to storage.
-pub trait PostingsMut {
-    /// Insert or update the posting for `(centroid_id, record_id)`.
-    fn insert(&mut self, centroid_id: u32, record_id: i64, vector: &[u8]) -> Result<()>;
-
-    /// Remove the posting for `(centroid_id, record_id)`.
-    ///
-    /// Not-found is silently ignored.
-    fn remove(&mut self, centroid_id: u32, record_id: i64) -> Result<()>;
-
-    /// Remove all postings for `centroid_id`.
-    ///
-    /// Not-found is silently ignored.
-    fn remove_centroid(&mut self, centroid_id: u32) -> Result<()>;
-
-    /// Read all postings for `centroid_id` without removing them.
-    ///
-    /// This is transactional -- it reflects all mutations made to each centroid.
-    fn read_centroid(&mut self, centroid_id: u32) -> Result<Vec<(i64, Vec<u8>)>>;
-
-    /// Write all buffered changes to storage.
-    fn flush(&mut self) -> Result<()>;
-}
-
-/// Posting mutations backed by the row-per-vector table format.
-///
-/// Each `(centroid_id, record_id)` pair occupies its own WiredTiger row. Mutations go to storage
-/// immediately; [`flush`][PostingsMut::flush] is a no-op.
-pub struct RowPostingsMut<'a> {
-    cursor: TypedCursorGuard<'a, PostingKey, Vec<u8>>,
-}
-
-impl<'a> RowPostingsMut<'a> {
-    pub fn new(cursor: TypedCursorGuard<'a, PostingKey, Vec<u8>>) -> Self {
-        Self { cursor }
-    }
-}
-
-impl PostingsMut for RowPostingsMut<'_> {
-    fn insert(&mut self, centroid_id: u32, record_id: i64, vector: &[u8]) -> Result<()> {
-        self.cursor.set(
-            PostingKey {
-                centroid_id,
-                record_id,
-            },
-            vector,
-        )
-    }
-
-    fn remove(&mut self, centroid_id: u32, record_id: i64) -> Result<()> {
-        self.cursor
-            .remove(PostingKey {
-                centroid_id,
-                record_id,
-            })
-            .or_else(|e| {
-                if e == Error::not_found_error() {
-                    Ok(())
-                } else {
-                    Err(e)
-                }
-            })
-    }
-
-    fn remove_centroid(&mut self, centroid_id: u32) -> Result<()> {
-        self.cursor
-            .set_bounds(PostingKey::centroid_range(centroid_id))?;
-        while let Some(r) = self.cursor.next() {
-            let (key, _) = r?;
-            self.cursor.remove(key)?;
-        }
-        self.cursor.reset()?;
-        Ok(())
-    }
-
-    fn read_centroid(&mut self, centroid_id: u32) -> Result<Vec<(i64, Vec<u8>)>> {
-        let mut entries = vec![];
-        self.cursor
-            .set_bounds(PostingKey::centroid_range(centroid_id))?;
-        while let Some(r) = self.cursor.next() {
-            let (key, vector) = r?;
-            entries.push((key.record_id, vector));
-        }
-        self.cursor.reset()?;
-        Ok(entries)
-    }
-
-    fn flush(&mut self) -> Result<()> {
-        Ok(())
-    }
-}
-
 /// Posting mutations backed by a centroid-keyed [`PostingBlock`] table.
 ///
 /// Each centroid maps to a single row whose value is a serialized [`PostingBlock`] containing all
 /// vectors assigned to that centroid. Modified blocks are held in memory and written to storage
-/// only when [`flush`][PostingsMut::flush] is called.
+/// only when [`flush`] is called.
 pub struct BlockPostingsMut<'a> {
     cursor: TypedCursorGuard<'a, u32, Vec<u8>>,
     vector_len: usize,
@@ -124,6 +27,60 @@ impl<'a> BlockPostingsMut<'a> {
             vector_len,
             dirty: HashMap::new(),
         }
+    }
+
+    /// Insert or update the posting for `(centroid_id, record_id)`.
+    pub fn insert(&mut self, centroid_id: u32, record_id: i64, vector: &[u8]) -> Result<()> {
+        self.load_or_create(centroid_id)?
+            .insert(record_id, vector.to_vec());
+        Ok(())
+    }
+
+    /// Remove the posting for `(centroid_id, record_id)`.
+    ///
+    /// Not-found is silently ignored.
+    pub fn remove(&mut self, centroid_id: u32, record_id: i64) -> Result<()> {
+        self.load_or_create(centroid_id)?.remove(record_id);
+        Ok(())
+    }
+
+    /// Remove all postings for `centroid_id`.
+    ///
+    /// Not-found is silently ignored.
+    pub fn remove_centroid(&mut self, centroid_id: u32) -> Result<()> {
+        // Overwrite with an empty block; flush will delete the row from storage.
+        self.dirty
+            .insert(centroid_id, PostingBlockMut::new(self.vector_len));
+        Ok(())
+    }
+
+    /// Read all postings for `centroid_id` without removing them.
+    ///
+    /// Reflects any pending mutations not yet flushed.
+    pub fn read_centroid(&mut self, centroid_id: u32) -> Result<Vec<(i64, Vec<u8>)>> {
+        Ok(self
+            .load_or_create(centroid_id)?
+            .iter()
+            .map(|(id, v)| (id, v.to_vec()))
+            .collect())
+    }
+
+    /// Write all buffered changes to storage.
+    pub fn flush(&mut self) -> Result<()> {
+        for (centroid_id, block) in self.dirty.drain() {
+            if block.is_empty() {
+                self.cursor.remove(centroid_id).or_else(|e| {
+                    if e == Error::not_found_error() {
+                        Ok(())
+                    } else {
+                        Err(e)
+                    }
+                })?;
+            } else {
+                self.cursor.set(centroid_id, block.serialize().as_slice())?;
+            }
+        }
+        Ok(())
     }
 
     fn load_or_create(&mut self, centroid_id: u32) -> Result<&mut PostingBlockMut> {
@@ -142,50 +99,5 @@ impl<'a> BlockPostingsMut<'a> {
                 Ok(e.insert(block))
             }
         }
-    }
-}
-
-impl PostingsMut for BlockPostingsMut<'_> {
-    fn insert(&mut self, centroid_id: u32, record_id: i64, vector: &[u8]) -> Result<()> {
-        self.load_or_create(centroid_id)?
-            .insert(record_id, vector.to_vec());
-        Ok(())
-    }
-
-    fn remove(&mut self, centroid_id: u32, record_id: i64) -> Result<()> {
-        self.load_or_create(centroid_id)?.remove(record_id);
-        Ok(())
-    }
-
-    fn remove_centroid(&mut self, centroid_id: u32) -> Result<()> {
-        // Overwrite with an empty block; flush will delete the row from storage.
-        self.dirty
-            .insert(centroid_id, PostingBlockMut::new(self.vector_len));
-        Ok(())
-    }
-
-    fn read_centroid(&mut self, centroid_id: u32) -> Result<Vec<(i64, Vec<u8>)>> {
-        Ok(self
-            .load_or_create(centroid_id)?
-            .iter()
-            .map(|(id, v)| (id, v.to_vec()))
-            .collect())
-    }
-
-    fn flush(&mut self) -> Result<()> {
-        for (centroid_id, block) in self.dirty.drain() {
-            if block.is_empty() {
-                self.cursor.remove(centroid_id).or_else(|e| {
-                    if e == Error::not_found_error() {
-                        Ok(())
-                    } else {
-                        Err(e)
-                    }
-                })?;
-            } else {
-                self.cursor.set(centroid_id, block.serialize().as_slice())?;
-            }
-        }
-        Ok(())
     }
 }

--- a/src/spann/postings.rs
+++ b/src/spann/postings.rs
@@ -1,6 +1,9 @@
 //! Trait and implementations for mutating SPANN postings.
 
-use std::collections::HashMap;
+use std::collections::{
+    hash_map::Entry::{Occupied, Vacant},
+    HashMap,
+};
 
 use wt_mdb::{Error, Result, TypedCursorGuard};
 
@@ -21,8 +24,10 @@ pub trait PostingsMut {
     /// Not-found is silently ignored.
     fn remove(&mut self, centroid_id: u32, record_id: i64) -> Result<()>;
 
-    /// Remove all postings for `centroid_id` and return them as `(record_id, vector)` pairs.
-    fn drain(&mut self, centroid_id: u32) -> Result<Vec<(i64, Vec<u8>)>>;
+    /// Remove all postings for `centroid_id`.
+    ///
+    /// Not-found is silently ignored.
+    fn remove_centroid(&mut self, centroid_id: u32) -> Result<()>;
 
     /// Read all postings for `centroid_id` without removing them.
     ///
@@ -73,17 +78,15 @@ impl PostingsMut for RowPostingsMut<'_> {
             })
     }
 
-    fn drain(&mut self, centroid_id: u32) -> Result<Vec<(i64, Vec<u8>)>> {
-        let mut vectors = vec![];
+    fn remove_centroid(&mut self, centroid_id: u32) -> Result<()> {
         self.cursor
             .set_bounds(PostingKey::centroid_range(centroid_id))?;
         while let Some(r) = self.cursor.next() {
-            let (key, vector) = r?;
-            vectors.push((key.record_id, vector));
+            let (key, _) = r?;
             self.cursor.remove(key)?;
         }
         self.cursor.reset()?;
-        Ok(vectors)
+        Ok(())
     }
 
     fn read_centroid(&mut self, centroid_id: u32) -> Result<Vec<(i64, Vec<u8>)>> {
@@ -124,19 +127,21 @@ impl<'a> BlockPostingsMut<'a> {
     }
 
     fn load_or_create(&mut self, centroid_id: u32) -> Result<&mut PostingBlockMut> {
-        if !self.dirty.contains_key(&centroid_id) {
-            let block = match self.cursor.seek_exact(centroid_id) {
-                Some(r) => {
-                    let data = r?;
-                    let pb = PostingBlock::new(&data, self.vector_len)
-                        .ok_or_else(|| Error::WiredTiger(wt_mdb::WiredTigerError::Generic))?;
-                    PostingBlockMut::from_block(&pb)
-                }
-                None => PostingBlockMut::new(self.vector_len),
-            };
-            self.dirty.insert(centroid_id, block);
+        match self.dirty.entry(centroid_id) {
+            Occupied(e) => Ok(e.into_mut()),
+            Vacant(e) => {
+                let block = match self.cursor.seek_exact(centroid_id) {
+                    Some(r) => {
+                        let data = r?;
+                        let pb = PostingBlock::new(&data, self.vector_len)
+                            .ok_or_else(|| Error::WiredTiger(wt_mdb::WiredTigerError::Generic))?;
+                        PostingBlockMut::from_block(&pb)
+                    }
+                    None => PostingBlockMut::new(self.vector_len),
+                };
+                Ok(e.insert(block))
+            }
         }
-        Ok(self.dirty.get_mut(&centroid_id).unwrap())
     }
 }
 
@@ -152,12 +157,11 @@ impl PostingsMut for BlockPostingsMut<'_> {
         Ok(())
     }
 
-    fn drain(&mut self, centroid_id: u32) -> Result<Vec<(i64, Vec<u8>)>> {
-        let vector_len = self.vector_len;
-        let block = self.load_or_create(centroid_id)?;
-        let entries = block.iter().map(|(id, v)| (id, v.to_vec())).collect();
-        *block = PostingBlockMut::new(vector_len);
-        Ok(entries)
+    fn remove_centroid(&mut self, centroid_id: u32) -> Result<()> {
+        // Overwrite with an empty block; flush will delete the row from storage.
+        self.dirty
+            .insert(centroid_id, PostingBlockMut::new(self.vector_len));
+        Ok(())
     }
 
     fn read_centroid(&mut self, centroid_id: u32) -> Result<Vec<(i64, Vec<u8>)>> {

--- a/src/spann/postings.rs
+++ b/src/spann/postings.rs
@@ -5,7 +5,7 @@ use std::collections::{
     HashMap,
 };
 
-use wt_mdb::{Error, Result, TypedCursorGuard};
+use wt_mdb::{Error, Result, TypedCursorGuard, WT_MODIFY};
 
 use crate::posting_block::{PostingBlock, PostingBlockMut};
 
@@ -67,7 +67,9 @@ impl<'a> BlockPostingsMut<'a> {
 
     /// Write all buffered changes to storage.
     pub fn flush(&mut self) -> Result<()> {
-        for (centroid_id, block) in self.dirty.drain() {
+        let dirty = std::mem::take(&mut self.dirty);
+        let mut modify_buf = [WT_MODIFY::default(); 128];
+        for (centroid_id, block) in dirty {
             if block.is_empty() {
                 self.cursor.remove(centroid_id).or_else(|e| {
                     if e == Error::not_found_error() {
@@ -76,9 +78,25 @@ impl<'a> BlockPostingsMut<'a> {
                         Err(e)
                     }
                 })?;
-            } else {
-                self.cursor.set(centroid_id, block.serialize().as_slice())?;
+                continue;
             }
+            let new_serialized = block.serialize();
+            let base = block.base_block();
+            if !base.is_empty() {
+                let max_diff = base.len() * 15 / 100;
+                if let Some(mut deltas) = self.cursor.calculate_modifications(
+                    base,
+                    &new_serialized,
+                    max_diff,
+                    &mut modify_buf,
+                ) {
+                    // SAFETY: modify_buf[..n] holds WT_MODIFY entries whose data pointers
+                    // point into new_serialized, which remains alive for this call.
+                    unsafe { self.cursor.modify_unsafe(centroid_id, &mut deltas)? };
+                    continue;
+                }
+            }
+            self.cursor.set(centroid_id, new_serialized.as_slice())?;
         }
         Ok(())
     }

--- a/src/spann/rebalance.rs
+++ b/src/spann/rebalance.rs
@@ -165,7 +165,8 @@ pub fn merge_centroid(
         .transaction()
         .open_cursor::<PostingKey, Vec<u8>>(index.postings_table_name())?;
     let mut postings = RowPostingsMut::new(posting_cursor);
-    let vectors = postings.drain(centroid_id as u32)?;
+    let vectors = postings.read_centroid(centroid_id as u32)?;
+    postings.remove_centroid(centroid_id as u32)?;
     assert_eq!(
         vectors.len(),
         len,
@@ -248,7 +249,8 @@ pub fn split_centroid(
         .transaction()
         .open_cursor::<PostingKey, Vec<u8>>(txn_idx.index().postings_table_name())?;
     let mut postings = RowPostingsMut::new(posting_cursor);
-    let vectors = postings.drain(centroid_id as u32)?;
+    let vectors = postings.read_centroid(centroid_id as u32)?;
+    postings.remove_centroid(centroid_id as u32)?;
     assert_eq!(
         vectors.len(),
         len,

--- a/src/spann/rebalance.rs
+++ b/src/spann/rebalance.rs
@@ -7,13 +7,14 @@ use std::{
 
 use rand::Rng;
 use tracing::warn;
-use wt_mdb::{session::Formatted, Error, Result, TypedCursor};
+use wt_mdb::{session::Formatted, Error, Result};
 
 use crate::{
     input::VecVectorStore,
     kmeans,
     spann::{
         centroid_stats::{CentroidAssignmentUpdater, CentroidCounts, CentroidStats},
+        postings::{PostingsMut, RowPostingsMut},
         select_centroids, CentroidAssignment, PostingKey, TransactionIndex,
     },
     vamana::{
@@ -160,10 +161,11 @@ pub fn merge_centroid(
 ) -> Result<MergeStats> {
     // Collect all of the vectors for the centroid to merge.
     let index = Arc::clone(txn_idx.index());
-    let mut posting_cursor = txn_idx
+    let posting_cursor = txn_idx
         .transaction()
         .open_cursor::<PostingKey, Vec<u8>>(index.postings_table_name())?;
-    let vectors = drain_centroid(centroid_id, &mut posting_cursor)?;
+    let mut postings = RowPostingsMut::new(posting_cursor);
+    let vectors = postings.drain(centroid_id as u32)?;
     assert_eq!(
         vectors.len(),
         len,
@@ -190,7 +192,6 @@ pub fn merge_centroid(
     let mut float_vector = vec![0.0f32; index.head_config().config().dimensions.get()];
     let mut unique_centroids = HashSet::new();
     let mut assignment_updater = CentroidAssignmentUpdater::new(txn_idx)?;
-    posting_cursor.reset()?;
     for (record_id, vector) in vectors {
         coder.decode_to(&vector, &mut float_vector);
         // TODO: seed the search with the existing assignments for this record; reduce budget.
@@ -209,20 +210,18 @@ pub fn merge_centroid(
         let old_assignments =
             assignment_updater.update(record_id, new_assignments.to_formatted_ref())?;
         move_postings(
-            PostingKey {
-                centroid_id: centroid_id as u32,
-                record_id,
-            },
+            record_id,
             &vector,
             &old_assignments,
             &new_assignments,
-            &mut posting_cursor,
+            &mut postings,
         )?;
         for (_, new_centroid) in new_assignments.iter() {
             unique_centroids.insert(new_centroid);
         }
     }
 
+    postings.flush()?;
     assignment_updater.flush()?;
     txn_idx
         .transaction()
@@ -245,10 +244,11 @@ pub fn split_centroid(
     len: usize,
     rng: &mut impl Rng,
 ) -> Result<SplitStats> {
-    let mut posting_cursor = txn_idx
+    let posting_cursor = txn_idx
         .transaction()
         .open_cursor::<PostingKey, Vec<u8>>(txn_idx.index().postings_table_name())?;
-    let vectors = drain_centroid(centroid_id, &mut posting_cursor)?;
+    let mut postings = RowPostingsMut::new(posting_cursor);
+    let vectors = postings.drain(centroid_id as u32)?;
     assert_eq!(
         vectors.len(),
         len,
@@ -266,7 +266,6 @@ pub fn split_centroid(
         posting_coder.decode_to(vector, &mut scratch_vector);
         clustering_vectors.push(&scratch_vector);
     }
-    posting_cursor.reset()?;
 
     let centroids = match kmeans::balanced_binary_partition(
         &clustering_vectors,
@@ -371,14 +370,11 @@ pub fn split_centroid(
         let old_assignments =
             assignment_updater.update(record_id, new_assignments.to_formatted_ref())?;
         move_postings(
-            PostingKey {
-                centroid_id: centroid_id as u32,
-                record_id,
-            },
+            record_id,
             &vector,
             &old_assignments,
             &new_assignments,
-            &mut posting_cursor,
+            &mut postings,
         )?;
 
         for (_, new_centroid) in new_assignments.iter() {
@@ -390,9 +386,6 @@ pub fn split_centroid(
     let mut nearby_moved = 0;
     // For a list of nearby centroids, examine all vectors and reassign them if they are closer
     // to one of the new centroids than they are to the current centroid.
-    let mut nearby_posting_cursor = txn_idx
-        .transaction()
-        .open_cursor::<PostingKey, Vec<u8>>(txn_idx.index().postings_table_name())?;
     let mut assignment_cursor = txn_idx
         .transaction()
         .open_cursor::<i64, CentroidAssignment>(
@@ -415,19 +408,17 @@ pub fn split_centroid(
             )
         };
 
-        nearby_posting_cursor.set_bounds(PostingKey::centroid_range(nearby_centroid_id))?;
-        while let Some(r) = unsafe { nearby_posting_cursor.next_unsafe() } {
-            let (key, vector) = r?;
-            let c0_dist = c0_dist_fn.distance(vector);
-            let c1_dist = c1_dist_fn.distance(vector);
-            let c2_dist = c2_dist_fn.distance(vector);
+        for (record_id, vector) in postings.read_centroid(nearby_centroid_id)? {
+            let c0_dist = c0_dist_fn.distance(&vector);
+            let c1_dist = c1_dist_fn.distance(&vector);
+            let c2_dist = c2_dist_fn.distance(&vector);
 
             // Do not move postings that are not assigned to the original centroid; we're not
             // willing to do this work for secondaries.
             if txn_idx.index().config().replica_count > 1
                 && assignment_cursor
-                    .seek_exact(key.record_id)
-                    .map(|r| r.map(|a| a.primary_id != key.centroid_id))
+                    .seek_exact(record_id)
+                    .map(|r| r.map(|a| a.primary_id != nearby_centroid_id))
                     .unwrap_or(Ok(true))?
             {
                 continue;
@@ -444,7 +435,7 @@ pub fn split_centroid(
 
             let new_assignments = if txn_idx.index().config().replica_count > 1 {
                 searches += 1;
-                posting_coder.decode_to(vector, &mut scratch_vector);
+                posting_coder.decode_to(&vector, &mut scratch_vector);
                 let candidates = searcher.search_with_filter(
                     &scratch_vector,
                     |i| i != centroid_id as i64,
@@ -462,17 +453,18 @@ pub fn split_centroid(
             };
 
             let old_assignments =
-                assignment_updater.update(key.record_id, new_assignments.to_formatted_ref())?;
+                assignment_updater.update(record_id, new_assignments.to_formatted_ref())?;
             nearby_moved += move_postings(
-                key,
-                vector,
+                record_id,
+                &vector,
                 &old_assignments,
                 &new_assignments,
-                &mut posting_cursor,
+                &mut postings,
             )?;
         }
     }
 
+    postings.flush()?;
     assignment_updater.flush()?;
     txn_idx
         .transaction()
@@ -488,27 +480,12 @@ pub fn split_centroid(
     })
 }
 
-/// Remove all the vectors from `centroid_id` using `cursor` and return them.
-fn drain_centroid(
-    centroid_id: usize,
-    cursor: &mut TypedCursor<'_, PostingKey, Vec<u8>>,
-) -> Result<Vec<(i64, Vec<u8>)>> {
-    let mut vectors = vec![];
-    cursor.set_bounds(PostingKey::centroid_range(centroid_id as u32))?;
-    while let Some(r) = cursor.next() {
-        let (key, vector) = r?;
-        vectors.push((key.record_id, vector));
-        cursor.remove(key)?;
-    }
-    Ok(vectors)
-}
-
 fn move_postings(
-    original_key: PostingKey,
+    record_id: i64,
     vector: &[u8],
     old_assignment: &CentroidAssignment,
     new_assignment: &CentroidAssignment,
-    posting_cursor: &mut TypedCursor<'_, PostingKey, Vec<u8>>,
+    postings: &mut impl PostingsMut,
 ) -> Result<usize> {
     let old_assignment = old_assignment
         .iter()
@@ -518,27 +495,12 @@ fn move_postings(
         .iter()
         .map(|(_, id)| id)
         .collect::<BTreeSet<_>>();
-    for to_remove in old_assignment
-        .difference(&new_assignment)
-        .map(|&c| original_key.with_centroid_id(c))
-    {
-        posting_cursor
-            .remove(to_remove)
-            .or_else(|e| {
-                if e == Error::not_found_error() {
-                    Ok(())
-                } else {
-                    Err(e)
-                }
-            })
-            .expect("failed to remove posting");
+    for &centroid_id in old_assignment.difference(&new_assignment) {
+        postings.remove(centroid_id, record_id)?;
     }
     let mut added = 0;
-    for to_add in new_assignment
-        .difference(&old_assignment)
-        .map(|&c| original_key.with_centroid_id(c))
-    {
-        posting_cursor.set(to_add, vector)?;
+    for &centroid_id in new_assignment.difference(&old_assignment) {
+        postings.insert(centroid_id, record_id, vector)?;
         added += 1;
     }
     Ok(added)

--- a/src/spann/rebalance.rs
+++ b/src/spann/rebalance.rs
@@ -15,7 +15,7 @@ use crate::{
     spann::{
         centroid_stats::{CentroidAssignmentUpdater, CentroidCounts, CentroidStats},
         postings::BlockPostingsMut,
-        select_centroids, CentroidAssignment, PostingKey, TransactionIndex,
+        select_centroids, CentroidAssignment, TransactionIndex,
     },
     vamana::{
         mutate::{delete_vector, upsert_vector},

--- a/src/spann/rebalance.rs
+++ b/src/spann/rebalance.rs
@@ -14,7 +14,7 @@ use crate::{
     kmeans,
     spann::{
         centroid_stats::{CentroidAssignmentUpdater, CentroidCounts, CentroidStats},
-        postings::{PostingsMut, RowPostingsMut},
+        postings::BlockPostingsMut,
         select_centroids, CentroidAssignment, PostingKey, TransactionIndex,
     },
     vamana::{
@@ -163,8 +163,8 @@ pub fn merge_centroid(
     let index = Arc::clone(txn_idx.index());
     let posting_cursor = txn_idx
         .transaction()
-        .open_cursor::<PostingKey, Vec<u8>>(index.postings_table_name())?;
-    let mut postings = RowPostingsMut::new(posting_cursor);
+        .open_cursor::<u32, Vec<u8>>(index.postings_table_name())?;
+    let mut postings = BlockPostingsMut::new(posting_cursor, index.posting_vector_len());
     let vectors = postings.read_centroid(centroid_id as u32)?;
     postings.remove_centroid(centroid_id as u32)?;
     assert_eq!(
@@ -247,8 +247,8 @@ pub fn split_centroid(
 ) -> Result<SplitStats> {
     let posting_cursor = txn_idx
         .transaction()
-        .open_cursor::<PostingKey, Vec<u8>>(txn_idx.index().postings_table_name())?;
-    let mut postings = RowPostingsMut::new(posting_cursor);
+        .open_cursor::<u32, Vec<u8>>(txn_idx.index().postings_table_name())?;
+    let mut postings = BlockPostingsMut::new(posting_cursor, txn_idx.index().posting_vector_len());
     let vectors = postings.read_centroid(centroid_id as u32)?;
     postings.remove_centroid(centroid_id as u32)?;
     assert_eq!(
@@ -487,7 +487,7 @@ fn move_postings(
     vector: &[u8],
     old_assignment: &CentroidAssignment,
     new_assignment: &CentroidAssignment,
-    postings: &mut impl PostingsMut,
+    postings: &mut BlockPostingsMut<'_>,
 ) -> Result<usize> {
     let old_assignment = old_assignment
         .iter()

--- a/src/spann/search.rs
+++ b/src/spann/search.rs
@@ -14,7 +14,7 @@ use vectors::QueryVectorDistance;
 use wt_mdb::Result;
 
 use crate::{
-    spann::{centroid_stats::CentroidStats, PostingKey, TransactionIndex},
+    spann::{centroid_stats::CentroidStats, postings::PostingsMut, TransactionIndex},
     vamana::{
         search::{GraphSearchStats, GraphSearcher},
         GraphSearchParams, GraphVectorIndex,
@@ -194,7 +194,12 @@ impl Searcher {
         self.stats
     }
 
-    pub fn search(&mut self, query: &[f32], reader: &TransactionIndex) -> Result<Vec<Neighbor>> {
+    pub fn search(
+        &mut self,
+        query: &[f32],
+        reader: &TransactionIndex,
+        postings: &mut impl PostingsMut,
+    ) -> Result<Vec<Neighbor>> {
         self.stats = SearchStats::default();
 
         let mut centroids = self.head_searcher.search(query, reader.head())?;
@@ -222,25 +227,19 @@ impl Searcher {
         for c in centroids {
             let centroid_id: u32 = c.vertex().try_into().expect("centroid_id is a u32");
             // TODO: if I can't read a posting list then skip and warn rather than exiting early.
-            let mut cursor = reader
-                .transaction()
-                .open_cursor::<PostingKey, Vec<u8>>(&reader.index().table_names.postings)?;
-            cursor.set_bounds(PostingKey::centroid_range(centroid_id))?;
-            while let Some(r) = unsafe { cursor.next_unsafe() } {
+            let entries = match postings.read_centroid(centroid_id) {
+                Ok(e) => e,
+                Err(e) => {
+                    warn!("failed to read posting in centroid {centroid_id}: {e}");
+                    continue;
+                }
+            };
+            for (record_id, vector) in entries {
                 self.stats.posting_vectors_read += 1;
-                let (record_id, vector) = match r {
-                    Ok((k, v)) => (k.record_id, v),
-                    Err(e) => {
-                        warn!("failed to read posting in centroid {centroid_id}: {e}");
-                        continue;
-                    }
-                };
-
                 if !self.seen.insert(record_id) {
                     continue; // already seen
                 }
-
-                result_queue.push(record_id, vector);
+                result_queue.push(record_id, &vector);
             }
         }
 

--- a/src/spann/search.rs
+++ b/src/spann/search.rs
@@ -11,10 +11,11 @@ use std::{
 use min_max_heap::MinMaxHeap;
 use tracing::warn;
 use vectors::QueryVectorDistance;
-use wt_mdb::Result;
+use wt_mdb::{Result, TypedCursorGuard};
 
 use crate::{
-    spann::{centroid_stats::CentroidStats, postings::BlockPostingsMut, TransactionIndex},
+    posting_block::PostingBlock,
+    spann::{centroid_stats::CentroidStats, TransactionIndex},
     vamana::{
         search::{GraphSearchStats, GraphSearcher},
         GraphSearchParams, GraphVectorIndex,
@@ -198,7 +199,7 @@ impl Searcher {
         &mut self,
         query: &[f32],
         reader: &TransactionIndex,
-        postings: &mut BlockPostingsMut<'_>,
+        posting_cursor: &mut TypedCursorGuard<'_, u32, Vec<u8>>,
     ) -> Result<Vec<Neighbor>> {
         self.stats = SearchStats::default();
 
@@ -224,22 +225,28 @@ impl Searcher {
                     None,
                 ),
         );
+        let vector_len = reader.index().posting_vector_len();
         for c in centroids {
             let centroid_id: u32 = c.vertex().try_into().expect("centroid_id is a u32");
-            // TODO: if I can't read a posting list then skip and warn rather than exiting early.
-            let entries = match postings.read_centroid(centroid_id) {
-                Ok(e) => e,
-                Err(e) => {
-                    warn!("failed to read posting in centroid {centroid_id}: {e}");
+            // SAFETY: we are not performing any WT operations in between seeks.
+            let data = match unsafe { posting_cursor.seek_exact_unsafe(centroid_id) } {
+                Some(Ok(data)) => data,
+                Some(Err(e)) => {
+                    warn!("failed to read posting for centroid {centroid_id}: {e}");
                     continue;
                 }
+                None => continue,
             };
-            for (record_id, vector) in entries {
+            let Some(block) = PostingBlock::new(&data, vector_len) else {
+                warn!("malformed posting block for centroid {centroid_id}");
+                continue;
+            };
+            for (record_id, vector) in block.iter() {
                 self.stats.posting_vectors_read += 1;
                 if !self.seen.insert(record_id) {
                     continue; // already seen
                 }
-                result_queue.push(record_id, &vector);
+                result_queue.push(record_id, vector);
             }
         }
 

--- a/src/spann/search.rs
+++ b/src/spann/search.rs
@@ -237,7 +237,7 @@ impl Searcher {
                 }
                 None => continue,
             };
-            let Some(block) = PostingBlock::new(&data, vector_len) else {
+            let Some(block) = PostingBlock::new(data, vector_len) else {
                 warn!("malformed posting block for centroid {centroid_id}");
                 continue;
             };

--- a/src/spann/search.rs
+++ b/src/spann/search.rs
@@ -14,7 +14,7 @@ use vectors::QueryVectorDistance;
 use wt_mdb::Result;
 
 use crate::{
-    spann::{centroid_stats::CentroidStats, postings::PostingsMut, TransactionIndex},
+    spann::{centroid_stats::CentroidStats, postings::BlockPostingsMut, TransactionIndex},
     vamana::{
         search::{GraphSearchStats, GraphSearcher},
         GraphSearchParams, GraphVectorIndex,
@@ -198,7 +198,7 @@ impl Searcher {
         &mut self,
         query: &[f32],
         reader: &TransactionIndex,
-        postings: &mut impl PostingsMut,
+        postings: &mut BlockPostingsMut<'_>,
     ) -> Result<Vec<Neighbor>> {
         self.stats = SearchStats::default();
 

--- a/wt_mdb/src/lib.rs
+++ b/wt_mdb/src/lib.rs
@@ -131,6 +131,7 @@ pub use session::{
     IndexCursor, IndexCursorGuard, RecordCursor, RecordCursorGuard, StatCursor, TypedCursor,
     TypedCursorGuard, ValueDelta,
 };
+pub use wt_sys::WT_MODIFY;
 pub use transaction::Transaction;
 pub type Result<T> = std::result::Result<T, Error>;
 

--- a/wt_mdb/src/session/typed_cursor.rs
+++ b/wt_mdb/src/session/typed_cursor.rs
@@ -138,15 +138,73 @@ impl<'a, K: Formatted, V: Formatted> TypedCursor<'a, K, V> {
     ///
     /// Returns `ENOTSUP` if the value format is not `u`.
     pub fn modify(&mut self, key: K::Ref<'_>, deltas: &[ValueDelta<'_>]) -> Result<()> {
+        let mut entries: SmallVec<[WT_MODIFY; 32]> =
+            deltas.iter().copied().map(WT_MODIFY::from).collect();
+        unsafe { self.modify_unsafe(key, &mut entries) }
+    }
+
+    /// Compute modifications between `old_value` and `new_value` that can be passed to
+    /// `modify_unsafe()`.
+    ///
+    /// `modify()` and friends are useful if values may be large to avoid write amplification by
+    /// only logging deltas rather than the entire replacement value.
+    ///
+    /// This will compute up to `max_diff` bytes of diffs with up to `entries.len()` different
+    /// modifications. If set the return value contains the list of modification to apply via
+    /// `modify_unsafe()`. The returned WT_MODIFY values contain pointers into `new_value`; callers
+    /// are responsible for ensuring these pointer stay alive as long as is necessary.
+    pub fn calculate_modifications<'m>(
+        &self,
+        old_value: &[u8],
+        new_value: &[u8],
+        max_diff: usize,
+        modifications: &'m mut [WT_MODIFY],
+    ) -> Option<&'m [WT_MODIFY]> {
+        unsafe {
+            let old_value = WT_ITEM::from_slice(old_value);
+            let new_value = WT_ITEM::from_slice(new_value);
+            let mut nentries = 0i32;
+            let ret = wt_sys::wiredtiger_calc_modify(
+                self.session.ptr.as_ptr(),
+                &old_value,
+                &new_value,
+                max_diff,
+                modifications.as_mut_ptr(),
+                &mut nentries,
+            );
+            if ret == 0 {
+                Some(&modifications[..nentries as usize])
+            } else {
+                None
+            }
+        }
+    }
+
+    /// Modify the value at `key` using a series insertions/deletions/replacements specified in
+    /// `modifications`.
+    ///
+    /// `modify()` and friends are useful if values may be large to avoid write amplification by
+    /// only logging deltas rather than the entire replacement value.
+    ///
+    /// This method _requires_ that there be an existing value for `key` and that the value type is
+    /// `u` or `Vec<u8>`. See WiredTiger documentation for more detail.
+    pub unsafe fn modify_unsafe(
+        &mut self,
+        key: K::Ref<'_>,
+        modifications: &mut [WT_MODIFY],
+    ) -> Result<()> {
         if V::FORMAT.format_str() != "u" {
             return Err(Error::Errno(Errno::NOTSUP));
         }
         let key = format_to_buf!(key, K, self.key_buf)?;
-        let mut entries: SmallVec<[WT_MODIFY; 32]> =
-            deltas.iter().copied().map(WT_MODIFY::from).collect();
         unsafe {
             wt_call!(void self.inner.0, set_key, &Item::from(key).0)?;
-            wt_call!(self.inner.0, modify, entries.as_mut_ptr(), entries.len() as i32)
+            wt_call!(
+                self.inner.0,
+                modify,
+                modifications.as_mut_ptr(),
+                modifications.len() as i32
+            )
         }
     }
 

--- a/wt_mdb/src/session/typed_cursor.rs
+++ b/wt_mdb/src/session/typed_cursor.rs
@@ -159,11 +159,11 @@ impl<'a, K: Formatted, V: Formatted> TypedCursor<'a, K, V> {
         new_value: &[u8],
         max_diff: usize,
         modifications: &'m mut [WT_MODIFY],
-    ) -> Option<&'m [WT_MODIFY]> {
+    ) -> Option<&'m mut [WT_MODIFY]> {
         unsafe {
             let old_value = WT_ITEM::from_slice(old_value);
             let new_value = WT_ITEM::from_slice(new_value);
-            let mut nentries = 0i32;
+            let mut nentries = modifications.len() as i32;
             let ret = wt_sys::wiredtiger_calc_modify(
                 self.session.ptr.as_ptr(),
                 &old_value,
@@ -173,7 +173,7 @@ impl<'a, K: Formatted, V: Formatted> TypedCursor<'a, K, V> {
                 &mut nentries,
             );
             if ret == 0 {
-                Some(&modifications[..nentries as usize])
+                Some(&mut modifications[..nentries as usize])
             } else {
                 None
             }

--- a/wt_mdb/src/session/typed_cursor.rs
+++ b/wt_mdb/src/session/typed_cursor.rs
@@ -188,6 +188,10 @@ impl<'a, K: Formatted, V: Formatted> TypedCursor<'a, K, V> {
     ///
     /// This method _requires_ that there be an existing value for `key` and that the value type is
     /// `u` or `Vec<u8>`. See WiredTiger documentation for more detail.
+    ///
+    /// # Safety
+    ///
+    /// The inputs to this method are unsafe as [`WT_MODIFY`] contains raw pointers.
     pub unsafe fn modify_unsafe(
         &mut self,
         key: K::Ref<'_>,

--- a/wt_sys/src/lib.rs
+++ b/wt_sys/src/lib.rs
@@ -11,3 +11,38 @@
 #![allow(rustdoc::broken_intra_doc_links)]
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+
+impl Default for __wt_item {
+    fn default() -> Self {
+        Self {
+            data: std::ptr::null(),
+            size: 0,
+            mem: std::ptr::null_mut(),
+            memsize: 0,
+            flags: 0,
+        }
+    }
+}
+
+impl __wt_item {
+    /// Construct a `WT_ITEM` pointing into `s`. The caller must ensure `s` outlives the item.
+    pub unsafe fn from_slice(s: &[u8]) -> Self {
+        Self {
+            data: s.as_ptr() as *const _,
+            size: s.len(),
+            mem: std::ptr::null_mut(),
+            memsize: 0,
+            flags: 0,
+        }
+    }
+}
+
+impl Default for __wt_modify {
+    fn default() -> Self {
+        Self {
+            data: __wt_item::default(),
+            offset: 0,
+            size: 0,
+        }
+    }
+}


### PR DESCRIPTION
Write tail indexes as centroid_id keyed with a single value containing a block of hits.

During mutation we maintain a cache of blocks that include mutations, flushing them in between operations. When mutations make relatively small changes we push them into wiredtiger as "modifications" of the value to reduce write amplification. At search time we simply pull up the relevant blocks and score all of the results.

In testing this appears to be make searches roughly twice as fast but conversely makes insert ingestion 60% slower. Faster search makes plenty of sense: the compute cost of reading a single key-value pair in wiredtiger was at least double the cost of the computation that needed to be done, so if I reduce the key-value pair count by 400x that should help. The insertion slowdown should be investigated further but that path also has many other problems that need to be addressed.