### PR TITLE
Graph search performance improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 members = ["et", "vectors", "wt_mdb", "wt_sys"]
 
 [workspace.dependencies]
+ahash = "0.8.12"
 approx = "0.5.1"
 bindgen = "0.72.1"
 bytemuck = "1.24.0"
@@ -30,7 +31,7 @@ rustix = "1.0.7"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.132"
 simsimd = "6.5.0"
-smallvec = "1"
+smallvec = "1.15"
 stable_deref_trait = "1.2.0"
 tempfile = "3.20.0"
 thread_local = "1.1.9"
@@ -39,7 +40,7 @@ tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 wgpu = "29.0.1"
 
 [dependencies]
-ahash = "0.8.12"
+ahash = { workspace = true }
 bytemuck = { workspace = true }
 crossbeam-skiplist = { workspace = true }
 half = { workspace = true }
@@ -52,6 +53,7 @@ rustix = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 simsimd = { workspace = true }
+smallvec = { workspace = true }
 stable_deref_trait = { workspace = true }
 thread_local = { workspace = true }
 tracing = { workspace = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 wgpu = "29.0.1"
 
 [dependencies]
+ahash = "0.8.12"
 bytemuck = { workspace = true }
 crossbeam-skiplist = { workspace = true }
 half = { workspace = true }

--- a/et/src/vamana/search.rs
+++ b/et/src/vamana/search.rs
@@ -12,9 +12,9 @@ use clap::Args;
 use easy_tiger::{
     input::{DerefVectorStore, VectorStore},
     vamana::{
-        GraphSearchParams, PatienceParams,
-        search::{GraphSearchStats, GraphSearcher},
+        search::{GraphSearchStats, GraphSearcher, Options as GraphSearchOptions},
         wt::{TableGraphVectorIndex, TransactionGraphVectorIndex},
+        GraphSearchParams, PatienceParams,
     },
 };
 use memmap2::Mmap;
@@ -242,7 +242,7 @@ impl SearcherState {
         let start = Instant::now();
         let results = self
             .searcher
-            .search_with_filter(query, |i| i < record_limit, &reader)?;
+            .search_with_options(query, GraphSearchOptions::with_filter(|i| i < record_limit), &reader)?;
         let duration = Instant::now() - start;
         Ok(AggregateSearchStats::new(
             duration,

--- a/src/spann/rebalance.rs
+++ b/src/spann/rebalance.rs
@@ -9,7 +9,7 @@ use crate::{
         postings::BlockPostingsMut,
         CentroidAssignment, TableIndex, TransactionIndex,
     },
-    vamana::{mutate::delete_vector, search::GraphSearcher},
+    vamana::{mutate::delete_vector, search::GraphSearcher, search::Options as GraphSearchOptions},
 };
 
 use std::ops::{Add, AddAssign};
@@ -181,9 +181,9 @@ pub fn merge_centroid(
     for (record_id, vector) in vectors {
         coder.decode_to(&vector, &mut float_vector);
         // TODO: seed the search with the existing assignments for this record; reduce budget.
-        let candidates = searcher.search_with_filter(
+        let candidates = searcher.search_with_options(
             &float_vector,
-            |i| i != centroid_id as i64,
+            GraphSearchOptions::with_filter(|i| i != centroid_id as i64),
             txn_idx.head(),
         )?;
         let new_assignments = CentroidAssignment::new(candidates[0].vertex() as u32);
@@ -415,6 +415,7 @@ mod split {
     use crate::vamana::{
         mutate::{delete_vector, upsert_vector},
         search::GraphSearcher,
+        search::Options as GraphSearchOptions,
         GraphVectorIndex, GraphVectorStore,
     };
 
@@ -555,8 +556,11 @@ mod split {
                 .unwrap_or_else(|| Err(Error::not_found_error()))?,
         );
         let mut searcher = GraphSearcher::new(txn_idx.index().config().head_search_params);
-        let mut candidates =
-            searcher.search_with_filter(&query, |i| i != centroid_id as i64, txn_idx.head())?;
+        let mut candidates = searcher.search_with_options(
+            &query,
+            GraphSearchOptions::with_filter(|i| i != centroid_id as i64),
+            txn_idx.head(),
+        )?;
         candidates.truncate(64);
         Ok(candidates.into_iter().map(|n| n.vertex() as u32).collect())
     }

--- a/src/vamana/search.rs
+++ b/src/vamana/search.rs
@@ -81,9 +81,8 @@ pub struct Options<F: FnMut(i64) -> bool> {
     result_scratch: Option<Vec<Neighbor>>,
 }
 
-impl Options<fn(i64) -> bool> {
-    /// Create default options.
-    pub fn new() -> Self {
+impl Default for Options<fn(i64) -> bool> {
+    fn default() -> Self {
         Self {
             filter: (|_| true) as fn(i64) -> bool,
             seeds: smallvec::SmallVec::new(),
@@ -177,7 +176,7 @@ impl GraphSearcher {
         reader: &impl GraphVectorIndex,
     ) -> Result<Vec<Neighbor>> {
         self.seen.clear();
-        self.search_internal(query, Options::new(), reader)
+        self.search_internal(query, Options::default(), reader)
     }
 
     /// Search for `query` in the given graph `reader`, with oracle function `filter_predicate` dictating which
@@ -277,7 +276,7 @@ impl GraphSearcher {
 
         self.search_graph_and_rerank(
             nav_query.as_ref(),
-            Options::new(),
+            Options::default(),
             rerank_query.as_ref().map(|q| q.as_ref()),
             reader,
         )
@@ -404,28 +403,33 @@ impl GraphSearcher {
             }
         }
 
-        // XXX re-use the scratch vector instead of allocating a new one every time.
+        // Reuse result_scratch if present to avoid reallocation of the result vec.
+        let mut results = options
+            .result_scratch
+            .take()
+            .map(|mut v| {
+                v.clear();
+                v
+            })
+            .unwrap_or_default();
         if let Some(rerank_query) = rerank_query {
             let mut rerank_vectors = reader.rerank_vectors().expect("rerank enabled")?;
-            let rescored = self
-                .candidates
-                .iter()
-                .take(self.params.num_rerank)
-                .map(|c| {
-                    let vertex = c.neighbor.vertex();
+            results.reserve(self.params.num_rerank);
+            for c in self.candidates.iter().take(self.params.num_rerank) {
+                let vertex = c.neighbor.vertex();
+                results.push(
                     rerank_vectors
                         .get(vertex)
                         .expect("row exists")
-                        .map(|rv| Neighbor::new(vertex, rerank_query.distance(rv)))
-                })
-                .collect::<Result<Vec<_>>>();
-            rescored.map(|mut r| {
-                r.sort();
-                r
-            })
+                        .map(|rv| Neighbor::new(vertex, rerank_query.distance(rv)))?,
+                );
+            }
+            results.sort_unstable();
         } else {
-            Ok(self.candidates.iter().map(|c| c.neighbor).collect())
+            results.reserve(self.candidates.len());
+            results.extend(self.candidates.iter().map(|c| c.neighbor));
         }
+        Ok(results)
     }
 }
 
@@ -510,6 +514,10 @@ impl CandidateList {
     fn clear(&mut self) {
         self.candidates.clear();
         self.next_unvisited = 0;
+    }
+
+    fn len(&self) -> usize {
+        self.candidates.len()
     }
 }
 

--- a/src/vamana/search.rs
+++ b/src/vamana/search.rs
@@ -179,44 +179,6 @@ impl GraphSearcher {
         self.search_internal(query, Options::default(), reader)
     }
 
-    /// Search for `query` in the given graph `reader`, with oracle function `filter_predicate` dictating which
-    /// vertex ids are valid results. The returned results will only include vertices that match `filter_predicate`
-    /// and will assume that for any vertex id that all calls will return the same value.
-    ///
-    /// Returns an approximate list of neighbors matching `filter_predicate` with the highest scores.
-    // XXX die
-    pub fn search_with_filter(
-        &mut self,
-        query: &[f32],
-        filter_predicate: impl FnMut(i64) -> bool,
-        reader: &impl GraphVectorIndex,
-    ) -> Result<Vec<Neighbor>> {
-        self.seen.clear();
-        self.search_internal(query, Options::with_filter(filter_predicate), reader)
-    }
-
-    /// Search for `query` in the given graph `reader`, with oracle function `filter_predicate` dictating which
-    /// vertex ids are valid results, seeding the candidate queue with `seeds` in addition to the graph entry point.
-    ///
-    /// Any seed vertex that cannot be found in the graph is silently skipped.
-    ///
-    /// Returns an approximate list of neighbors matching `filter_predicate` with the highest scores.
-    // XXX DIE
-    pub fn search_with_filter_and_seeds(
-        &mut self,
-        query: &[f32],
-        filter_predicate: impl FnMut(i64) -> bool,
-        seeds: impl IntoIterator<Item = i64>,
-        reader: &impl GraphVectorIndex,
-    ) -> Result<Vec<Neighbor>> {
-        self.seen.clear();
-        self.search_internal(
-            query,
-            Options::with_filter(filter_predicate).with_seeds(seeds),
-            reader,
-        )
-    }
-
     /// Search for `query` in graph `reader` with `options`.
     ///
     /// Returns a an approximate list of the closest neighbors matching any specified filter
@@ -574,7 +536,7 @@ mod test {
     };
     use crate::Neighbor;
 
-    use super::{GraphSearchParams, GraphSearcher};
+    use super::{GraphSearchParams, GraphSearcher, Options};
 
     #[derive(Debug)]
     struct TestVector {
@@ -939,7 +901,11 @@ mod test {
 
         // Search with a filter that rejects vertex 1
         let _ = searcher
-            .search_with_filter(&[-0.1, -0.1, -0.1, -0.1], |v| v != 1, &mut index.reader())
+            .search_with_options(
+                &[-0.1, -0.1, -0.1, -0.1],
+                Options::with_filter(|v| v != 1),
+                &mut index.reader(),
+            )
             .unwrap();
 
         let stats = searcher.stats();

--- a/src/vamana/search.rs
+++ b/src/vamana/search.rs
@@ -5,7 +5,7 @@ use std::ops::{Add, AddAssign};
 use ahash::AHashSet;
 
 use super::{Graph, GraphSearchParams, GraphVectorIndex, GraphVectorStore};
-use crate::{Neighbor, vamana::PatienceParams};
+use crate::{vamana::PatienceParams, Neighbor};
 
 use vectors::QueryVectorDistance;
 use wt_mdb::{Error, Result};
@@ -74,6 +74,50 @@ impl Patience {
     }
 }
 
+/// Options for a graph search.
+pub struct Options<F: FnMut(i64) -> bool> {
+    filter: F,
+    seeds: smallvec::SmallVec<[i64; 4]>,
+    result_scratch: Option<Vec<Neighbor>>,
+}
+
+impl Options<fn(i64) -> bool> {
+    /// Create default options.
+    pub fn new() -> Self {
+        Self {
+            filter: (|_| true) as fn(i64) -> bool,
+            seeds: smallvec::SmallVec::new(),
+            result_scratch: None,
+        }
+    }
+}
+
+impl<F: FnMut(i64) -> bool> Options<F> {
+    /// Create options with a pre-filter function that is applied to each result before it is
+    /// returned.
+    pub fn with_filter(filter: F) -> Self {
+        Self {
+            filter,
+            seeds: smallvec::SmallVec::new(),
+            result_scratch: None,
+        }
+    }
+
+    /// Set seed vector ids for this request. Seeds are added as initial candidates along with the
+    /// entry point to the graph. Any seed id that cannot be found is ignored.
+    pub fn with_seeds(mut self, seeds: impl IntoIterator<Item = i64>) -> Self {
+        self.seeds = seeds.into_iter().collect();
+        self
+    }
+
+    /// A pre-allocated buffer of neighbors. This may be used to buffer results returned by a
+    /// search_with_options() call.
+    pub fn with_result_scratch(mut self, scratch: Vec<Neighbor>) -> Self {
+        self.result_scratch = Some(scratch);
+        self
+    }
+}
+
 /// Helper to search a Vamana graph.
 pub struct GraphSearcher {
     params: GraphSearchParams,
@@ -133,7 +177,7 @@ impl GraphSearcher {
         reader: &impl GraphVectorIndex,
     ) -> Result<Vec<Neighbor>> {
         self.seen.clear();
-        self.search_internal(query, |_| true, std::iter::empty(), reader)
+        self.search_internal(query, Options::new(), reader)
     }
 
     /// Search for `query` in the given graph `reader`, with oracle function `filter_predicate` dictating which
@@ -141,6 +185,7 @@ impl GraphSearcher {
     /// and will assume that for any vertex id that all calls will return the same value.
     ///
     /// Returns an approximate list of neighbors matching `filter_predicate` with the highest scores.
+    // XXX die
     pub fn search_with_filter(
         &mut self,
         query: &[f32],
@@ -148,7 +193,7 @@ impl GraphSearcher {
         reader: &impl GraphVectorIndex,
     ) -> Result<Vec<Neighbor>> {
         self.seen.clear();
-        self.search_internal(query, filter_predicate, std::iter::empty(), reader)
+        self.search_internal(query, Options::with_filter(filter_predicate), reader)
     }
 
     /// Search for `query` in the given graph `reader`, with oracle function `filter_predicate` dictating which
@@ -157,6 +202,7 @@ impl GraphSearcher {
     /// Any seed vertex that cannot be found in the graph is silently skipped.
     ///
     /// Returns an approximate list of neighbors matching `filter_predicate` with the highest scores.
+    // XXX DIE
     pub fn search_with_filter_and_seeds(
         &mut self,
         query: &[f32],
@@ -165,7 +211,25 @@ impl GraphSearcher {
         reader: &impl GraphVectorIndex,
     ) -> Result<Vec<Neighbor>> {
         self.seen.clear();
-        self.search_internal(query, filter_predicate, seeds, reader)
+        self.search_internal(
+            query,
+            Options::with_filter(filter_predicate).with_seeds(seeds),
+            reader,
+        )
+    }
+
+    /// Search for `query` in graph `reader` with `options`.
+    ///
+    /// Returns a an approximate list of the closest neighbors matching any specified filter
+    /// predicate.
+    pub fn search_with_options<F: FnMut(i64) -> bool>(
+        &mut self,
+        query: &[f32],
+        options: Options<F>,
+        reader: &impl GraphVectorIndex,
+    ) -> Result<Vec<Neighbor>> {
+        self.seen.clear();
+        self.search_internal(query, options, reader)
     }
 
     /// Search for the vector at `vertex_id` and return matching candidates.
@@ -213,18 +277,16 @@ impl GraphSearcher {
 
         self.search_graph_and_rerank(
             nav_query.as_ref(),
-            |_| true,
-            std::iter::empty(),
+            Options::new(),
             rerank_query.as_ref().map(|q| q.as_ref()),
             reader,
         )
     }
 
-    fn search_internal(
+    fn search_internal<F: FnMut(i64) -> bool>(
         &mut self,
         query: &[f32],
-        filter_predicate: impl FnMut(i64) -> bool,
-        seeds: impl IntoIterator<Item = i64>,
+        options: Options<F>,
         reader: &impl GraphVectorIndex,
     ) -> Result<Vec<Neighbor>> {
         let nav_query = reader.config().nav_format.query_distance_asymmetric(
@@ -246,18 +308,16 @@ impl GraphSearcher {
 
         self.search_graph_and_rerank(
             nav_query.as_ref(),
-            filter_predicate,
-            seeds,
+            options,
             rerank_query.as_ref().map(|q| q.as_ref()),
             reader,
         )
     }
 
-    fn search_graph_and_rerank(
+    fn search_graph_and_rerank<F: FnMut(i64) -> bool>(
         &mut self,
         nav_query: &dyn QueryVectorDistance,
-        mut filter_predicate: impl FnMut(i64) -> bool,
-        seeds: impl IntoIterator<Item = i64>,
+        mut options: Options<F>,
         rerank_query: Option<&dyn QueryVectorDistance>,
         reader: &impl GraphVectorIndex,
     ) -> Result<Vec<Neighbor>> {
@@ -286,7 +346,7 @@ impl GraphSearcher {
             self.seen.insert(entry_point);
         }
 
-        for seed in seeds {
+        for seed in options.seeds {
             if !self.seen.insert(seed) {
                 continue;
             }
@@ -306,7 +366,7 @@ impl GraphSearcher {
         while let Some(best_candidate) = self.candidates.next_unvisited() {
             self.visited += 1;
             let vertex_id = best_candidate.neighbor().vertex();
-            if filter_predicate(vertex_id) {
+            if (options.filter)(vertex_id) {
                 best_candidate.visit();
             } else {
                 best_candidate.remove();
@@ -344,6 +404,7 @@ impl GraphSearcher {
             }
         }
 
+        // XXX re-use the scratch vector instead of allocating a new one every time.
         if let Some(rerank_query) = rerank_query {
             let mut rerank_vectors = reader.rerank_vectors().expect("rerank enabled")?;
             let rescored = self
@@ -500,10 +561,10 @@ mod test {
     use vectors::{F32VectorCoding, F32VectorDistance, VectorSimilarity};
     use wt_mdb::{Error, Result};
 
-    use crate::Neighbor;
     use crate::vamana::{
         EdgePruningConfig, EdgeType, Graph, GraphConfig, GraphVectorIndex, GraphVectorStore,
     };
+    use crate::Neighbor;
 
     use super::{GraphSearchParams, GraphSearcher};
 

--- a/src/vamana/search.rs
+++ b/src/vamana/search.rs
@@ -133,7 +133,7 @@ impl GraphSearcher {
         reader: &impl GraphVectorIndex,
     ) -> Result<Vec<Neighbor>> {
         self.seen.clear();
-        self.search_internal(query, |_| true, reader)
+        self.search_internal(query, |_| true, std::iter::empty(), reader)
     }
 
     /// Search for `query` in the given graph `reader`, with oracle function `filter_predicate` dictating which
@@ -148,7 +148,24 @@ impl GraphSearcher {
         reader: &impl GraphVectorIndex,
     ) -> Result<Vec<Neighbor>> {
         self.seen.clear();
-        self.search_internal(query, filter_predicate, reader)
+        self.search_internal(query, filter_predicate, std::iter::empty(), reader)
+    }
+
+    /// Search for `query` in the given graph `reader`, with oracle function `filter_predicate` dictating which
+    /// vertex ids are valid results, seeding the candidate queue with `seeds` in addition to the graph entry point.
+    ///
+    /// Any seed vertex that cannot be found in the graph is silently skipped.
+    ///
+    /// Returns an approximate list of neighbors matching `filter_predicate` with the highest scores.
+    pub fn search_with_filter_and_seeds(
+        &mut self,
+        query: &[f32],
+        filter_predicate: impl FnMut(i64) -> bool,
+        seeds: impl IntoIterator<Item = i64>,
+        reader: &impl GraphVectorIndex,
+    ) -> Result<Vec<Neighbor>> {
+        self.seen.clear();
+        self.search_internal(query, filter_predicate, seeds, reader)
     }
 
     /// Search for the vector at `vertex_id` and return matching candidates.
@@ -197,6 +214,7 @@ impl GraphSearcher {
         self.search_graph_and_rerank(
             nav_query.as_ref(),
             |_| true,
+            std::iter::empty(),
             rerank_query.as_ref().map(|q| q.as_ref()),
             reader,
         )
@@ -206,6 +224,7 @@ impl GraphSearcher {
         &mut self,
         query: &[f32],
         filter_predicate: impl FnMut(i64) -> bool,
+        seeds: impl IntoIterator<Item = i64>,
         reader: &impl GraphVectorIndex,
     ) -> Result<Vec<Neighbor>> {
         let nav_query = reader.config().nav_format.query_distance_asymmetric(
@@ -228,6 +247,7 @@ impl GraphSearcher {
         self.search_graph_and_rerank(
             nav_query.as_ref(),
             filter_predicate,
+            seeds,
             rerank_query.as_ref().map(|q| q.as_ref()),
             reader,
         )
@@ -237,6 +257,7 @@ impl GraphSearcher {
         &mut self,
         nav_query: &dyn QueryVectorDistance,
         mut filter_predicate: impl FnMut(i64) -> bool,
+        seeds: impl IntoIterator<Item = i64>,
         rerank_query: Option<&dyn QueryVectorDistance>,
         reader: &impl GraphVectorIndex,
     ) -> Result<Vec<Neighbor>> {
@@ -263,6 +284,23 @@ impl GraphSearcher {
                 self.candidates_added += 1;
             }
             self.seen.insert(entry_point);
+        }
+
+        for seed in seeds {
+            if !self.seen.insert(seed) {
+                continue;
+            }
+            let seed_vector = match nav.get(seed) {
+                Some(Ok(v)) => v,
+                // Silently skip any seed that cannot be found in the graph.
+                _ => continue,
+            };
+            if self
+                .candidates
+                .add_unvisited(Neighbor::new(seed, nav_query.distance(seed_vector)))
+            {
+                self.candidates_added += 1;
+            }
         }
 
         while let Some(best_candidate) = self.candidates.next_unvisited() {

--- a/src/vamana/search.rs
+++ b/src/vamana/search.rs
@@ -1,9 +1,8 @@
 //! Index search implementation, including graph search and re-ranking.
 
-use std::{
-    collections::HashSet,
-    ops::{Add, AddAssign},
-};
+use std::ops::{Add, AddAssign};
+
+use ahash::AHashSet;
 
 use super::{Graph, GraphSearchParams, GraphVectorIndex, GraphVectorStore};
 use crate::{vamana::PatienceParams, Neighbor};
@@ -81,7 +80,7 @@ pub struct GraphSearcher {
     patience: Option<Patience>,
 
     candidates: CandidateList,
-    seen: HashSet<i64>, // TODO: use a more efficient hash function (ahash?)
+    seen: AHashSet<i64>,
     candidates_added: usize,
     visited: usize,
     filtered: usize,
@@ -100,7 +99,7 @@ impl GraphSearcher {
             params,
             patience,
             candidates: CandidateList::new(params.beam_width.get()),
-            seen: HashSet::new(),
+            seen: AHashSet::new(),
             candidates_added: 0,
             visited: 0,
             filtered: 0,

--- a/src/vamana/search.rs
+++ b/src/vamana/search.rs
@@ -5,7 +5,7 @@ use std::ops::{Add, AddAssign};
 use ahash::AHashSet;
 
 use super::{Graph, GraphSearchParams, GraphVectorIndex, GraphVectorStore};
-use crate::{vamana::PatienceParams, Neighbor};
+use crate::{Neighbor, vamana::PatienceParams};
 
 use vectors::QueryVectorDistance;
 use wt_mdb::{Error, Result};
@@ -278,8 +278,7 @@ impl GraphSearcher {
             let mut added = 0;
             for edge in graph
                 .edges(vertex_id)
-                .unwrap_or(Err(Error::not_found_error()))?
-                .collect::<Vec<_>>()
+                .unwrap_or_else(|| Err(Error::not_found_error()))?
             {
                 if !self.seen.insert(edge) {
                     continue;
@@ -463,10 +462,10 @@ mod test {
     use vectors::{F32VectorCoding, F32VectorDistance, VectorSimilarity};
     use wt_mdb::{Error, Result};
 
+    use crate::Neighbor;
     use crate::vamana::{
         EdgePruningConfig, EdgeType, Graph, GraphConfig, GraphVectorIndex, GraphVectorStore,
     };
-    use crate::Neighbor;
 
     use super::{GraphSearchParams, GraphSearcher};
 


### PR DESCRIPTION
* Use `ahash` for the visited set
* Allow seeding the search in addition to the entry point. This may be useful in SPANN where insert/rebalancing operations may search around certain vertexes.
* Allow callers to pass a result vec for re-use to avoid reallocating results for every search.