### PR TITLE
SOAR + geometric distance filtering

### DIFF
--- a/src/spann.rs
+++ b/src/spann.rs
@@ -13,7 +13,10 @@ use std::{io, num::NonZero, ops::RangeInclusive, sync::Arc};
 
 use rustix::io::Errno;
 use serde::{Deserialize, Serialize};
-use vectors::{F32VectorCoder, F32VectorCoding, soar::SoarQueryVectorDistance};
+use vectors::{
+    EuclideanDistance, F32VectorCoder, F32VectorCoding, F32VectorDistance,
+    soar::SoarQueryVectorDistance,
+};
 use wt_mdb::{
     Connection, Error, Result, Transaction,
     connection::{CreateOptionsBuilder, DropOptions},
@@ -476,6 +479,10 @@ fn select_centroids_rng(
     ))
 }
 
+/// Ratio of distance from a vector to secondary and primary centroid.
+/// If the distance ratio is <= TAU then keep the secondary, else discard.
+const TAU: f64 = 1.05;
+
 fn select_centroids_soar(
     replica_count: usize,
     candidates: Vec<Neighbor>,
@@ -491,33 +498,33 @@ fn select_centroids_soar(
             .get(candidates[0].vertex())
             .unwrap_or(Err(Error::not_found_error()))?,
     );
-    let soar_dist = if let Some(dist) = SoarQueryVectorDistance::new(vector, &primary) {
-        dist
-    } else {
-        return Ok(CentroidAssignment::new(candidates[0].vertex() as u32, &[]));
-    };
-    let mut secondary_centroid_ids = Vec::with_capacity(candidates.len() - 1);
-    let mut candidate_vector = vec![0.0f32; primary.len()];
-    for candidate in candidates.iter().skip(1) {
-        coder.decode_to(
-            vectors
-                .get(candidate.vertex())
-                .unwrap_or(Err(Error::not_found_error()))?,
-            &mut candidate_vector,
-        );
-        secondary_centroid_ids.push(Neighbor::new(
-            candidate.vertex(),
-            soar_dist.distance(&candidate_vector),
-        ));
-    }
+    let soar_dist = SoarQueryVectorDistance::new(vector, &primary);
+    let dist_fn = EuclideanDistance::get();
 
-    secondary_centroid_ids.sort_unstable();
+    let mut candidate_vector = vec![0.0f32; primary.len()];
+    let mut secondaries = candidates[1..]
+        .into_iter()
+        .map(|n| {
+            let v = vectors
+                .get(n.vertex())
+                .unwrap_or(Err(Error::not_found_error()))?;
+            coder.decode_to(v, &mut candidate_vector);
+            Ok((
+                Neighbor::new(n.vertex(), soar_dist.loss(&candidate_vector)),
+                dist_fn.distance_f32(vector, &candidate_vector),
+            ))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    secondaries.sort_unstable_by_key(|x| x.0);
+    secondaries.truncate(replica_count - 1);
+
+    let primary_dist = dist_fn.distance_f32(vector, &primary);
     Ok(CentroidAssignment::new(
         candidates[0].vertex() as u32,
-        &secondary_centroid_ids
-            .iter()
-            .take(replica_count - 1)
-            .map(|n| n.vertex() as u32)
+        &secondaries
+            .into_iter()
+            .filter(|(_, d)| *d / primary_dist < TAU)
+            .map(|x| x.0.vertex() as u32)
             .collect::<Vec<_>>(),
     ))
 }

--- a/src/spann.rs
+++ b/src/spann.rs
@@ -503,7 +503,7 @@ fn select_centroids_soar(
 
     let mut candidate_vector = vec![0.0f32; primary.len()];
     let mut secondaries = candidates[1..]
-        .into_iter()
+        .iter()
         .map(|n| {
             let v = vectors
                 .get(n.vertex())

--- a/vectors/src/float32.rs
+++ b/vectors/src/float32.rs
@@ -337,7 +337,7 @@ impl F32VectorCoder for VectorCoder {
 
 static L2_DIST: OnceLock<EuclideanDistance> = OnceLock::new();
 
-/// Computes a score based on l2 distance.
+/// Compute squared l2 (Euclidean) distance.
 #[derive(Debug, Copy, Clone, Default)]
 pub struct EuclideanDistance(InstructionSet);
 

--- a/vectors/src/soar.rs
+++ b/vectors/src/soar.rs
@@ -1,8 +1,8 @@
 //! Implementation of SOAR indexing distance for selecting replica centroids.
 //!
-//! https://arxiv.org/abs/2404.00774
+//! https://arxiv.org/pdf/2404.00774
 
-use crate::{F32VectorDistance, float32::EuclideanDistance};
+use crate::{DotProductDistance, F32VectorDistance};
 
 /// Compute SOAR distance between an input vector and another (centroid) vector, considering
 /// orthogonality to the primary centroid.
@@ -11,13 +11,15 @@ use crate::{F32VectorDistance, float32::EuclideanDistance};
 /// to decode any quantized vector format into floats before computing the value. It is recommended
 /// that callers use a high precision format for this purpose: f32, f16, or lvq2x.
 pub struct SoarQueryVectorDistance<'a> {
-    // The vector to compute centroid distance against.
+    /// The index vector to compute centroid distance against.
     vector: &'a [f32],
-    // Residual of vector and primary centroid.
-    residual: Vec<f32>,
-    // Distance between vector and primary centroid.
-    l2_dist_sq: f64,
-    // Hyper parameter.
+    /// Residual of vector and primary centroid.
+    primary_residual: Vec<f32>,
+    /// Dot of the residual vector against itself.
+    primary_residual_dot: f64,
+    /// Hyper parameter. Larger values select for orthogonality more aggressively.
+    /// When combined with a geometric ratio filter larger values tend to result in fewer replicas.
+    /// TODO: choose a lambda value based on expected MSE or the residual.
     lambda: f64,
 }
 
@@ -26,51 +28,44 @@ impl<'a> SoarQueryVectorDistance<'a> {
     const DEFAULT_LAMBDA: f64 = 1.0;
 
     /// Create a new soar vector from a vector reference and the closest centroid.
-    pub fn new(vector: &'a [f32], centroid: &[f32]) -> Option<Self> {
+    pub fn new(vector: &'a [f32], centroid: &[f32]) -> Self {
         Self::with_lambda(vector, centroid, Self::DEFAULT_LAMBDA)
     }
 
     /// Create a new soar vector from a vector reference, the closest centroid, and lambda param.
-    pub fn with_lambda(vector: &'a [f32], centroid: &[f32], lambda: f64) -> Option<Self> {
+    pub fn with_lambda(vector: &'a [f32], centroid: &[f32], lambda: f64) -> Self {
         assert_eq!(vector.len(), centroid.len());
 
-        // If the vector and centroid are very close to each other then decline to provide SOAR
-        // distance scoring; the caller should not select any replicas.
-        let l2_dist_sq = EuclideanDistance::default().distance_f32(vector, centroid);
-        if l2_dist_sq < 1e-10 {
-            return None;
-        }
-        let residual = vector
+        let primary_residual = vector
             .iter()
             .zip(centroid.iter())
             .map(|(v, c)| *v - *c)
             .collect::<Vec<_>>();
-        Some(Self {
+        let primary_residual_dot =
+            DotProductDistance::get().distance_f32(&primary_residual, &primary_residual);
+        Self {
             vector,
-            residual,
-            l2_dist_sq,
+            primary_residual,
+            primary_residual_dot,
             lambda,
-        })
+        }
     }
 
-    /// Compute the SOAR distance between a fixed query and a new centroid vector.
-    pub fn distance(&self, centroid: &[f32]) -> f64 {
-        let mut centroid_l2_dist_sq = 0.0;
-        let mut centroid_residual_projection = 0.0;
-        for ((v, r), c) in self
+    /// Compute loss for `centroid` as a secondary assignment. Lower values are preferred.
+    pub fn loss(&self, centroid: &[f32]) -> f64 {
+        let mut secondary_residual_dot = 0.0;
+        let mut residual_dot = 0.0;
+        for ((&v, &r), &c) in self
             .vector
             .iter()
-            .zip(self.residual.iter())
+            .zip(self.primary_residual.iter())
             .zip(centroid.iter())
         {
-            let diff = *v - *c;
-            centroid_l2_dist_sq = diff.mul_add(diff, centroid_l2_dist_sq);
-            centroid_residual_projection = diff.mul_add(*r, centroid_residual_projection)
+            let diff = v - c;
+            secondary_residual_dot = diff.mul_add(diff, secondary_residual_dot);
+            residual_dot = diff.mul_add(r, residual_dot)
         }
-        f64::from(centroid_l2_dist_sq)
-            + self.lambda
-                * f64::from(centroid_residual_projection)
-                * f64::from(centroid_residual_projection)
-                / self.l2_dist_sq
+        f64::from(secondary_residual_dot)
+            + self.lambda * f64::from(residual_dot).powi(2) / self.primary_residual_dot
     }
 }


### PR DESCRIPTION
Reorient SOAR implementation -- it's a loss function we use to order replica candidates. Filter the top candidate(s) based on geometric ratio of l2 distance using a fixed constant.

This doesn't appear to do much. Depending on tau value this might generate 5-25% of extra replicas. When using a fixed vector_count this always performs worse, probably due to a reduction in result diversity. If I only consider primaries in vector_count is results in overscoring, so it performs better. It's barely effective as a mechanism to reduce the number of postings read and does absolutely nothing to reduce the number of vectors scored.