### PR TITLE
Disable WiredTiger logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,9 @@ tempfile = { workspace = true }
 [build-dependencies]
 cc = { workspace = true }
 
+[profile.release]
+debug = "line-tables-only"
+
 [profile.profiling]
 inherits = "release"
 debug = true

--- a/et/src/wt_args.rs
+++ b/et/src/wt_args.rs
@@ -26,8 +26,7 @@ impl WiredTigerArgs {
         let mut connection_options = OptionsBuilder::default()
             .cache_size_mb(self.wiredtiger_cache_size_mb)
             .statistics(Statistics::Fast)
-            .checkpoint_log_size(1 << 30)
-            .log(true);
+            .checkpoint_wait_seconds(5);
         if self.wiredtiger_create_db {
             connection_options = connection_options.create();
         }


### PR DESCRIPTION
It is very expensive here as it ends up writing WAL logs for the postings table. I could disable logging for just the postings table, but then it might become inconsistent with the other tables. WAL logging was necessary to support timestamps, but I was never able to get that to work correctly. Anyway, save 50GB of output when building a 1.9M vector index.

Generate line information in release builds to assist with backtrace debugging.