### PR TITLE
Further walltime breakdown for spann insert + optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Cargo.lock
 profile.json
 profile.json.gz
 flamegraph.svg
+**/*.swp

--- a/et/src/spann/insert_vectors.rs
+++ b/et/src/spann/insert_vectors.rs
@@ -2,15 +2,15 @@ use std::{collections::HashMap, fs::File, io, num::NonZero, ops::Range, path::Pa
 
 use clap::Args;
 use easy_tiger::{
-    Neighbor,
     input::{DerefVectorStore, VectorStore},
     spann::{
-        CentroidAssignment, TableIndex, TransactionIndex,
         centroid_stats::{CentroidAssignmentUpdater, CentroidStats},
         postings::BlockPostingsMut,
         rebalance::{BalanceSummary, RebalanceStats},
+        CentroidAssignment, TableIndex, TransactionIndex,
     },
     vamana::search::{GraphSearchStats, GraphSearcher, Options as GraphSearchOptions},
+    Neighbor,
 };
 use indicatif::{ParallelProgressIterator, ProgressBar};
 use rand::SeedableRng;
@@ -132,7 +132,7 @@ pub fn insert_vectors(
     let total_time = insert_time + rebalance_time;
     println!("Wall time:");
     println!(
-        "  Insert:       {:10.2} s ({:5.1}%)",
+        "  Insert:           {:10.2} s ({:5.1}%)",
         insert_time.as_secs_f64(),
         if total_time.is_zero() {
             0.0
@@ -141,7 +141,7 @@ pub fn insert_vectors(
         }
     );
     println!(
-        "    Prepare:    {:10.2} s ({:5.1}%)",
+        "    Prepare:        {:10.2} s ({:5.1}%)",
         prepare_time.as_secs_f64(),
         if total_time.is_zero() {
             0.0
@@ -150,7 +150,7 @@ pub fn insert_vectors(
         }
     );
     println!(
-        "    Apply:      {:10.2} s ({:5.1}%)",
+        "    Apply:          {:10.2} s ({:5.1}%)",
         apply_time.as_secs_f64(),
         if total_time.is_zero() {
             0.0
@@ -159,7 +159,7 @@ pub fn insert_vectors(
         }
     );
     println!(
-        "  Rebalance:    {:10.2} s ({:5.1}%)",
+        "  Rebalance:        {:10.2} s ({:5.1}%)",
         rebalance_time.as_secs_f64(),
         if total_time.is_zero() {
             0.0
@@ -170,7 +170,7 @@ pub fn insert_vectors(
     let pd = rebalance_stats.phase_durations;
     let phase = |label: &str, d: std::time::Duration| {
         println!(
-            "    {:<24}{:10.2} s ({:5.1}%)",
+            "    {:<16}{:10.2} s ({:5.1}%)",
             label,
             d.as_secs_f64(),
             if total_time.is_zero() {
@@ -180,11 +180,12 @@ pub fn insert_vectors(
             }
         );
     };
-    phase("Split update head:", pd.split_update_head);
-    phase("Posting reassign:", pd.posting_reassignments);
-    phase("Select nearby:", pd.select_nearby_centroids);
-    phase("Compute nearby:", pd.compute_nearby_reassignments);
-    phase("Apply nearby:", pd.apply_nearby_reassignments);
+    phase("Partition:", pd.split_update_head);
+    phase("Reassign:", pd.posting_reassignments);
+    phase("Apply Reassign:", pd.apply_posting_reassignments);
+    phase("Nearby Find:", pd.select_nearby_centroids);
+    phase("Nearby Select:", pd.compute_nearby_reassignments);
+    phase("Nearby Apply:", pd.apply_nearby_reassignments);
     println!("Batches:        {:10}", batches);
     if batches > 0 {
         println!(

--- a/et/src/spann/insert_vectors.rs
+++ b/et/src/spann/insert_vectors.rs
@@ -95,12 +95,14 @@ pub fn insert_vectors(
     let mut search_stats = GraphSearchStats::default();
     let mut insert_time = std::time::Duration::ZERO;
     let mut rebalance_time = std::time::Duration::ZERO;
+    let mut prepare_time = std::time::Duration::ZERO;
+    let mut apply_time = std::time::Duration::ZERO;
 
     for batch_start in (args.start..end).step_by(batch_size) {
         let batch_end = (batch_start + batch_size).min(end);
 
         let insert_start = std::time::Instant::now();
-        let (unique_centroids, batch_search_stats) = insert_batch(
+        let batch_result = insert_batch(
             &index,
             &connection,
             &f32_vectors,
@@ -110,8 +112,10 @@ pub fn insert_vectors(
             &main_progress,
         )?;
         insert_time += insert_start.elapsed();
-        total_batch_unique_centroids += unique_centroids;
-        search_stats += batch_search_stats;
+        total_batch_unique_centroids += batch_result.unique_centroids;
+        search_stats += batch_result.search_stats;
+        prepare_time += batch_result.prepare_time;
+        apply_time += batch_result.apply_time;
         batches += 1;
 
         main_progress.set_message("rebalancing index");
@@ -137,6 +141,24 @@ pub fn insert_vectors(
         }
     );
     println!(
+        "    Prepare:    {:10.2} s ({:5.1}%)",
+        prepare_time.as_secs_f64(),
+        if total_time.is_zero() {
+            0.0
+        } else {
+            prepare_time.as_secs_f64() / total_time.as_secs_f64() * 100.0
+        }
+    );
+    println!(
+        "    Apply:      {:10.2} s ({:5.1}%)",
+        apply_time.as_secs_f64(),
+        if total_time.is_zero() {
+            0.0
+        } else {
+            apply_time.as_secs_f64() / total_time.as_secs_f64() * 100.0
+        }
+    );
+    println!(
         "  Rebalance:    {:10.2} s ({:5.1}%)",
         rebalance_time.as_secs_f64(),
         if total_time.is_zero() {
@@ -145,6 +167,24 @@ pub fn insert_vectors(
             rebalance_time.as_secs_f64() / total_time.as_secs_f64() * 100.0
         }
     );
+    let pd = rebalance_stats.phase_durations;
+    let phase = |label: &str, d: std::time::Duration| {
+        println!(
+            "    {:<24}{:10.2} s ({:5.1}%)",
+            label,
+            d.as_secs_f64(),
+            if total_time.is_zero() {
+                0.0
+            } else {
+                d.as_secs_f64() / total_time.as_secs_f64() * 100.0
+            }
+        );
+    };
+    phase("Split update head:", pd.split_update_head);
+    phase("Posting reassign:", pd.posting_reassignments);
+    phase("Select nearby:", pd.select_nearby_centroids);
+    phase("Compute nearby:", pd.compute_nearby_reassignments);
+    phase("Apply nearby:", pd.apply_nearby_reassignments);
     println!("Batches:        {:10}", batches);
     if batches > 0 {
         println!(
@@ -300,6 +340,16 @@ impl PreparedInsertBatch {
     }
 }
 
+/// Result of inserting a single batch of vectors.
+struct InsertBatchResult {
+    unique_centroids: usize,
+    search_stats: GraphSearchStats,
+    /// Time spent producing the prepared batch (search + encoding).
+    prepare_time: std::time::Duration,
+    /// Time spent applying the prepared batch to the index.
+    apply_time: std::time::Duration,
+}
+
 fn insert_batch(
     index: &Arc<TableIndex>,
     connection: &Arc<Connection>,
@@ -308,9 +358,10 @@ fn insert_batch(
     posting_coder: &dyn F32VectorCoder,
     rerank_coder: Option<&dyn F32VectorCoder>,
     progress: &ProgressBar,
-) -> Result<(usize, GraphSearchStats)> {
+) -> Result<InsertBatchResult> {
     progress.set_message("inserting vectors");
 
+    let prepare_start = std::time::Instant::now();
     let mut prepared_batch = batch
         .clone()
         .into_par_iter()
@@ -366,9 +417,12 @@ fn insert_batch(
             },
         )?;
 
+    let prepare_time = prepare_start.elapsed();
+
     let unique_centroids = prepared_batch.postings.len();
     let search_stats = prepared_batch.stats;
 
+    let apply_start = std::time::Instant::now();
     std::mem::take(&mut prepared_batch.postings)
         .into_par_iter()
         .try_for_each(|(centroid, postings)| {
@@ -407,8 +461,14 @@ fn insert_batch(
 
             txn_idx.commit(None)
         })?;
+    let apply_time = apply_start.elapsed();
 
-    Ok((unique_centroids, search_stats))
+    Ok(InsertBatchResult {
+        unique_centroids,
+        search_stats,
+        prepare_time,
+        apply_time,
+    })
 }
 
 fn rebalance(

--- a/et/src/spann/insert_vectors.rs
+++ b/et/src/spann/insert_vectors.rs
@@ -181,8 +181,10 @@ pub fn insert_vectors(
         );
     };
     phase("Partition:", pd.split_update_head);
+    phase("Insert:", pd.insert_split_centroids);
     phase("Reassign:", pd.posting_reassignments);
     phase("Apply Reassign:", pd.apply_posting_reassignments);
+    phase("Remove:", pd.remove_source_centroids);
     phase("Nearby Find:", pd.select_nearby_centroids);
     phase("Nearby Select:", pd.compute_nearby_reassignments);
     phase("Nearby Apply:", pd.apply_nearby_reassignments);

--- a/et/src/wt_args.rs
+++ b/et/src/wt_args.rs
@@ -26,7 +26,7 @@ impl WiredTigerArgs {
         let mut connection_options = OptionsBuilder::default()
             .cache_size_mb(self.wiredtiger_cache_size_mb)
             .statistics(Statistics::Fast)
-            .checkpoint_log_size(128 << 20)
+            .checkpoint_log_size(1 << 30)
             .log(true);
         if self.wiredtiger_create_db {
             connection_options = connection_options.create();

--- a/src/spann/rebalance.rs
+++ b/src/spann/rebalance.rs
@@ -68,6 +68,38 @@ impl AddAssign for SplitStats {
     }
 }
 
+/// Time spent in each of the phases run during `parallel_rebalance`.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct RebalancePhaseDurations {
+    pub split_update_head: std::time::Duration,
+    pub posting_reassignments: std::time::Duration,
+    pub select_nearby_centroids: std::time::Duration,
+    pub compute_nearby_reassignments: std::time::Duration,
+    pub apply_nearby_reassignments: std::time::Duration,
+}
+
+impl Add for RebalancePhaseDurations {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self {
+            split_update_head: self.split_update_head + rhs.split_update_head,
+            posting_reassignments: self.posting_reassignments + rhs.posting_reassignments,
+            select_nearby_centroids: self.select_nearby_centroids + rhs.select_nearby_centroids,
+            compute_nearby_reassignments: self.compute_nearby_reassignments
+                + rhs.compute_nearby_reassignments,
+            apply_nearby_reassignments: self.apply_nearby_reassignments
+                + rhs.apply_nearby_reassignments,
+        }
+    }
+}
+
+impl AddAssign for RebalancePhaseDurations {
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
+    }
+}
+
 /// Statistics collected during a rebalance operation.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct RebalanceStats {
@@ -77,6 +109,8 @@ pub struct RebalanceStats {
     pub split_stats: SplitStats,
     /// Accumulated graph search stats for all searches performed during rebalancing.
     pub search_stats: GraphSearchStats,
+    /// Time spent in each parallel rebalance phase.
+    pub phase_durations: RebalancePhaseDurations,
 }
 
 impl Add for RebalanceStats {
@@ -89,6 +123,7 @@ impl Add for RebalanceStats {
             split: self.split + rhs.split,
             split_stats: self.split_stats + rhs.split_stats,
             search_stats: self.search_stats + rhs.search_stats,
+            phase_durations: self.phase_durations + rhs.phase_durations,
         }
     }
 }
@@ -109,6 +144,7 @@ impl Add<MergeStats> for RebalanceStats {
             split: self.split,
             split_stats: self.split_stats,
             search_stats: self.search_stats,
+            phase_durations: self.phase_durations,
         }
     }
 }
@@ -129,6 +165,7 @@ impl Add<SplitStats> for RebalanceStats {
             split: self.split + 1,
             split_stats: self.split_stats + rhs,
             search_stats: self.search_stats,
+            phase_durations: self.phase_durations,
         }
     }
 }
@@ -831,13 +868,37 @@ pub fn parallel_rebalance<R: Rng>(
         CentroidStats::from_index_stats(&txn)?
     };
     let ops = parallel::get_rebalance_ops(&centroid_stats, index.config().centroid_len_range());
+
+    let start = std::time::Instant::now();
     parallel::split_update_head(connection, index, &ops, rng_supplier)?;
+    let split_update_head = start.elapsed();
+
+    let start = std::time::Instant::now();
     let (reassignments, mut stats) = parallel::posting_reassignments(connection, index, &ops)?;
+    let posting_reassignments = start.elapsed();
+
     parallel::apply_posting_reassignments(connection, index, &reassignments, &ops)?;
+
+    let start = std::time::Instant::now();
     let (nearby_to_targets, _) = parallel::select_nearby_centroids(connection, index, &ops)?;
+    let select_nearby_centroids = start.elapsed();
+
+    let start = std::time::Instant::now();
     let (nearby_reassignments, nearby_stats) =
         parallel::compute_nearby_reassignments(connection, index, &nearby_to_targets)?;
+    let compute_nearby_reassignments = start.elapsed();
     stats += nearby_stats;
+
+    let start = std::time::Instant::now();
     parallel::apply_nearby_reassignments(connection, index, &nearby_reassignments)?;
+    let apply_nearby_reassignments = start.elapsed();
+
+    stats.phase_durations += RebalancePhaseDurations {
+        split_update_head,
+        posting_reassignments,
+        select_nearby_centroids,
+        compute_nearby_reassignments,
+        apply_nearby_reassignments,
+    };
     Ok(stats)
 }

--- a/src/spann/rebalance.rs
+++ b/src/spann/rebalance.rs
@@ -72,8 +72,10 @@ impl AddAssign for SplitStats {
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct RebalancePhaseDurations {
     pub split_update_head: std::time::Duration,
+    pub insert_split_centroids: std::time::Duration,
     pub posting_reassignments: std::time::Duration,
     pub apply_posting_reassignments: std::time::Duration,
+    pub remove_source_centroids: std::time::Duration,
     pub select_nearby_centroids: std::time::Duration,
     pub compute_nearby_reassignments: std::time::Duration,
     pub apply_nearby_reassignments: std::time::Duration,
@@ -85,9 +87,11 @@ impl Add for RebalancePhaseDurations {
     fn add(self, rhs: Self) -> Self::Output {
         Self {
             split_update_head: self.split_update_head + rhs.split_update_head,
+            insert_split_centroids: self.insert_split_centroids + rhs.insert_split_centroids,
             posting_reassignments: self.posting_reassignments + rhs.posting_reassignments,
             apply_posting_reassignments: self.apply_posting_reassignments
                 + rhs.apply_posting_reassignments,
+            remove_source_centroids: self.remove_source_centroids + rhs.remove_source_centroids,
             select_nearby_centroids: self.select_nearby_centroids + rhs.select_nearby_centroids,
             compute_nearby_reassignments: self.compute_nearby_reassignments
                 + rhs.compute_nearby_reassignments,
@@ -416,35 +420,63 @@ mod parallel {
             .collect()
     }
 
-    /// For all split operations, generates new target centroids and inserts them in head index.
-    pub fn split_update_head<R: Rng>(
+    /// For all split operations, generate new centroid vectors in parallel.
+    pub fn generate_split_centroids<R: Rng>(
         connection: &Arc<Connection>,
         index: &Arc<TableIndex>,
         ops: &[RebalanceOp],
         rng_supplier: &(impl Fn() -> R + Send + Sync),
-    ) -> Result<()> {
-        // NB: deliberately done sequentially to avoid conflicts.
-        // TODO: parallelize invocation of partition_postings.
-        let txn_idx = TransactionIndex::new(index, connection.begin_transaction(None)?);
-        for op in ops {
-            if let RebalanceOp::Split(s, t0, t1) = op {
-                let mut posting_cursor = txn_idx
-                    .transaction()
-                    .open_cursor::<u32, Vec<u8>>(index.postings_table_name())?;
-                let Some(raw_posting) =
-                    unsafe { posting_cursor.seek_exact_unsafe(*s) }.transpose()?
-                else {
-                    return Ok(());
-                };
-                let block = PostingBlock::new(raw_posting, txn_idx.index().posting_vector_len())
-                    .expect("valid posting block");
-                let mut rng = rng_supplier();
-                let centroids =
-                    partition_postings(&txn_idx, *s, block.iter().map(|(_, v)| v), &mut rng);
+    ) -> Result<Vec<(u32, u32, VecVectorStore<f32>)>> {
+        ops.par_iter()
+            .filter_map(|op| match op {
+                RebalanceOp::Split(s, t0, t1) => Some((*s, *t0, *t1)),
+                RebalanceOp::Merge(_) => None,
+            })
+            .map_init(
+                || {
+                    TransactionIndex::new(
+                        index,
+                        connection
+                            .begin_transaction(None)
+                            .expect("open session and txn"),
+                    )
+                },
+                |txn_idx, (s, t0, t1)| {
+                    let mut posting_cursor = txn_idx
+                        .transaction()
+                        .open_cursor::<u32, Vec<u8>>(index.postings_table_name())?;
+                    let Some(raw_posting) =
+                        unsafe { posting_cursor.seek_exact_unsafe(s) }.transpose()?
+                    else {
+                        return Ok(None);
+                    };
+                    let block =
+                        PostingBlock::new(raw_posting, txn_idx.index().posting_vector_len())
+                            .expect("valid posting block");
+                    let mut rng = rng_supplier();
+                    let centroids =
+                        partition_postings(txn_idx, s, block.iter().map(|(_, v)| v), &mut rng);
+                    Ok(Some((t0, t1, centroids)))
+                },
+            )
+            .filter_map(|r: Result<Option<_>>| r.transpose())
+            .collect()
+    }
 
-                upsert_vector(*t0 as i64, &centroids[0], txn_idx.head())?;
-                upsert_vector(*t1 as i64, &centroids[1], txn_idx.head())?;
-            }
+    /// Insert pre-computed split centroids into the head index.
+    // NB: deliberately sequential to avoid conflicts.
+    pub fn insert_split_centroids(
+        connection: &Arc<Connection>,
+        index: &Arc<TableIndex>,
+        split_centroids: &[(u32, u32, VecVectorStore<f32>)],
+    ) -> Result<()> {
+        if split_centroids.is_empty() {
+            return Ok(());
+        }
+        let txn_idx = TransactionIndex::new(index, connection.begin_transaction(None)?);
+        for (t0, t1, centroids) in split_centroids {
+            upsert_vector(*t0 as i64, &centroids[0], txn_idx.head())?;
+            upsert_vector(*t1 as i64, &centroids[1], txn_idx.head())?;
         }
         txn_idx.commit(None)
     }
@@ -649,12 +681,11 @@ mod parallel {
         Ok((by_target, stats))
     }
 
-    /// Apply all posting reassignments then remove the source centroid ids.
+    /// Apply all posting reassignments by copying vectors to their target centroids.
     pub fn apply_posting_reassignments(
         connection: &Arc<Connection>,
         index: &Arc<TableIndex>,
         reassignments: &HashMap<u32, Vec<(u32, i64)>>,
-        ops: &[RebalanceOp],
     ) -> Result<()> {
         reassignments
             .par_iter()
@@ -667,9 +698,17 @@ mod parallel {
                 updater.flush()?;
                 txn.commit(None)?;
                 Ok::<_, Error>(())
-            })?;
+            })
+    }
 
-        // NB: deliberately sequential to avoid high conflict rate.
+    /// Remove source centroid ids from stats, postings, and the head graph.
+    ///
+    // NB: deliberately sequential to avoid high conflict rate.
+    pub fn remove_source_centroids(
+        connection: &Arc<Connection>,
+        index: &Arc<TableIndex>,
+        ops: &[RebalanceOp],
+    ) -> Result<()> {
         let txn_idx = TransactionIndex::new(index, connection.begin_transaction(None)?);
         for op in ops {
             let mut stats_cursor = txn_idx
@@ -873,16 +912,25 @@ pub fn parallel_rebalance<R: Rng>(
     let ops = parallel::get_rebalance_ops(&centroid_stats, index.config().centroid_len_range());
 
     let start = std::time::Instant::now();
-    parallel::split_update_head(connection, index, &ops, rng_supplier)?;
+    let split_centroids =
+        parallel::generate_split_centroids(connection, index, &ops, rng_supplier)?;
     let split_update_head = start.elapsed();
+
+    let start = std::time::Instant::now();
+    parallel::insert_split_centroids(connection, index, &split_centroids)?;
+    let insert_split_centroids = start.elapsed();
 
     let start = std::time::Instant::now();
     let (reassignments, mut stats) = parallel::posting_reassignments(connection, index, &ops)?;
     let posting_reassignments = start.elapsed();
 
     let start = std::time::Instant::now();
-    parallel::apply_posting_reassignments(connection, index, &reassignments, &ops)?;
+    parallel::apply_posting_reassignments(connection, index, &reassignments)?;
     let apply_posting_reassignments = start.elapsed();
+
+    let start = std::time::Instant::now();
+    parallel::remove_source_centroids(connection, index, &ops)?;
+    let remove_source_centroids = start.elapsed();
 
     let start = std::time::Instant::now();
     let (nearby_to_targets, _) = parallel::select_nearby_centroids(connection, index, &ops)?;
@@ -900,8 +948,10 @@ pub fn parallel_rebalance<R: Rng>(
 
     stats.phase_durations += RebalancePhaseDurations {
         split_update_head,
+        insert_split_centroids,
         posting_reassignments,
         apply_posting_reassignments,
+        remove_source_centroids,
         select_nearby_centroids,
         compute_nearby_reassignments,
         apply_nearby_reassignments,

--- a/src/spann/rebalance.rs
+++ b/src/spann/rebalance.rs
@@ -73,6 +73,7 @@ impl AddAssign for SplitStats {
 pub struct RebalancePhaseDurations {
     pub split_update_head: std::time::Duration,
     pub posting_reassignments: std::time::Duration,
+    pub apply_posting_reassignments: std::time::Duration,
     pub select_nearby_centroids: std::time::Duration,
     pub compute_nearby_reassignments: std::time::Duration,
     pub apply_nearby_reassignments: std::time::Duration,
@@ -85,6 +86,8 @@ impl Add for RebalancePhaseDurations {
         Self {
             split_update_head: self.split_update_head + rhs.split_update_head,
             posting_reassignments: self.posting_reassignments + rhs.posting_reassignments,
+            apply_posting_reassignments: self.apply_posting_reassignments
+                + rhs.apply_posting_reassignments,
             select_nearby_centroids: self.select_nearby_centroids + rhs.select_nearby_centroids,
             compute_nearby_reassignments: self.compute_nearby_reassignments
                 + rhs.compute_nearby_reassignments,
@@ -877,7 +880,9 @@ pub fn parallel_rebalance<R: Rng>(
     let (reassignments, mut stats) = parallel::posting_reassignments(connection, index, &ops)?;
     let posting_reassignments = start.elapsed();
 
+    let start = std::time::Instant::now();
     parallel::apply_posting_reassignments(connection, index, &reassignments, &ops)?;
+    let apply_posting_reassignments = start.elapsed();
 
     let start = std::time::Instant::now();
     let (nearby_to_targets, _) = parallel::select_nearby_centroids(connection, index, &ops)?;
@@ -896,6 +901,7 @@ pub fn parallel_rebalance<R: Rng>(
     stats.phase_durations += RebalancePhaseDurations {
         split_update_head,
         posting_reassignments,
+        apply_posting_reassignments,
         select_nearby_centroids,
         compute_nearby_reassignments,
         apply_nearby_reassignments,


### PR DESCRIPTION
Break down walltime spent on sub-phases of insert and rebalance to help evaluate optimizations.

Parallelize application of inserts: when choosing centroid for each input vector, group by target centroid then apply each centroid separately in parallel.