### PR TITLE
Skip source centroids on split insert path

### DIFF
--- a/src/spann/rebalance.rs
+++ b/src/spann/rebalance.rs
@@ -286,7 +286,7 @@ mod parallel {
             CentroidAssignment, TableIndex, TransactionIndex,
         },
         vamana::{
-            mutate::{delete_vector, upsert_vector},
+            mutate::{delete_vector, upsert_vector_with_options},
             search::{GraphSearchStats, GraphSearcher, Options as GraphSearchOptions},
             wt::CursorVectorStore,
             GraphVectorIndex, GraphVectorStore,
@@ -464,19 +464,38 @@ mod parallel {
     }
 
     /// Insert pre-computed split centroids into the head index.
+    ///
+    /// Excludes every source centroid in `ops` (both merge and split sources) from selection as
+    /// an edge for the newly inserted centroids. Source centroids are still present in the graph
+    /// at this point and will be removed later by `remove_source_centroids`; since a split
+    /// centroid is a near-duplicate of its source, allowing an edge to form between them can
+    /// trigger pruning that evicts one of the source's other edges before it's deleted, silently
+    /// dropping connectivity that `remove_source_centroids`'s cross-linking can no longer repair.
     // NB: deliberately sequential to avoid conflicts.
     pub fn insert_split_centroids(
         connection: &Arc<Connection>,
         index: &Arc<TableIndex>,
+        ops: &[RebalanceOp],
         split_centroids: &[(u32, u32, VecVectorStore<f32>)],
     ) -> Result<()> {
         if split_centroids.is_empty() {
             return Ok(());
         }
+        let sources = ops.iter().map(RebalanceOp::source).collect::<HashSet<_>>();
         let txn_idx = TransactionIndex::new(index, connection.begin_transaction(None)?);
         for (t0, t1, centroids) in split_centroids {
-            upsert_vector(*t0 as i64, &centroids[0], txn_idx.head())?;
-            upsert_vector(*t1 as i64, &centroids[1], txn_idx.head())?;
+            upsert_vector_with_options(
+                *t0 as i64,
+                &centroids[0],
+                txn_idx.head(),
+                GraphSearchOptions::with_filter(|i: i64| !sources.contains(&(i as u32))),
+            )?;
+            upsert_vector_with_options(
+                *t1 as i64,
+                &centroids[1],
+                txn_idx.head(),
+                GraphSearchOptions::with_filter(|i: i64| !sources.contains(&(i as u32))),
+            )?;
         }
         txn_idx.commit(None)
     }
@@ -917,7 +936,7 @@ pub fn parallel_rebalance<R: Rng>(
     let split_update_head = start.elapsed();
 
     let start = std::time::Instant::now();
-    parallel::insert_split_centroids(connection, index, &split_centroids)?;
+    parallel::insert_split_centroids(connection, index, &ops, &split_centroids)?;
     let insert_split_centroids = start.elapsed();
 
     let start = std::time::Instant::now();

--- a/src/vamana/mutate.rs
+++ b/src/vamana/mutate.rs
@@ -1,7 +1,8 @@
 //! Tools for mutating a vamana graph vector index.
 use crate::vamana::{
-    prune_edges, search::GraphSearcher, EdgePruningConfig, EdgeSetDistanceComputer, EdgeType,
-    Graph, GraphVectorIndex, GraphVectorStore,
+    prune_edges,
+    search::{GraphSearcher, Options as GraphSearchOptions},
+    EdgePruningConfig, EdgeSetDistanceComputer, EdgeType, Graph, GraphVectorIndex, GraphVectorStore,
 };
 use crate::Neighbor;
 use std::collections::{hash_map::Entry, HashMap};
@@ -10,8 +11,21 @@ use wt_mdb::{Error, Result};
 
 /// Insert a vertex for `vector` and return the id assigned to the vector.
 pub fn insert_vector(vector: &[f32], index: &impl GraphVectorIndex) -> Result<i64> {
+    insert_vector_with_options(vector, index, GraphSearchOptions::default())
+}
+
+/// Insert a vertex for `vector` and return the id assigned to the vector.
+///
+/// `options` is used for the graph search that selects candidate edges for the new vertex; in
+/// particular a filter may be used to exclude specific vertex ids from being selected as edges
+/// (their edges are still traversed during the search, they are just never linked to).
+pub fn insert_vector_with_options<F: FnMut(i64) -> bool>(
+    vector: &[f32],
+    index: &impl GraphVectorIndex,
+    options: GraphSearchOptions<F>,
+) -> Result<i64> {
     let vertex_id = index.graph()?.next_available_vertex_id()?;
-    insert_internal(vertex_id, vector, index).map(|_| vertex_id)
+    insert_internal(vertex_id, vector, index, options).map(|_| vertex_id)
 }
 
 /// Delete `vertex_id` from the graph index.
@@ -220,11 +234,25 @@ fn delete_vector_directed(vertex_id: i64, index: &impl GraphVectorIndex) -> Resu
 
 /// Upsert vector with the externally assigned `vertex_id`.
 pub fn upsert_vector(vertex_id: i64, vector: &[f32], index: &impl GraphVectorIndex) -> Result<()> {
+    upsert_vector_with_options(vertex_id, vector, index, GraphSearchOptions::default())
+}
+
+/// Upsert vector with the externally assigned `vertex_id`.
+///
+/// `options` is used for the graph search that selects candidate edges for the (re-)inserted
+/// vertex; in particular a filter may be used to exclude specific vertex ids from being selected
+/// as edges (their edges are still traversed during the search, they are just never linked to).
+pub fn upsert_vector_with_options<F: FnMut(i64) -> bool>(
+    vertex_id: i64,
+    vector: &[f32],
+    index: &impl GraphVectorIndex,
+    options: GraphSearchOptions<F>,
+) -> Result<()> {
     let mut graph = index.graph()?;
     if graph.edges(vertex_id).is_some() {
         delete_vector(vertex_id, index)?;
     }
-    insert_internal(vertex_id, vector, index)
+    insert_internal(vertex_id, vector, index, options)
 }
 
 /// Insert `vector` at `vertex_id` into the index.
@@ -234,12 +262,17 @@ pub fn upsert_vector(vertex_id: i64, vector: &[f32], index: &impl GraphVectorInd
 /// prune out edges in backlink nodes to maintain the max_edges limit.
 ///
 /// This method assumes that `vertex_id` does not already exist.
-fn insert_internal(vertex_id: i64, vector: &[f32], index: &impl GraphVectorIndex) -> Result<()> {
+fn insert_internal<F: FnMut(i64) -> bool>(
+    vertex_id: i64,
+    vector: &[f32],
+    index: &impl GraphVectorIndex,
+    options: GraphSearchOptions<F>,
+) -> Result<()> {
     // TODO: make this an error instead of panicking.
     assert_eq!(index.config().dimensions.get(), vector.len());
 
     let mut searcher = GraphSearcher::new(index.config().index_search_params);
-    let mut candidate_edges = searcher.search(vector, index)?;
+    let mut candidate_edges = searcher.search_with_options(vector, options, index)?;
     let mut graph = index.graph()?;
     if candidate_edges.is_empty() {
         graph.set_entry_point(vertex_id)?;
@@ -450,8 +483,8 @@ mod tests {
     use wt_mdb::{Connection, Result};
 
     use crate::vamana::{
-        mutate::{delete_vector, insert_vector, upsert_vector},
-        search::GraphSearcher,
+        mutate::{delete_vector, insert_vector, upsert_vector, upsert_vector_with_options},
+        search::{GraphSearcher, Options as GraphSearchOptions},
         wt::{TableGraphVectorIndex, TransactionGraphVectorIndex},
         EdgePruningConfig, EdgeType, Graph, GraphConfig, GraphSearchParams, GraphVectorIndex,
     };
@@ -704,6 +737,56 @@ mod tests {
         txn_index.commit(None)?;
 
         assert_eq!(fixture.search(&[0.0, 0.0]), Ok(vec![1, 2, 3, 5, 4, 0]));
+
+        Ok(())
+    }
+
+    // Verify that a filter passed via upsert_vector_with_options excludes the filtered vertex
+    // from selection as an edge, even when it would otherwise be the closest candidate.
+    #[test]
+    fn upsert_with_options_filter_excludes_vertex() -> Result<()> {
+        let fixture = Fixture::default();
+
+        let vertex_ids = fixture.insert_many(&[
+            [0.0, 0.0],
+            [0.1, 0.1],
+            [-0.1, 0.1],
+            [0.1, -0.1],
+            [-0.2, -0.2],
+            [-0.1, -0.1],
+        ])?;
+        let reader = fixture.new_txn_index();
+        let mut graph = reader.graph()?;
+        assert!(graph
+            .edges(vertex_ids[0])
+            .unwrap()?
+            .collect::<Vec<_>>()
+            .contains(&vertex_ids[1]));
+
+        let txn_index = fixture.new_txn_index();
+        upsert_vector_with_options(
+            vertex_ids[0],
+            &[0.0, 0.0],
+            &txn_index,
+            GraphSearchOptions::with_filter(|i: i64| i != vertex_ids[1]),
+        )?;
+        txn_index.commit(None)?;
+
+        let reader = fixture.new_txn_index();
+        let mut graph = reader.graph()?;
+        let edges = graph
+            .edges(vertex_ids[0])
+            .unwrap()?
+            .collect::<Vec<_>>();
+        assert!(
+            !edges.contains(&vertex_ids[1]),
+            "filtered vertex should never be selected as an edge, got {edges:?}"
+        );
+        // The rest of the graph should still be reachable through the other edges.
+        assert_eq!(
+            fixture.search(&[0.0, 0.0])?.into_iter().collect::<std::collections::HashSet<_>>(),
+            vertex_ids.iter().copied().collect::<std::collections::HashSet<_>>()
+        );
 
         Ok(())
     }


### PR DESCRIPTION
Split generates two new centroids that are very close to one existing centroid. Things tend to hub around the source centroid and removing it is more likely to create subgraphs or relatively isolated vertexes that can be difficult or impossible to reach, negatively affecting recall.

As a work-around, exclude _all_ of the source centroids within a parallel rebalance set during insertion in the graph index. Since we aren't creating direct edges between the source and target vertexes this hub problem is less likely to occur, and the source and targets are still linked indirectly.

This improves reachability in the delete-sim tool substantially, on the order of 50%.