### PR TITLE
Add backtraces to wt_mdb Errors

### DIFF
--- a/src/spann.rs
+++ b/src/spann.rs
@@ -292,7 +292,7 @@ impl Formatted for CentroidAssignment {
     #[inline(always)]
     fn unpack<'b>(packed: &'b [u8]) -> Result<Self::Ref<'b>> {
         if packed.len() != 4 {
-            return Err(Error::Errno(Errno::INVAL));
+            return Err(Error::errno(Errno::INVAL));
         }
         Ok(Self {
             primary_id: u32::from_le_bytes(packed.try_into().unwrap()),

--- a/src/spann/centroid_stats.rs
+++ b/src/spann/centroid_stats.rs
@@ -172,7 +172,7 @@ impl<'a> CentroidAssignmentUpdater<'a> {
     pub fn insert(&mut self, record_id: i64, assignment: CentroidAssignment) -> Result<()> {
         if let Some(_existing_assignment) = self.assignments_cursor.seek_exact(record_id) {
             error!("attempted to insert duplicate record id {}", record_id);
-            return Err(Error::WiredTiger(wt_mdb::WiredTigerError::DuplicateKey));
+            return Err(Error::wired_tiger(wt_mdb::WiredTigerError::DuplicateKey));
         }
         self.assignments_cursor.set(record_id, assignment)?;
         self.stats.increment_count(assignment.primary_id)?;
@@ -186,7 +186,7 @@ impl<'a> CentroidAssignmentUpdater<'a> {
         let existing_assignment = self
             .assignments_cursor
             .seek_exact(record_id)
-            .unwrap_or(Err(Error::not_found_error()))?;
+            .unwrap_or_else(|| Err(Error::not_found_error()))?;
         self.stats.decrement_count(existing_assignment.primary_id)?;
         self.assignments_cursor.remove(record_id)?;
         Ok(existing_assignment)
@@ -203,7 +203,7 @@ impl<'a> CentroidAssignmentUpdater<'a> {
         let existing_assignment = self
             .assignments_cursor
             .seek_exact(record_id)
-            .unwrap_or(Err(Error::not_found_error()))?;
+            .unwrap_or_else(|| Err(Error::not_found_error()))?;
         self.stats.decrement_count(existing_assignment.primary_id)?;
         self.stats.increment_count(assignment.primary_id)?;
         self.assignments_cursor

--- a/src/spann/postings.rs
+++ b/src/spann/postings.rs
@@ -145,7 +145,7 @@ impl<'a> BlockPostingsMut<'a> {
                     Some(r) => {
                         let data = r?;
                         let pb = PostingBlock::new(&data, self.vector_len)
-                            .ok_or(Error::WiredTiger(wt_mdb::WiredTigerError::Generic))?;
+                            .ok_or(Error::wired_tiger(wt_mdb::WiredTigerError::Generic))?;
                         PostingBlockMut::from_block(&pb)
                     }
                     None => PostingBlockMut::new(self.vector_len),

--- a/src/spann/rebalance.rs
+++ b/src/spann/rebalance.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashSet, ops::RangeInclusive, sync::Arc};
 
 use rand::Rng;
-use wt_mdb::{Connection, Error, Result, WiredTigerError};
+use wt_mdb::{Connection, Error, Kind, Result, WiredTigerError};
 
 use crate::{
     spann::{
@@ -552,7 +552,7 @@ mod split {
         let query = store.new_coder().decode(
             store
                 .get(centroid_id as i64)
-                .unwrap_or(Err(Error::not_found_error()))?,
+                .unwrap_or_else(|| Err(Error::not_found_error()))?,
         );
         let mut searcher = GraphSearcher::new(txn_idx.index().config().head_search_params);
         let mut candidates =
@@ -625,7 +625,7 @@ mod split {
             let query = self
                 .centroid_store
                 .get(centroid_id as i64)
-                .unwrap_or(Err(Error::not_found_error()))?;
+                .unwrap_or_else(|| Err(Error::not_found_error()))?;
             if let Some(head_coder) = self.head_coder.as_ref() {
                 let query = head_coder.decode(query);
                 Ok(self
@@ -679,7 +679,7 @@ fn retry_on_rollback<R>(
             index,
             connection.begin_transaction(None)?,
         )) {
-            Err(Error::WiredTiger(WiredTigerError::Rollback)) => continue,
+            Err(e) if e.kind() == Kind::WiredTiger(WiredTigerError::Rollback) => continue,
             result => break result,
         }
     }

--- a/src/vamana.rs
+++ b/src/vamana.rs
@@ -271,7 +271,7 @@ impl EdgeSetDistanceComputer {
             Self::from_store_and_edges(
                 &mut reader
                     .rerank_vectors()
-                    .unwrap_or(Err(Error::Errno(Errno::NOTSUP)))?,
+                    .unwrap_or_else(|| Err(Error::errno(Errno::NOTSUP)))?,
                 edges,
             )
         } else {
@@ -288,7 +288,7 @@ impl EdgeSetDistanceComputer {
             .map(|n| {
                 store
                     .get(n.vertex())
-                    .unwrap_or(Err(Error::not_found_error()))
+                    .unwrap_or_else(|| Err(Error::not_found_error()))
                     .map(|v| v.to_vec())
             })
             .collect::<Result<Vec<_>>>()?;

--- a/src/vamana/bulk.rs
+++ b/src/vamana/bulk.rs
@@ -758,23 +758,23 @@ impl<D: Send + Sync> Graph for BulkLoadBuilderGraph<'_, D> {
     }
 
     fn set_entry_point(&mut self, _: i64) -> Result<()> {
-        Err(Error::Errno(Errno::NOTSUP))
+        Err(Error::errno(Errno::NOTSUP))
     }
 
     fn remove_entry_point(&mut self) -> Result<()> {
-        Err(Error::Errno(Errno::NOTSUP))
+        Err(Error::errno(Errno::NOTSUP))
     }
 
     fn set_edges(&mut self, _: i64, _: impl Into<Vec<i64>>) -> Result<()> {
-        Err(Error::Errno(Errno::NOTSUP))
+        Err(Error::errno(Errno::NOTSUP))
     }
 
     fn remove_vertex(&mut self, _: i64) -> Result<Vec<i64>> {
-        Err(Error::Errno(Errno::NOTSUP))
+        Err(Error::errno(Errno::NOTSUP))
     }
 
     fn next_available_vertex_id(&mut self) -> Result<i64> {
-        Err(Error::Errno(Errno::NOTSUP))
+        Err(Error::errno(Errno::NOTSUP))
     }
 }
 
@@ -847,10 +847,10 @@ impl GraphVectorStore for BulkLoadGraphVectorStore<'_> {
     }
 
     fn set(&mut self, _: i64, _: impl AsRef<[u8]>) -> Result<()> {
-        Err(Error::Errno(Errno::NOTSUP))
+        Err(Error::errno(Errno::NOTSUP))
     }
 
     fn remove(&mut self, _: i64) -> Result<Vec<u8>> {
-        Err(Error::Errno(Errno::NOTSUP))
+        Err(Error::errno(Errno::NOTSUP))
     }
 }

--- a/src/vamana/mutate.rs
+++ b/src/vamana/mutate.rs
@@ -49,7 +49,7 @@ fn delete_vector_undirected(vertex_id: i64, index: &impl GraphVectorIndex) -> Re
         .map(|e| {
             graph
                 .edges(e)
-                .unwrap_or(Err(Error::not_found_error()))
+                .unwrap_or_else(|| Err(Error::not_found_error()))
                 .map(|edges| {
                     let vector = vectors.get(e).expect("row exists").map(|rv| rv.to_vec());
                     vector.map(|rv| (e, rv, edges.filter(|d| *d != vertex_id).collect::<Vec<_>>()))
@@ -326,7 +326,7 @@ fn insert_edge_directed(
 ) -> Result<Vec<i64>> {
     let mut edges = graph
         .edges(src_vertex_id)
-        .unwrap_or(Err(Error::not_found_error()))?
+        .unwrap_or_else(|| Err(Error::not_found_error()))?
         .collect::<Vec<_>>();
     if edges.contains(&dst_vertex_id) {
         return Ok(edges); // edge already exists.
@@ -358,7 +358,7 @@ fn remove_edge_directed(
 ) -> Result<()> {
     let edges = graph
         .edges(src_vertex_id)
-        .unwrap_or(Err(Error::not_found_error()))?
+        .unwrap_or_else(|| Err(Error::not_found_error()))?
         .filter(|v| *v != dst_vertex_id)
         .collect::<Vec<_>>();
     graph.set_edges(src_vertex_id, edges)

--- a/src/vamana/search.rs
+++ b/src/vamana/search.rs
@@ -168,7 +168,7 @@ impl GraphSearcher {
         let nav_query_rep = reader
             .nav_vectors()?
             .get(vertex_id)
-            .unwrap_or(Err(Error::not_found_error()))?
+            .unwrap_or_else(|| Err(Error::not_found_error()))?
             .to_vec();
         let nav_query = reader.config().nav_format.query_distance_symmetric(
             reader.config().similarity,
@@ -181,7 +181,7 @@ impl GraphSearcher {
                 let mut vectors = vectors?;
                 let query = vectors
                     .get(vertex_id)
-                    .unwrap_or(Err(Error::not_found_error()))?
+                    .unwrap_or_else(|| Err(Error::not_found_error()))?
                     .to_vec();
                 Some(vectors.format().query_distance_symmetric(
                     vectors.similarity(),
@@ -256,7 +256,7 @@ impl GraphSearcher {
             let entry_point = epr?;
             let entry_vector = nav
                 .get(entry_point)
-                .unwrap_or(Err(Error::not_found_error()))?;
+                .unwrap_or_else(|| Err(Error::not_found_error()))?;
             if self
                 .candidates
                 .add_unvisited(Neighbor::new(entry_point, nav_query.distance(entry_vector)))
@@ -279,7 +279,7 @@ impl GraphSearcher {
             let mut added = 0;
             for edge in graph
                 .edges(vertex_id)
-                .unwrap_or(Err(Error::not_found_error()))?
+                .unwrap_or_else(|| Err(Error::not_found_error()))?
                 .collect::<Vec<_>>()
             {
                 if !self.seen.insert(edge) {
@@ -652,23 +652,23 @@ mod test {
         }
 
         fn set_entry_point(&mut self, _: i64) -> Result<()> {
-            Err(Error::Errno(Errno::NOTSUP))
+            Err(Error::errno(Errno::NOTSUP))
         }
 
         fn remove_entry_point(&mut self) -> Result<()> {
-            Err(Error::Errno(Errno::NOTSUP))
+            Err(Error::errno(Errno::NOTSUP))
         }
 
         fn set_edges(&mut self, _: i64, _: impl Into<Vec<i64>>) -> Result<()> {
-            Err(Error::Errno(Errno::NOTSUP))
+            Err(Error::errno(Errno::NOTSUP))
         }
 
         fn remove_vertex(&mut self, _: i64) -> Result<Vec<i64>> {
-            Err(Error::Errno(Errno::NOTSUP))
+            Err(Error::errno(Errno::NOTSUP))
         }
 
         fn next_available_vertex_id(&mut self) -> Result<i64> {
-            Err(Error::Errno(Errno::NOTSUP))
+            Err(Error::errno(Errno::NOTSUP))
         }
     }
 
@@ -705,11 +705,11 @@ mod test {
         }
 
         fn set(&mut self, _: i64, _: impl AsRef<[u8]>) -> Result<()> {
-            Err(Error::Errno(Errno::NOTSUP))
+            Err(Error::errno(Errno::NOTSUP))
         }
 
         fn remove(&mut self, _: i64) -> Result<Vec<u8>> {
-            Err(Error::Errno(Errno::NOTSUP))
+            Err(Error::errno(Errno::NOTSUP))
         }
     }
 

--- a/src/vamana/wt.rs
+++ b/src/vamana/wt.rs
@@ -32,7 +32,7 @@ fn read_app_metadata_internal(txn: &Transaction, table_name: &str) -> Result<Str
     {
         Ok(app_metadata.to_owned())
     } else {
-        Err(Error::Errno(Errno::INVAL))
+        Err(Error::errno(Errno::INVAL))
     }
 }
 
@@ -107,7 +107,7 @@ impl Graph for CursorGraph<'_> {
 
     fn remove_vertex(&mut self, vertex_id: i64) -> Result<Vec<i64>> {
         self.edges(vertex_id)
-            .unwrap_or(Err(Error::not_found_error()))
+            .unwrap_or_else(|| Err(Error::not_found_error()))
             .map(|e| e.collect::<Vec<_>>())
             .and_then(|e| self.0.remove(vertex_id).map(|_| e))
     }
@@ -167,7 +167,7 @@ impl GraphVectorStore for CursorVectorStore<'_> {
         let vector = self
             .inner
             .seek_exact(vertex_id)
-            .unwrap_or(Err(Error::not_found_error()))?;
+            .unwrap_or_else(|| Err(Error::not_found_error()))?;
         self.inner.remove(vertex_id).map(|()| vector)
     }
 }
@@ -244,7 +244,7 @@ impl TableGraphVectorIndex {
         rerank_table_name: String,
     ) -> io::Result<Self> {
         if config.index_search_params.num_rerank > 0 && config.rerank_format.is_none() {
-            return Err(Error::Errno(Errno::NOTSUP).into());
+            return Err(Error::errno(Errno::NOTSUP).into());
         }
         let centroid: Option<Arc<[f32]>> = config.centroid.as_deref().map(Arc::from);
         Ok(Self {

--- a/wt_mdb/src/lib.rs
+++ b/wt_mdb/src/lib.rs
@@ -15,11 +15,13 @@ pub mod transaction;
 use rustix::io::Errno;
 use wt_sys::wiredtiger_strerror;
 
+use std::backtrace::Backtrace;
 use std::ffi::{c_char, CStr};
 use std::io;
 use std::io::ErrorKind;
 use std::num::NonZero;
 use std::str::FromStr;
+use std::sync::Arc;
 
 /// WiredTiger specific error codes.
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
@@ -79,38 +81,84 @@ impl From<WiredTigerError> for ErrorKind {
     }
 }
 
-/// An Error, either WiredTiger-specific or POSIX.
+/// The kind of a WiredTiger [`Error`], either WiredTiger-specific or POSIX.
 // TODO: use rustix::io::Errno instead of Posix
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
-pub enum Error {
+pub enum Kind {
     WiredTiger(WiredTigerError),
     Errno(Errno),
 }
 
+/// An Error, either WiredTiger-specific or POSIX, with a backtrace captured at the point
+/// the error was created.
+#[derive(Clone, Debug)]
+pub struct Error {
+    kind: Kind,
+    backtrace: Arc<Backtrace>,
+}
+
 impl Error {
+    fn new(kind: Kind) -> Self {
+        Error {
+            kind,
+            backtrace: Arc::new(Backtrace::capture()),
+        }
+    }
+
+    /// Construct a WiredTiger-specific error.
+    pub fn wired_tiger(kind: WiredTigerError) -> Self {
+        Self::new(Kind::WiredTiger(kind))
+    }
+
+    /// Construct a POSIX errno error.
+    pub fn errno(errno: Errno) -> Self {
+        Self::new(Kind::Errno(errno))
+    }
+
     fn generic_error() -> Self {
-        Error::WiredTiger(WiredTigerError::Generic)
+        Self::wired_tiger(WiredTigerError::Generic)
     }
 
     /// Return a WiredTiger `NotFound` error.
-    pub const fn not_found_error() -> Self {
-        Error::WiredTiger(WiredTigerError::NotFound)
+    pub fn not_found_error() -> Self {
+        Self::wired_tiger(WiredTigerError::NotFound)
+    }
+
+    /// Return the kind of this error.
+    pub fn kind(&self) -> Kind {
+        self.kind
+    }
+
+    /// Return the backtrace captured when this error was created.
+    ///
+    /// Only populated if backtrace capture is enabled, e.g. by setting `RUST_BACKTRACE=1`.
+    pub fn backtrace(&self) -> &Backtrace {
+        &self.backtrace
     }
 }
 
+impl PartialEq for Error {
+    fn eq(&self, other: &Self) -> bool {
+        self.kind == other.kind
+    }
+}
+
+impl Eq for Error {}
+
 impl From<NonZero<i32>> for Error {
     fn from(value: NonZero<i32>) -> Self {
-        WiredTigerError::try_from_code(value.get())
-            .map(Error::WiredTiger)
-            .unwrap_or_else(|| Error::Errno(Errno::from_raw_os_error(value.get())))
+        let kind = WiredTigerError::try_from_code(value.get())
+            .map(Kind::WiredTiger)
+            .unwrap_or_else(|| Kind::Errno(Errno::from_raw_os_error(value.get())));
+        Self::new(kind)
     }
 }
 
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::WiredTiger(w) => write!(f, "WT {w}"),
-            Self::Errno(p) => write!(f, "errno {p}"),
+        match self.kind {
+            Kind::WiredTiger(w) => write!(f, "WT {w}"),
+            Kind::Errno(p) => write!(f, "errno {p}"),
         }
     }
 }
@@ -119,9 +167,9 @@ impl std::error::Error for Error {}
 
 impl From<Error> for std::io::Error {
     fn from(value: Error) -> Self {
-        match &value {
-            Error::WiredTiger(wt) => io::Error::new((*wt).into(), value),
-            Error::Errno(errno) => io::Error::from(*errno),
+        match value.kind {
+            Kind::WiredTiger(wt) => io::Error::new(wt.into(), value),
+            Kind::Errno(errno) => io::Error::from(errno),
         }
     }
 }
@@ -342,7 +390,7 @@ mod test {
         assert_eq!(cursor.next(), None);
         assert_eq!(
             cursor.remove(13),
-            Err(Error::WiredTiger(WiredTigerError::NotFound))
+            Err(Error::wired_tiger(WiredTigerError::NotFound))
         );
     }
 
@@ -360,7 +408,7 @@ mod test {
         assert_eq!(cursor.next(), None);
         assert_eq!(
             cursor.remove(&b"c".as_slice()),
-            Err(Error::WiredTiger(WiredTigerError::NotFound))
+            Err(Error::wired_tiger(WiredTigerError::NotFound))
         );
     }
 
@@ -495,7 +543,7 @@ mod test {
         txn.commit(None).unwrap();
         assert_eq!(
             conn.bulk_load::<i64, Vec<u8>, _>("test", None, [(7, b"foo".to_vec())].into_iter()),
-            Err(Error::Errno(Errno::BUSY))
+            Err(Error::errno(Errno::BUSY))
         );
     }
 
@@ -510,7 +558,7 @@ mod test {
                 None,
                 [(11, b"bar".to_vec()), (7, b"foo".to_vec())].into_iter()
             ),
-            Err(Error::Errno(Errno::INVAL))
+            Err(Error::errno(Errno::INVAL))
         );
     }
 
@@ -709,7 +757,7 @@ mod test {
         let data = cursor_bounds_test_data();
         let fixture = RecordTableFixture::with_data("test", &data);
         let mut cursor = fixture.open_cursor().unwrap();
-        assert_eq!(cursor.set_bounds(1..-1), Err(Error::Errno(Errno::INVAL)));
+        assert_eq!(cursor.set_bounds(1..-1), Err(Error::errno(Errno::INVAL)));
     }
 
     #[test]
@@ -833,9 +881,9 @@ mod test {
 
     #[test]
     fn io_error() {
-        let err = Error::WiredTiger(WiredTigerError::NotFound);
+        let err = Error::wired_tiger(WiredTigerError::NotFound);
         assert_eq!(
-            std::io::Error::from(err).to_string(),
+            std::io::Error::from(err.clone()).to_string(),
             std::io::Error::new(ErrorKind::NotFound, err).to_string()
         );
     }
@@ -928,7 +976,7 @@ mod test {
         let mut cursor = txn.open_metadata_cursor().unwrap();
         assert_eq!(
             cursor.modify(c"table:test", &[]),
-            Err(Error::Errno(Errno::NOTSUP))
+            Err(Error::errno(Errno::NOTSUP))
         );
     }
 }

--- a/wt_mdb/src/session/format.rs
+++ b/wt_mdb/src/session/format.rs
@@ -160,7 +160,7 @@ impl Formatted for CString {
     #[inline(always)]
     fn unpack<'b>(packed: &'b [u8]) -> Result<Self::Ref<'b>> {
         CStr::from_bytes_with_nul(packed)
-            .map_err(|_| Error::WiredTiger(crate::WiredTigerError::Generic))
+            .map_err(|_| Error::wired_tiger(crate::WiredTigerError::Generic))
     }
 }
 

--- a/wt_mdb/src/session/typed_cursor.rs
+++ b/wt_mdb/src/session/typed_cursor.rs
@@ -106,7 +106,7 @@ impl<'a, K: Formatted, V: Formatted> TypedCursor<'a, K, V> {
                 _vm: PhantomData,
             })
         } else {
-            Err(Error::Errno(Errno::INVAL))
+            Err(Error::errno(Errno::INVAL))
         }
     }
 
@@ -198,7 +198,7 @@ impl<'a, K: Formatted, V: Formatted> TypedCursor<'a, K, V> {
         modifications: &mut [WT_MODIFY],
     ) -> Result<()> {
         if V::FORMAT.format_str() != "u" {
-            return Err(Error::Errno(Errno::NOTSUP));
+            return Err(Error::errno(Errno::NOTSUP));
         }
         let key = format_to_buf!(key, K, self.key_buf)?;
         unsafe {


### PR DESCRIPTION
Use the slop machine to add a backtrace field populated on `RUST_BACKTRACE=1`. Very helpful for tracking down rogue NotFound errors. Needs adjustment to debug output in order to get line numbers in stack traces.