### PR TITLE
Speed up vector rotation code

### DIFF
--- a/vectors/benches/coding.rs
+++ b/vectors/benches/coding.rs
@@ -1,6 +1,6 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use rand::{Rng, SeedableRng};
-use vectors::rotate::Rotator;
+use vectors::rotate::{Kernel, Rotator};
 use vectors::{F32VectorCoding, VectorSimilarity};
 
 fn generate_test_vector(dim: usize) -> Vec<f32> {
@@ -69,16 +69,18 @@ fn lvq_benchmarks(c: &mut Criterion) {
 }
 
 fn rotator_benchmarks(c: &mut Criterion) {
-    for dim in [512usize, 768, 1024, 1536, 2048] {
-        let vector = generate_test_vector(dim);
-        let rotator = Rotator::new(dim, 0x455A_5469676572);
-        c.bench_function(&format!("rotate/forward/{dim}"), |b| {
-            b.iter(|| rotator.forward(std::hint::black_box(&vector)))
-        });
-        let rotated = rotator.forward(&vector);
-        c.bench_function(&format!("rotate/backward/{dim}"), |b| {
-            b.iter(|| rotator.backward(std::hint::black_box(&rotated)))
-        });
+    for kernel in Kernel::all() {
+        for dim in [512usize, 768, 1024, 1536, 2048] {
+            let vector = generate_test_vector(dim);
+            let rotator = Rotator::with_kernel(dim, 0x455A_5469676572, kernel);
+            c.bench_function(&format!("rotate/{kernel}/forward/{dim}"), |b| {
+                b.iter(|| rotator.forward(std::hint::black_box(&vector)))
+            });
+            let rotated = rotator.forward(&vector);
+            c.bench_function(&format!("rotate/{kernel}/backward/{dim}"), |b| {
+                b.iter(|| rotator.backward(std::hint::black_box(&rotated)))
+            });
+        }
     }
 }
 

--- a/vectors/src/rotate.rs
+++ b/vectors/src/rotate.rs
@@ -1,3 +1,5 @@
+#[cfg(target_arch = "aarch64")]
+mod aarch64;
 mod scalar;
 
 use std::ops::Range;
@@ -8,6 +10,8 @@ use rand_xoshiro::Xoshiro256PlusPlus;
 // XXX in general we need to test these implementations against one another.
 enum Kernel {
     Scalar,
+    #[cfg(target_arch = "aarch64")]
+    Neon,
 }
 
 impl Kernel {
@@ -23,12 +27,17 @@ impl Kernel {
     pub fn walsh_hadamard_transform<const F: bool>(&self, v: &mut [f32], signs: &[u32]) {
         match self {
             Self::Scalar => scalar::walsh_hadamard_transform::<F>(v, signs),
+            #[cfg(target_arch = "aarch64")]
+            Self::Neon => aarch64::neon_walsh_hadamard_transform::<F>(v, signs),
         }
     }
 }
 
 impl Default for Kernel {
     fn default() -> Self {
+        if cfg!(target_arch = "aarch64") {
+            return Self::Neon;
+        }
         Self::Scalar
     }
 }

--- a/vectors/src/rotate.rs
+++ b/vectors/src/rotate.rs
@@ -36,14 +36,29 @@ impl Shuffle {
     }
 }
 
+struct Block {
+    dims: Range<usize>,
+    sign: Vec<u32>,
+}
+
+impl Block {
+    fn new(dims: Range<usize>, rng: &mut impl Rng) -> Self {
+        let sign = dims
+            .clone()
+            .map(|_| if rng.random_bool(0.5) { 0 } else { 1 << 31 })
+            .collect();
+        Self { dims, sign }
+    }
+}
+
 /// Implement orthogonal rotation of a vector for quantization to preserve distances and inner
 /// products while changing the distribution of the vector's components to minimize quantization
 /// error.
 pub struct Rotator {
     /// Vector dimensions are shuffled in the event that there are multiple blocks.
+    // XXX should rep be an enum?
     shuffle: Option<Shuffle>,
-    sign_flips: Vec<f32>,
-    blocks: Vec<Range<usize>>,
+    blocks: Vec<Block>,
 }
 
 impl Rotator {
@@ -61,24 +76,16 @@ impl Rotator {
             None
         };
 
-        let sign_flips = (0..dims)
-            .map(|_| if rng.random_bool(0.5) { 0.0 } else { -0.0 })
-            .collect::<Vec<f32>>();
-
-        let mut blocks: Vec<Range<usize>> = vec![];
+        let mut blocks: Vec<Block> = vec![];
         let mut d = dims;
         while d > 0 {
-            let start = blocks.last().map(|b| b.end).unwrap_or(0);
+            let start = blocks.last().map(|b| b.dims.end).unwrap_or(0);
             let len = 1usize << (63 - d.leading_zeros());
-            blocks.push(start..(start + len));
+            blocks.push(Block::new(start..(start + len), &mut rng));
             d ^= len;
         }
 
-        Self {
-            shuffle,
-            sign_flips,
-            blocks,
-        }
+        Self { shuffle, blocks }
     }
 
     /// Rotate forward for quantization.
@@ -93,11 +100,8 @@ impl Rotator {
             v.to_vec()
         };
 
-        for (&s, v) in self.sign_flips.iter().zip(rotated.iter_mut()) {
-            *v = f32::from_bits(v.to_bits() ^ s.to_bits());
-        }
         for block in self.blocks.iter() {
-            Self::walsh_hadamard_transform(&mut rotated[block.clone()]);
+            Self::walsh_hadamard_transform(&mut rotated[block.dims.clone()], Some(&block.sign));
         }
 
         rotated
@@ -109,10 +113,16 @@ impl Rotator {
     pub fn backward(&self, v: &[f32]) -> Vec<f32> {
         let mut tmp = v.to_vec();
         for block in self.blocks.iter() {
-            Self::walsh_hadamard_transform(&mut tmp[block.clone()]);
-        }
-        for (&s, v) in self.sign_flips.iter().zip(tmp.iter_mut()) {
-            *v = f32::from_bits(v.to_bits() ^ s.to_bits());
+            Self::walsh_hadamard_transform(&mut tmp[block.dims.clone()], None);
+            // XXX I hate this it should be fused inside the transform -- specifically backward
+            // should scale and sign flip together.
+
+            // Sign flips and the Hadamard transform don't commute, so unlike forward() (which fuses
+            // the flip immediately before each block's butterfly stages) the flip here must happen
+            // once, after every block has been fully transformed.
+            for (&s, v) in block.sign.iter().zip(tmp[block.dims.clone()].iter_mut()) {
+                *v = f32::from_bits(v.to_bits() ^ s);
+            }
         }
 
         let b = if let Some(p) = self.shuffle.as_ref() {
@@ -125,29 +135,89 @@ impl Rotator {
         b
     }
 
-    fn walsh_hadamard_transform(v: &mut [f32]) {
-        let n = v.len();
+    fn walsh_hadamard_transform(v: &mut [f32], signs: Option<&[u32]>) {
+        // Perform the early strides of the block transformation together in 64 dimension chunks
+        // in an effort to improve locality.
+        let (blocks, tail) = v.as_chunks_mut::<64>();
+        match signs {
+            Some(signs) => {
+                let (sblocks, stail) = signs.as_chunks::<64>();
+                for (b, s) in blocks.iter_mut().zip(sblocks.iter()) {
+                    Self::wht_fixed_block(b, Some(s));
+                }
+
+                if tail.is_empty() {
+                    // Continue butterfly transformation at block size and beyond.
+                    Self::wht_block(v, 64);
+                } else {
+                    // In this case the whole vector length is a power of 2 less than 64.
+                    for (&s, v) in stail.iter().zip(tail.iter_mut()) {
+                        *v = f32::from_bits(v.to_bits() ^ s);
+                    }
+                    Self::wht_block(tail, 1);
+                }
+            }
+            None => {
+                for b in blocks.iter_mut() {
+                    Self::wht_fixed_block(b, None);
+                }
+
+                if tail.is_empty() {
+                    Self::wht_block(v, 64);
+                } else {
+                    Self::wht_block(tail, 1);
+                }
+            }
+        }
+
+        // Normalize by 1/sqrt(n) to preserve distances and inner products
+        let scale = 1.0 / (v.len() as f32).sqrt();
+        for x in v.iter_mut() {
+            *x *= scale;
+        }
+    }
+
+    fn wht_block(block: &mut [f32], initial_stride: usize) {
+        let n = block.len();
         assert!(
             n.is_power_of_two(),
             "Hadamard transform requires power of 2 length"
         );
-        let mut h = 1;
+        let mut h = initial_stride;
         while h < n {
             for i in (0..n).step_by(h * 2) {
                 for j in 0..h {
-                    let x = v[i + j];
-                    let y = v[i + j + h];
-                    v[i + j] = x + y;
-                    v[i + j + h] = x - y;
+                    let x = block[i + j];
+                    let y = block[i + j + h];
+                    block[i + j] = x + y;
+                    block[i + j + h] = x - y;
                 }
             }
             h *= 2;
         }
+    }
 
-        // Normalize by 1/sqrt(n) to preserve distances and inner products
-        let scale = 1.0 / (n as f32).sqrt();
-        for x in v.iter_mut() {
-            *x *= scale;
+    /// Initial base Walsh-Hadamard Transform over a fixed size block.
+    ///
+    /// This includes the sign flips that are needed before the operation begins.
+    fn wht_fixed_block<const N: usize>(block: &mut [f32; N], signs: Option<&[u32; N]>) {
+        if let Some(signs) = signs {
+            for (&s, v) in signs.iter().zip(block.iter_mut()) {
+                *v = f32::from_bits(v.to_bits() ^ s);
+            }
+        }
+
+        let mut h = 1;
+        while h < N {
+            for i in (0..N).step_by(h * 2) {
+                for j in 0..h {
+                    let x = block[i + j];
+                    let y = block[i + j + h];
+                    block[i + j] = x + y;
+                    block[i + j + h] = x - y;
+                }
+            }
+            h *= 2;
         }
     }
 }
@@ -247,21 +317,25 @@ mod tests {
         assert_ne!(r1, r2, "different seeds should produce different rotations");
     }
 
+    fn block_dims(rotator: &Rotator) -> Vec<Range<usize>> {
+        rotator.blocks.iter().map(|b| b.dims.clone()).collect()
+    }
+
     #[test]
     fn blocks_power_of_two_is_single_block() {
         let rotator = Rotator::new(64, 0);
-        assert_eq!(rotator.blocks, vec![0..64]);
+        assert_eq!(block_dims(&rotator), vec![0..64]);
     }
 
     #[test]
     fn blocks_non_power_of_two_decomposition() {
         // 192 = 128 + 64
         let rotator = Rotator::new(192, 0);
-        assert_eq!(rotator.blocks, vec![0..128, 128..192]);
+        assert_eq!(block_dims(&rotator), vec![0..128, 128..192]);
 
         // 100 = 64 + 32 + 4
         let rotator = Rotator::new(100, 0);
-        assert_eq!(rotator.blocks, vec![0..64, 64..96, 96..100]);
+        assert_eq!(block_dims(&rotator), vec![0..64, 64..96, 96..100]);
     }
 
     #[test]
@@ -269,9 +343,10 @@ mod tests {
         // Applying WHT twice should recover the original: each application normalizes by
         // 1/sqrt(n), so two applications give 1/n * n*I = I.
         let mut v = vec![1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
+        let signs = vec![0u32; v.len()];
         let original = v.clone();
-        Rotator::walsh_hadamard_transform(&mut v);
-        Rotator::walsh_hadamard_transform(&mut v);
+        Rotator::walsh_hadamard_transform(&mut v, Some(&signs));
+        Rotator::walsh_hadamard_transform(&mut v, Some(&signs));
         assert!(
             original
                 .iter()

--- a/vectors/src/rotate.rs
+++ b/vectors/src/rotate.rs
@@ -1,7 +1,37 @@
+mod scalar;
+
 use std::ops::Range;
 
 use rand::{Rng, SeedableRng, seq::SliceRandom};
 use rand_xoshiro::Xoshiro256PlusPlus;
+
+// XXX in general we need to test these implementations against one another.
+enum Kernel {
+    Scalar,
+}
+
+impl Kernel {
+    /// Walsh-Hadamard Transform vector `v` with `signs` random sign flips.
+    ///
+    /// `signs` are expected to contain 0 or 1 << 31 and will be XORed against floating point values to
+    /// flip the sign.
+    ///
+    /// `F` is true if this is a forward transform and false if this is a backward transform.
+    /// This determines whether the signs are applied before or after the butterfly transforms.
+    ///
+    /// *Panics* if `v.len()` is not a power of two, or if `v.len() != signs.len()`
+    pub fn walsh_hadamard_transform<const F: bool>(&self, v: &mut [f32], signs: &[u32]) {
+        match self {
+            Self::Scalar => scalar::walsh_hadamard_transform::<F>(v, signs),
+        }
+    }
+}
+
+impl Default for Kernel {
+    fn default() -> Self {
+        Self::Scalar
+    }
+}
 
 /// Random shuffle of the vector: forward (encode) and backward (decode).
 ///
@@ -55,6 +85,7 @@ impl Block {
 /// products while changing the distribution of the vector's components to minimize quantization
 /// error.
 pub struct Rotator {
+    kernel: Kernel,
     /// Vector dimensions are shuffled in the event that there are multiple blocks.
     // XXX should rep be an enum?
     shuffle: Option<Shuffle>,
@@ -85,7 +116,11 @@ impl Rotator {
             d ^= len;
         }
 
-        Self { shuffle, blocks }
+        Self {
+            kernel: Kernel::default(),
+            shuffle,
+            blocks,
+        }
     }
 
     /// Rotate forward for quantization.
@@ -101,7 +136,8 @@ impl Rotator {
         };
 
         for block in self.blocks.iter() {
-            Self::walsh_hadamard_transform::<true>(&mut rotated[block.dims.clone()], &block.sign);
+            self.kernel
+                .walsh_hadamard_transform::<true>(&mut rotated[block.dims.clone()], &block.sign);
         }
 
         rotated
@@ -113,7 +149,8 @@ impl Rotator {
     pub fn backward(&self, v: &[f32]) -> Vec<f32> {
         let mut tmp = v.to_vec();
         for block in self.blocks.iter() {
-            Self::walsh_hadamard_transform::<false>(&mut tmp[block.dims.clone()], &block.sign);
+            self.kernel
+                .walsh_hadamard_transform::<false>(&mut tmp[block.dims.clone()], &block.sign);
         }
 
         let b = if let Some(p) = self.shuffle.as_ref() {
@@ -124,98 +161,6 @@ impl Rotator {
             tmp
         };
         b
-    }
-
-    fn walsh_hadamard_transform<const F: bool>(v: &mut [f32], signs: &[u32]) {
-        assert!(
-            v.len().is_power_of_two(),
-            "Hadamard transform requires power of 2 length"
-        );
-        if v.len() < 64 {
-            if F {
-                // Forward must sign flip first.
-                for (&s, v) in signs.iter().zip(v.iter_mut()) {
-                    *v = f32::from_bits(v.to_bits() ^ s);
-                }
-            }
-            Self::wht_block::<1>(v)
-        } else {
-            // Perform the early strides of the block transformation together in 64 dimension chunks
-            // in an effort to improve locality. v.len() is a power of 2 and there are at least 64
-            // entries, so there will be no tail entries.
-            let blocks = v.as_chunks_mut::<64>().0;
-            let sblocks = signs.as_chunks::<64>().0;
-            if F {
-                for (b, s) in blocks.iter_mut().zip(sblocks.iter()) {
-                    Self::wht_fixed_block::<true, 64>(b, s);
-                }
-            } else {
-                for (b, s) in blocks.iter_mut().zip(sblocks.iter()) {
-                    Self::wht_fixed_block::<false, 64>(b, s);
-                }
-            }
-            // Continue butterfly transformation at block size and beyond.
-            Self::wht_block::<64>(v);
-        }
-
-        // Normalize by 1/sqrt(n) to preserve distances and inner products.
-        // For backwards transformation invert the sign flip here too.
-        let scale = 1.0 / (v.len() as f32).sqrt();
-        if F {
-            for x in v.iter_mut() {
-                *x *= scale;
-            }
-        } else {
-            for (&s, x) in signs.iter().zip(v.iter_mut()) {
-                *x *= f32::from_bits(scale.to_bits() ^ s);
-            }
-        }
-    }
-
-    #[inline]
-    fn wht_block<const S: usize>(block: &mut [f32]) {
-        let n = block.len();
-        assert!(
-            n.is_power_of_two(),
-            "Hadamard transform requires power of 2 length"
-        );
-        let mut h = S;
-        while h < n {
-            for i in (0..n).step_by(h * 2) {
-                for j in 0..h {
-                    let x = block[i + j];
-                    let y = block[i + j + h];
-                    block[i + j] = x + y;
-                    block[i + j + h] = x - y;
-                }
-            }
-            h *= 2;
-        }
-    }
-
-    /// Initial base Walsh-Hadamard Transform over a fixed size block.
-    ///
-    /// This includes the sign flips that are needed before the operation begins if `F` is true.
-    #[inline]
-    fn wht_fixed_block<const F: bool, const N: usize>(block: &mut [f32; N], signs: &[u32; N]) {
-        if F {
-            for (&s, v) in signs.iter().zip(block.iter_mut()) {
-                *v = f32::from_bits(v.to_bits() ^ s);
-            }
-        }
-
-        let mut h = 1;
-        while h < N {
-            for i in (0..N).step_by(h * 2) {
-                for j in 0..h {
-                    let x = block[i + j];
-                    let y = block[i + j + h];
-                    block[i + j] = x + y;
-                    block[i + j + h] = x - y;
-                }
-            }
-            h *= 2;
-        }
     }
 }
 
@@ -342,8 +287,8 @@ mod tests {
         let mut v = vec![1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
         let signs = vec![0u32; v.len()];
         let original = v.clone();
-        Rotator::walsh_hadamard_transform::<true>(&mut v, &signs);
-        Rotator::walsh_hadamard_transform::<true>(&mut v, &signs);
+        Kernel::Scalar.walsh_hadamard_transform::<true>(&mut v, &signs);
+        Kernel::Scalar.walsh_hadamard_transform::<true>(&mut v, &signs);
         assert!(
             original
                 .iter()

--- a/vectors/src/rotate.rs
+++ b/vectors/src/rotate.rs
@@ -25,26 +25,40 @@ pub enum Kernel {
 }
 
 impl Kernel {
+    /// Every kernel that could be used on this target, fastest first. `Scalar` is always last and
+    /// is always usable; the others must be checked with `is_available()`.
+    const CANDIDATES: &'static [Self] = &[
+        #[cfg(target_arch = "aarch64")]
+        Self::Neon,
+        #[cfg(target_arch = "x86_64")]
+        Self::Avx512,
+        #[cfg(target_arch = "x86_64")]
+        Self::Avx,
+        Self::Scalar,
+    ];
+
+    /// True if this kernel may be used on this host.
+    fn is_available(&self) -> bool {
+        match self {
+            Self::Scalar => true,
+            #[cfg(target_arch = "aarch64")]
+            Self::Neon => true,
+            #[cfg(target_arch = "x86_64")]
+            Self::Avx512 => is_x86_feature_detected!("avx512f"),
+            #[cfg(target_arch = "x86_64")]
+            Self::Avx => is_x86_feature_detected!("avx"),
+        }
+    }
+
     /// All kernels that may be used on this host, fastest first.
     ///
     /// Accelerated kernels appear only if the host supports them; `Scalar` is always last.
-    // The set of pushes varies by target and by runtime feature detection.
-    #[allow(clippy::vec_init_then_push)]
     pub fn all() -> Vec<Self> {
-        let mut kernels = vec![];
-        #[cfg(target_arch = "aarch64")]
-        kernels.push(Self::Neon);
-        #[cfg(target_arch = "x86_64")]
-        {
-            if is_x86_feature_detected!("avx512f") {
-                kernels.push(Self::Avx512);
-            }
-            if is_x86_feature_detected!("avx") {
-                kernels.push(Self::Avx);
-            }
-        }
-        kernels.push(Self::Scalar);
-        kernels
+        Self::CANDIDATES
+            .iter()
+            .copied()
+            .filter(Self::is_available)
+            .collect()
     }
 
     /// Walsh-Hadamard Transform vector `v` with `signs` random sign flips.
@@ -74,8 +88,12 @@ impl Kernel {
 impl Default for Kernel {
     /// The fastest kernel available on this host.
     fn default() -> Self {
-        // `all()` is ordered fastest first and always contains at least `Scalar`.
-        Self::all().swap_remove(0)
+        // `CANDIDATES` is ordered fastest first and ends with `Scalar`, which is always available.
+        Self::CANDIDATES
+            .iter()
+            .copied()
+            .find(Self::is_available)
+            .expect("Scalar kernel is always available")
     }
 }
 

--- a/vectors/src/rotate.rs
+++ b/vectors/src/rotate.rs
@@ -138,24 +138,24 @@ impl Rotator {
                     *v = f32::from_bits(v.to_bits() ^ s);
                 }
             }
-            Self::wht_block(v, 1)
+            Self::wht_block::<1>(v)
         } else {
             // Perform the early strides of the block transformation together in 64 dimension chunks
             // in an effort to improve locality. v.len() is a power of 2 and there are at least 64
             // entries, so there will be no tail entries.
             let blocks = v.as_chunks_mut::<64>().0;
+            let sblocks = signs.as_chunks::<64>().0;
             if F {
-                let sblocks = signs.as_chunks::<64>().0;
                 for (b, s) in blocks.iter_mut().zip(sblocks.iter()) {
-                    Self::wht_fixed_block(b, Some(s));
+                    Self::wht_fixed_block::<true, 64>(b, s);
                 }
             } else {
-                for b in blocks.iter_mut() {
-                    Self::wht_fixed_block(b, None);
+                for (b, s) in blocks.iter_mut().zip(sblocks.iter()) {
+                    Self::wht_fixed_block::<false, 64>(b, s);
                 }
             }
             // Continue butterfly transformation at block size and beyond.
-            Self::wht_block(v, 64);
+            Self::wht_block::<64>(v);
         }
 
         // Normalize by 1/sqrt(n) to preserve distances and inner products.
@@ -172,13 +172,14 @@ impl Rotator {
         }
     }
 
-    fn wht_block(block: &mut [f32], initial_stride: usize) {
+    #[inline]
+    fn wht_block<const S: usize>(block: &mut [f32]) {
         let n = block.len();
         assert!(
             n.is_power_of_two(),
             "Hadamard transform requires power of 2 length"
         );
-        let mut h = initial_stride;
+        let mut h = S;
         while h < n {
             for i in (0..n).step_by(h * 2) {
                 for j in 0..h {
@@ -194,9 +195,10 @@ impl Rotator {
 
     /// Initial base Walsh-Hadamard Transform over a fixed size block.
     ///
-    /// This includes the sign flips that are needed before the operation begins.
-    fn wht_fixed_block<const N: usize>(block: &mut [f32; N], signs: Option<&[u32; N]>) {
-        if let Some(signs) = signs {
+    /// This includes the sign flips that are needed before the operation begins if `F` is true.
+    #[inline]
+    fn wht_fixed_block<const F: bool, const N: usize>(block: &mut [f32; N], signs: &[u32; N]) {
+        if F {
             for (&s, v) in signs.iter().zip(block.iter_mut()) {
                 *v = f32::from_bits(v.to_bits() ^ s);
             }

--- a/vectors/src/rotate.rs
+++ b/vectors/src/rotate.rs
@@ -183,14 +183,13 @@ impl Rotator {
                 .walsh_hadamard_transform::<false>(&mut tmp[block.dims.clone()], &block.sign);
         }
 
-        let b = if let Some(p) = self.shuffle.as_ref() {
+        if let Some(p) = self.shuffle.as_ref() {
             let mut r = tmp.clone();
             p.backward(&tmp, &mut r);
             r
         } else {
             tmp
-        };
-        b
+        }
     }
 }
 

--- a/vectors/src/rotate.rs
+++ b/vectors/src/rotate.rs
@@ -1,6 +1,8 @@
 #[cfg(target_arch = "aarch64")]
 mod aarch64;
 mod scalar;
+#[cfg(target_arch = "x86_64")]
+mod x86_64;
 
 use std::ops::Range;
 
@@ -12,6 +14,8 @@ enum Kernel {
     Scalar,
     #[cfg(target_arch = "aarch64")]
     Neon,
+    #[cfg(target_arch = "x86_64")]
+    Avx512,
 }
 
 impl Kernel {
@@ -29,15 +33,42 @@ impl Kernel {
             Self::Scalar => scalar::walsh_hadamard_transform::<F>(v, signs),
             #[cfg(target_arch = "aarch64")]
             Self::Neon => aarch64::neon_walsh_hadamard_transform::<F>(v, signs),
+            // Safety: only constructed after `is_x86_feature_detected!("avx512f")` succeeded,
+            // see `Kernel::preferred` below.
+            #[cfg(target_arch = "x86_64")]
+            Self::Avx512 => unsafe { x86_64::avx512_walsh_hadamard_transform::<F>(v, signs) },
         }
     }
 }
 
 impl Default for Kernel {
     fn default() -> Self {
-        if cfg!(target_arch = "aarch64") {
-            return Self::Neon;
+        Self::preferred()
+    }
+}
+
+// XXX i hate this.
+#[cfg(target_arch = "aarch64")]
+impl Kernel {
+    fn preferred() -> Self {
+        Self::Neon
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+impl Kernel {
+    fn preferred() -> Self {
+        if is_x86_feature_detected!("avx512f") {
+            Self::Avx512
+        } else {
+            Self::Scalar
         }
+    }
+}
+
+#[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
+impl Kernel {
+    fn preferred() -> Self {
         Self::Scalar
     }
 }

--- a/vectors/src/rotate.rs
+++ b/vectors/src/rotate.rs
@@ -20,20 +20,30 @@ pub enum Kernel {
     Neon,
     #[cfg(target_arch = "x86_64")]
     Avx512,
+    #[cfg(target_arch = "x86_64")]
+    Avx,
 }
 
 impl Kernel {
-    /// All kernels that may be used on this host, in no particular order.
+    /// All kernels that may be used on this host, fastest first.
     ///
-    /// `Scalar` is always included; accelerated kernels appear only if the host supports them.
+    /// Accelerated kernels appear only if the host supports them; `Scalar` is always last.
+    // The set of pushes varies by target and by runtime feature detection.
+    #[allow(clippy::vec_init_then_push)]
     pub fn all() -> Vec<Self> {
-        let mut kernels = vec![Self::Scalar];
+        let mut kernels = vec![];
         #[cfg(target_arch = "aarch64")]
         kernels.push(Self::Neon);
         #[cfg(target_arch = "x86_64")]
-        if is_x86_feature_detected!("avx512f") {
-            kernels.push(Self::Avx512);
+        {
+            if is_x86_feature_detected!("avx512f") {
+                kernels.push(Self::Avx512);
+            }
+            if is_x86_feature_detected!("avx") {
+                kernels.push(Self::Avx);
+            }
         }
+        kernels.push(Self::Scalar);
         kernels
     }
 
@@ -51,32 +61,21 @@ impl Kernel {
             Self::Scalar => scalar::walsh_hadamard_transform::<F>(v, signs),
             #[cfg(target_arch = "aarch64")]
             Self::Neon => aarch64::neon_walsh_hadamard_transform::<F>(v, signs),
-            // Safety: only constructed after `is_x86_feature_detected!("avx512f")` succeeded,
-            // see `Kernel::preferred` below.
+            // Safety: these are only constructed after the matching `is_x86_feature_detected!`
+            // check succeeded, see `Kernel::all` above.
             #[cfg(target_arch = "x86_64")]
             Self::Avx512 => unsafe { x86_64::avx512_walsh_hadamard_transform::<F>(v, signs) },
+            #[cfg(target_arch = "x86_64")]
+            Self::Avx => unsafe { x86_64::avx_walsh_hadamard_transform::<F>(v, signs) },
         }
     }
 }
 
 impl Default for Kernel {
-    #[cfg(target_arch = "aarch64")]
+    /// The fastest kernel available on this host.
     fn default() -> Self {
-        Self::Neon
-    }
-
-    #[cfg(target_arch = "x86_64")]
-    fn default() -> Self {
-        if is_x86_feature_detected!("avx512f") {
-            Self::Avx512
-        } else {
-            Self::Scalar
-        }
-    }
-
-    #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
-    fn default() -> Self {
-        Self::Scalar
+        // `all()` is ordered fastest first and always contains at least `Scalar`.
+        Self::all().swap_remove(0)
     }
 }
 

--- a/vectors/src/rotate.rs
+++ b/vectors/src/rotate.rs
@@ -11,6 +11,7 @@ use rand_xoshiro::Xoshiro256PlusPlus;
 
 // XXX in general we need to test these implementations against one another.
 enum Kernel {
+    #[allow(dead_code)]
     Scalar,
     #[cfg(target_arch = "aarch64")]
     Neon,
@@ -42,33 +43,22 @@ impl Kernel {
 }
 
 impl Default for Kernel {
+    #[cfg(target_arch = "aarch64")]
     fn default() -> Self {
-        Self::preferred()
-    }
-}
-
-// XXX i hate this.
-#[cfg(target_arch = "aarch64")]
-impl Kernel {
-    fn preferred() -> Self {
         Self::Neon
     }
-}
 
-#[cfg(target_arch = "x86_64")]
-impl Kernel {
-    fn preferred() -> Self {
+    #[cfg(target_arch = "x86_64")]
+    fn default() -> Self {
         if is_x86_feature_detected!("avx512f") {
             Self::Avx512
         } else {
             Self::Scalar
         }
     }
-}
 
-#[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
-impl Kernel {
-    fn preferred() -> Self {
+    #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
+    fn default() -> Self {
         Self::Scalar
     }
 }
@@ -335,5 +325,63 @@ mod tests {
                 .zip(&v)
                 .all(|(a, b)| abs_diff_eq!(a, b, epsilon = 1e-6))
         );
+    }
+
+    /// The accelerated kernel available on the current hardware, e.g. `Neon` on aarch64 or
+    /// `Avx512` on x86_64 with the necessary feature present. `None` if only `Scalar` is
+    /// available (e.g. an x86_64 host without `avx512f`).
+    fn accelerated_kernel() -> Option<Kernel> {
+        match Kernel::default() {
+            Kernel::Scalar => None,
+            accelerated => Some(accelerated),
+        }
+    }
+
+    fn make_signs(dims: usize, seed: u64) -> Vec<u32> {
+        let mut rng = Xoshiro256PlusPlus::seed_from_u64(seed);
+        (0..dims)
+            .map(|_| if rng.random_bool(0.5) { 0 } else { 1u32 << 31 })
+            .collect()
+    }
+
+    /// Change-detector test: any accelerated kernel (Neon, Avx512, ...) must produce bit-for-bit
+    /// equivalent (within float epsilon) results to the scalar reference implementation, across
+    /// every block-size code path (below 64, exactly 64, and multiple 64-blocks) and both
+    /// transform directions.
+    #[test]
+    fn accelerated_matches_scalar() {
+        let Some(accelerated) = accelerated_kernel() else {
+            // No accelerated kernel is available on this hardware; nothing to compare.
+            return;
+        };
+
+        for &dims in &[1usize, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024] {
+            for seed in 0..5u64 {
+                let v = make_vec(dims, seed);
+                let signs = make_signs(dims, seed ^ 0xdead_beef);
+
+                let mut forward_scalar = v.clone();
+                let mut forward_accel = v.clone();
+                Kernel::Scalar.walsh_hadamard_transform::<true>(&mut forward_scalar, &signs);
+                accelerated.walsh_hadamard_transform::<true>(&mut forward_accel, &signs);
+                for (i, (a, b)) in forward_scalar.iter().zip(&forward_accel).enumerate() {
+                    assert!(
+                        abs_diff_eq!(a, b, epsilon = 1e-4),
+                        "dims={dims} seed={seed} forward mismatch at {i}: scalar={a} accel={b}"
+                    );
+                }
+
+                let mut backward_scalar = forward_scalar.clone();
+                let mut backward_accel = forward_accel.clone();
+                Kernel::Scalar.walsh_hadamard_transform::<false>(&mut backward_scalar, &signs);
+                accelerated.walsh_hadamard_transform::<false>(&mut backward_accel, &signs);
+                for (i, (a, b)) in backward_scalar.iter().zip(&backward_accel).enumerate() {
+                    assert!(
+                        abs_diff_eq!(a, b, epsilon = 1e-4),
+                        "dims={dims} seed={seed} backward mismatch at {i}: scalar={a} accel={b}"
+                    );
+                }
+            }
+        }
     }
 }

--- a/vectors/src/rotate.rs
+++ b/vectors/src/rotate.rs
@@ -9,9 +9,12 @@ use std::ops::Range;
 use rand::{Rng, SeedableRng, seq::SliceRandom};
 use rand_xoshiro::Xoshiro256PlusPlus;
 
-// XXX in general we need to test these implementations against one another.
-enum Kernel {
-    #[allow(dead_code)]
+/// Implementation of the Walsh-Hadamard transform used to rotate vectors.
+///
+/// Use [`Kernel::default()`] for the fastest kernel available on this host, or [`Kernel::all()`]
+/// to enumerate every kernel that may be used on this host.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum Kernel {
     Scalar,
     #[cfg(target_arch = "aarch64")]
     Neon,
@@ -20,6 +23,20 @@ enum Kernel {
 }
 
 impl Kernel {
+    /// All kernels that may be used on this host, in no particular order.
+    ///
+    /// `Scalar` is always included; accelerated kernels appear only if the host supports them.
+    pub fn all() -> Vec<Self> {
+        let mut kernels = vec![Self::Scalar];
+        #[cfg(target_arch = "aarch64")]
+        kernels.push(Self::Neon);
+        #[cfg(target_arch = "x86_64")]
+        if is_x86_feature_detected!("avx512f") {
+            kernels.push(Self::Avx512);
+        }
+        kernels
+    }
+
     /// Walsh-Hadamard Transform vector `v` with `signs` random sign flips.
     ///
     /// `signs` are expected to contain 0 or 1 << 31 and will be XORed against floating point values to
@@ -60,6 +77,12 @@ impl Default for Kernel {
     #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
     fn default() -> Self {
         Self::Scalar
+    }
+}
+
+impl std::fmt::Display for Kernel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(self, f)
     }
 }
 
@@ -130,6 +153,13 @@ impl Rotator {
     /// diagonal Hardamard transform will be used on blocks of dimensions dictated by a binary
     /// decomposition of `dims`.
     pub fn new(dims: usize, seed: u64) -> Self {
+        Self::with_kernel(dims, seed, Kernel::default())
+    }
+
+    /// Like [`Rotator::new()`] but uses `kernel` to compute the transforms instead of the fastest
+    /// kernel available on this host. All kernels produce equivalent results; this is intended for
+    /// testing and benchmarking.
+    pub fn with_kernel(dims: usize, seed: u64, kernel: Kernel) -> Self {
         let mut rng = Xoshiro256PlusPlus::seed_from_u64(seed);
         let shuffle = if !dims.is_power_of_two() {
             Some(Shuffle::new(dims, &mut rng))
@@ -147,7 +177,7 @@ impl Rotator {
         }
 
         Self {
-            kernel: Kernel::default(),
+            kernel,
             shuffle,
             blocks,
         }
@@ -329,11 +359,11 @@ mod tests {
     /// The accelerated kernel available on the current hardware, e.g. `Neon` on aarch64 or
     /// `Avx512` on x86_64 with the necessary feature present. `None` if only `Scalar` is
     /// available (e.g. an x86_64 host without `avx512f`).
-    fn accelerated_kernel() -> Option<Kernel> {
-        match Kernel::default() {
-            Kernel::Scalar => None,
-            accelerated => Some(accelerated),
-        }
+    fn accelerated_kernels() -> Vec<Kernel> {
+        Kernel::all()
+            .into_iter()
+            .filter(|k| *k != Kernel::Scalar)
+            .collect()
     }
 
     fn make_signs(dims: usize, seed: u64) -> Vec<u32> {
@@ -349,36 +379,34 @@ mod tests {
     /// transform directions.
     #[test]
     fn accelerated_matches_scalar() {
-        let Some(accelerated) = accelerated_kernel() else {
-            // No accelerated kernel is available on this hardware; nothing to compare.
-            return;
-        };
+        // If no accelerated kernel is available on this hardware there is nothing to compare.
+        for accelerated in accelerated_kernels() {
+            for &dims in &[1usize, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024] {
+                for seed in 0..5u64 {
+                    let v = make_vec(dims, seed);
+                    let signs = make_signs(dims, seed ^ 0xdead_beef);
 
-        for &dims in &[1usize, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024] {
-            for seed in 0..5u64 {
-                let v = make_vec(dims, seed);
-                let signs = make_signs(dims, seed ^ 0xdead_beef);
+                    let mut forward_scalar = v.clone();
+                    let mut forward_accel = v.clone();
+                    Kernel::Scalar.walsh_hadamard_transform::<true>(&mut forward_scalar, &signs);
+                    accelerated.walsh_hadamard_transform::<true>(&mut forward_accel, &signs);
+                    for (i, (a, b)) in forward_scalar.iter().zip(&forward_accel).enumerate() {
+                        assert!(
+                            abs_diff_eq!(a, b, epsilon = 1e-4),
+                            "{accelerated} dims={dims} seed={seed} forward mismatch at {i}: scalar={a} accel={b}"
+                        );
+                    }
 
-                let mut forward_scalar = v.clone();
-                let mut forward_accel = v.clone();
-                Kernel::Scalar.walsh_hadamard_transform::<true>(&mut forward_scalar, &signs);
-                accelerated.walsh_hadamard_transform::<true>(&mut forward_accel, &signs);
-                for (i, (a, b)) in forward_scalar.iter().zip(&forward_accel).enumerate() {
-                    assert!(
-                        abs_diff_eq!(a, b, epsilon = 1e-4),
-                        "dims={dims} seed={seed} forward mismatch at {i}: scalar={a} accel={b}"
-                    );
-                }
-
-                let mut backward_scalar = forward_scalar.clone();
-                let mut backward_accel = forward_accel.clone();
-                Kernel::Scalar.walsh_hadamard_transform::<false>(&mut backward_scalar, &signs);
-                accelerated.walsh_hadamard_transform::<false>(&mut backward_accel, &signs);
-                for (i, (a, b)) in backward_scalar.iter().zip(&backward_accel).enumerate() {
-                    assert!(
-                        abs_diff_eq!(a, b, epsilon = 1e-4),
-                        "dims={dims} seed={seed} backward mismatch at {i}: scalar={a} accel={b}"
-                    );
+                    let mut backward_scalar = forward_scalar.clone();
+                    let mut backward_accel = forward_accel.clone();
+                    Kernel::Scalar.walsh_hadamard_transform::<false>(&mut backward_scalar, &signs);
+                    accelerated.walsh_hadamard_transform::<false>(&mut backward_accel, &signs);
+                    for (i, (a, b)) in backward_scalar.iter().zip(&backward_accel).enumerate() {
+                        assert!(
+                            abs_diff_eq!(a, b, epsilon = 1e-4),
+                            "{accelerated} dims={dims} seed={seed} backward mismatch at {i}: scalar={a} accel={b}"
+                        );
+                    }
                 }
             }
         }

--- a/vectors/src/rotate.rs
+++ b/vectors/src/rotate.rs
@@ -157,7 +157,6 @@ impl Block {
 pub struct Rotator {
     kernel: Kernel,
     /// Vector dimensions are shuffled in the event that there are multiple blocks.
-    // XXX should rep be an enum?
     shuffle: Option<Shuffle>,
     blocks: Vec<Block>,
 }

--- a/vectors/src/rotate.rs
+++ b/vectors/src/rotate.rs
@@ -101,7 +101,7 @@ impl Rotator {
         };
 
         for block in self.blocks.iter() {
-            Self::walsh_hadamard_transform(&mut rotated[block.dims.clone()], Some(&block.sign));
+            Self::walsh_hadamard_transform::<true>(&mut rotated[block.dims.clone()], &block.sign);
         }
 
         rotated
@@ -113,16 +113,7 @@ impl Rotator {
     pub fn backward(&self, v: &[f32]) -> Vec<f32> {
         let mut tmp = v.to_vec();
         for block in self.blocks.iter() {
-            Self::walsh_hadamard_transform(&mut tmp[block.dims.clone()], None);
-            // XXX I hate this it should be fused inside the transform -- specifically backward
-            // should scale and sign flip together.
-
-            // Sign flips and the Hadamard transform don't commute, so unlike forward() (which fuses
-            // the flip immediately before each block's butterfly stages) the flip here must happen
-            // once, after every block has been fully transformed.
-            for (&s, v) in block.sign.iter().zip(tmp[block.dims.clone()].iter_mut()) {
-                *v = f32::from_bits(v.to_bits() ^ s);
-            }
+            Self::walsh_hadamard_transform::<false>(&mut tmp[block.dims.clone()], &block.sign);
         }
 
         let b = if let Some(p) = self.shuffle.as_ref() {
@@ -135,45 +126,49 @@ impl Rotator {
         b
     }
 
-    fn walsh_hadamard_transform(v: &mut [f32], signs: Option<&[u32]>) {
-        // Perform the early strides of the block transformation together in 64 dimension chunks
-        // in an effort to improve locality.
-        let (blocks, tail) = v.as_chunks_mut::<64>();
-        match signs {
-            Some(signs) => {
-                let (sblocks, stail) = signs.as_chunks::<64>();
+    fn walsh_hadamard_transform<const F: bool>(v: &mut [f32], signs: &[u32]) {
+        assert!(
+            v.len().is_power_of_two(),
+            "Hadamard transform requires power of 2 length"
+        );
+        if v.len() < 64 {
+            if F {
+                // Forward must sign flip first.
+                for (&s, v) in signs.iter().zip(v.iter_mut()) {
+                    *v = f32::from_bits(v.to_bits() ^ s);
+                }
+            }
+            Self::wht_block(v, 1)
+        } else {
+            // Perform the early strides of the block transformation together in 64 dimension chunks
+            // in an effort to improve locality. v.len() is a power of 2 and there are at least 64
+            // entries, so there will be no tail entries.
+            let blocks = v.as_chunks_mut::<64>().0;
+            if F {
+                let sblocks = signs.as_chunks::<64>().0;
                 for (b, s) in blocks.iter_mut().zip(sblocks.iter()) {
                     Self::wht_fixed_block(b, Some(s));
                 }
-
-                if tail.is_empty() {
-                    // Continue butterfly transformation at block size and beyond.
-                    Self::wht_block(v, 64);
-                } else {
-                    // In this case the whole vector length is a power of 2 less than 64.
-                    for (&s, v) in stail.iter().zip(tail.iter_mut()) {
-                        *v = f32::from_bits(v.to_bits() ^ s);
-                    }
-                    Self::wht_block(tail, 1);
-                }
-            }
-            None => {
+            } else {
                 for b in blocks.iter_mut() {
                     Self::wht_fixed_block(b, None);
                 }
-
-                if tail.is_empty() {
-                    Self::wht_block(v, 64);
-                } else {
-                    Self::wht_block(tail, 1);
-                }
             }
+            // Continue butterfly transformation at block size and beyond.
+            Self::wht_block(v, 64);
         }
 
-        // Normalize by 1/sqrt(n) to preserve distances and inner products
+        // Normalize by 1/sqrt(n) to preserve distances and inner products.
+        // For backwards transformation invert the sign flip here too.
         let scale = 1.0 / (v.len() as f32).sqrt();
-        for x in v.iter_mut() {
-            *x *= scale;
+        if F {
+            for x in v.iter_mut() {
+                *x *= scale;
+            }
+        } else {
+            for (&s, x) in signs.iter().zip(v.iter_mut()) {
+                *x *= f32::from_bits(scale.to_bits() ^ s);
+            }
         }
     }
 
@@ -345,8 +340,8 @@ mod tests {
         let mut v = vec![1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
         let signs = vec![0u32; v.len()];
         let original = v.clone();
-        Rotator::walsh_hadamard_transform(&mut v, Some(&signs));
-        Rotator::walsh_hadamard_transform(&mut v, Some(&signs));
+        Rotator::walsh_hadamard_transform::<true>(&mut v, &signs);
+        Rotator::walsh_hadamard_transform::<true>(&mut v, &signs);
         assert!(
             original
                 .iter()

--- a/vectors/src/rotate.rs
+++ b/vectors/src/rotate.rs
@@ -3,14 +3,45 @@ use std::ops::Range;
 use rand::{Rng, SeedableRng, seq::SliceRandom};
 use rand_xoshiro::Xoshiro256PlusPlus;
 
+/// Random shuffle of the vector: forward (encode) and backward (decode).
+///
+/// This is necessary when vector size is not a power of two since we will only shuffle within
+/// power of two sized blocks.
+struct Shuffle {
+    forward: Vec<u32>,
+    backward: Vec<u32>,
+}
+
+impl Shuffle {
+    fn new(dims: usize, rng: &mut impl Rng) -> Self {
+        let mut forward = (0..dims as u32).collect::<Vec<u32>>();
+        forward.shuffle(rng);
+        let mut backward = vec![0; dims];
+        for (i, &j) in forward.iter().enumerate() {
+            backward[j as usize] = i as u32;
+        }
+        Self { forward, backward }
+    }
+
+    fn forward(&self, unpermuted: &[f32], permuted: &mut [f32]) {
+        for (&i, o) in self.forward.iter().zip(permuted.iter_mut()) {
+            *o = unpermuted[i as usize];
+        }
+    }
+
+    fn backward(&self, permuted: &[f32], unpermuted: &mut [f32]) {
+        for (&i, o) in self.backward.iter().zip(unpermuted.iter_mut()) {
+            *o = permuted[i as usize];
+        }
+    }
+}
+
 /// Implement orthogonal rotation of a vector for quantization to preserve distances and inner
 /// products while changing the distribution of the vector's components to minimize quantization
 /// error.
-///
-/// Implement fast Hadamard transform, permutation, and sign flip
 pub struct Rotator {
-    forward_permutation: Vec<usize>,
-    backward_permutation: Vec<usize>,
+    /// Vector dimensions are shuffled in the event that there are multiple blocks.
+    shuffle: Option<Shuffle>,
     sign_flips: Vec<f32>,
     blocks: Vec<Range<usize>>,
 }
@@ -24,14 +55,14 @@ impl Rotator {
     /// decomposition of `dims`.
     pub fn new(dims: usize, seed: u64) -> Self {
         let mut rng = Xoshiro256PlusPlus::seed_from_u64(seed);
-        let mut forward_permutation = (0..dims).collect::<Vec<usize>>();
-        forward_permutation.shuffle(&mut rng);
-        let mut backward_permutation = vec![0; dims];
-        for (i, &j) in forward_permutation.iter().enumerate() {
-            backward_permutation[j] = i;
-        }
+        let shuffle = if !dims.is_power_of_two() {
+            Some(Shuffle::new(dims, &mut rng))
+        } else {
+            None
+        };
+
         let sign_flips = (0..dims)
-            .map(|_| if rng.random_bool(0.5) { 1.0 } else { -1.0 })
+            .map(|_| if rng.random_bool(0.5) { 0.0 } else { -0.0 })
             .collect::<Vec<f32>>();
 
         let mut blocks: Vec<Range<usize>> = vec![];
@@ -44,8 +75,7 @@ impl Rotator {
         }
 
         Self {
-            forward_permutation,
-            backward_permutation,
+            shuffle,
             sign_flips,
             blocks,
         }
@@ -55,18 +85,17 @@ impl Rotator {
     ///
     /// This applies sign flips, then permutation, then block diagonal Hadamard transforms.
     pub fn forward(&self, v: &[f32]) -> Vec<f32> {
-        let signed = self
-            .sign_flips
-            .iter()
-            .zip(v.iter())
-            .map(|(s, &x)| s * x)
-            .collect::<Vec<f32>>();
-        let mut rotated = self
-            .forward_permutation
-            .iter()
-            .map(|&i| signed[i])
-            .collect::<Vec<f32>>();
+        let mut rotated = if let Some(p) = self.shuffle.as_ref() {
+            let mut r = vec![0.0f32; v.len()];
+            p.forward(v, &mut r);
+            r
+        } else {
+            v.to_vec()
+        };
 
+        for (&s, v) in self.sign_flips.iter().zip(rotated.iter_mut()) {
+            *v = f32::from_bits(v.to_bits() ^ s.to_bits());
+        }
         for block in self.blocks.iter() {
             Self::walsh_hadamard_transform(&mut rotated[block.clone()]);
         }
@@ -82,15 +111,17 @@ impl Rotator {
         for block in self.blocks.iter() {
             Self::walsh_hadamard_transform(&mut tmp[block.clone()]);
         }
-
-        let mut b = self
-            .backward_permutation
-            .iter()
-            .map(|&i| tmp[i])
-            .collect::<Vec<f32>>();
-        for (i, v) in b.iter_mut().enumerate() {
-            *v *= self.sign_flips[i];
+        for (&s, v) in self.sign_flips.iter().zip(tmp.iter_mut()) {
+            *v = f32::from_bits(v.to_bits() ^ s.to_bits());
         }
+
+        let b = if let Some(p) = self.shuffle.as_ref() {
+            let mut r = tmp.clone();
+            p.backward(&tmp, &mut r);
+            r
+        } else {
+            tmp
+        };
         b
     }
 
@@ -147,7 +178,11 @@ mod tests {
         let v = make_vec(128, 1);
         let rotated = rotator.forward(&v);
         let recovered = rotator.backward(&rotated);
-        assert!(v.iter().zip(&recovered).all(|(a, b)| abs_diff_eq!(a, b, epsilon = 1e-5)));
+        assert!(
+            v.iter()
+                .zip(&recovered)
+                .all(|(a, b)| abs_diff_eq!(a, b, epsilon = 1e-5))
+        );
     }
 
     #[test]
@@ -157,7 +192,11 @@ mod tests {
         let v = make_vec(192, 2);
         let rotated = rotator.forward(&v);
         let recovered = rotator.backward(&rotated);
-        assert!(v.iter().zip(&recovered).all(|(a, b)| abs_diff_eq!(a, b, epsilon = 1e-5)));
+        assert!(
+            v.iter()
+                .zip(&recovered)
+                .all(|(a, b)| abs_diff_eq!(a, b, epsilon = 1e-5))
+        );
     }
 
     #[test]
@@ -167,7 +206,11 @@ mod tests {
         let v = make_vec(100, 3);
         let rotated = rotator.forward(&v);
         let recovered = rotator.backward(&rotated);
-        assert!(v.iter().zip(&recovered).all(|(a, b)| abs_diff_eq!(a, b, epsilon = 1e-5)));
+        assert!(
+            v.iter()
+                .zip(&recovered)
+                .all(|(a, b)| abs_diff_eq!(a, b, epsilon = 1e-5))
+        );
     }
 
     #[test]
@@ -229,6 +272,11 @@ mod tests {
         let original = v.clone();
         Rotator::walsh_hadamard_transform(&mut v);
         Rotator::walsh_hadamard_transform(&mut v);
-        assert!(original.iter().zip(&v).all(|(a, b)| abs_diff_eq!(a, b, epsilon = 1e-6)));
+        assert!(
+            original
+                .iter()
+                .zip(&v)
+                .all(|(a, b)| abs_diff_eq!(a, b, epsilon = 1e-6))
+        );
     }
 }

--- a/vectors/src/rotate/aarch64.rs
+++ b/vectors/src/rotate/aarch64.rs
@@ -12,7 +12,7 @@ pub fn neon_walsh_hadamard_transform<const F: bool>(v: &mut [f32], signs: &[u32]
     );
     assert_eq!(v.len(), signs.len());
     if v.len() < 64 {
-        return super::scalar::walsh_hadamard_transform::<F>(v, signs);
+        super::scalar::walsh_hadamard_transform::<F>(v, signs)
     } else {
         // Perform the early strides of the block transformation together in 64 dimension chunks
         // in an effort to improve locality. v.len() is a power of 2 and there are at least 64

--- a/vectors/src/rotate/aarch64.rs
+++ b/vectors/src/rotate/aarch64.rs
@@ -1,5 +1,5 @@
 use std::arch::aarch64::{
-    float32x4_t, vaddq_f32, veorq_u32, vld1q_f32, vld1q_u32, vreinterpretq_f32_f64,
+    float32x4_t, vaddq_f32, veorq_u32, vld1q_f32, vld1q_u32, vmulq_n_f32, vreinterpretq_f32_f64,
     vreinterpretq_f32_u32, vreinterpretq_f64_f32, vreinterpretq_u32_f32, vst1q_f32, vsubq_f32,
     vuzp1q_f32, vuzp1q_f64, vuzp2q_f32, vuzp2q_f64, vzip1q_f32, vzip1q_f64, vzip2q_f32, vzip2q_f64,
 };
@@ -29,41 +29,82 @@ pub fn neon_walsh_hadamard_transform<const F: bool>(v: &mut [f32], signs: &[u32]
             }
         }
         // Continue butterfly transformation at block size and beyond.
-        wht_block::<64>(v);
-    }
-
-    // Normalize by 1/sqrt(n) to preserve distances and inner products.
-    // For backwards transformation invert the sign flip here too.
-    let scale = 1.0 / (v.len() as f32).sqrt();
-    if F {
-        for x in v.iter_mut() {
-            *x *= scale;
-        }
-    } else {
-        for (&s, x) in signs.iter().zip(v.iter_mut()) {
-            *x *= f32::from_bits(scale.to_bits() ^ s);
-        }
+        wht_block_from64::<F>(v, signs);
     }
 }
 
 #[inline]
-fn wht_block<const S: usize>(block: &mut [f32]) {
+fn wht_block_from64<const F: bool>(block: &mut [f32], signs: &[u32]) {
     let n = block.len();
     assert!(
         n.is_power_of_two(),
         "Hadamard transform requires power of 2 length"
     );
-    let mut h = S;
-    while h < n {
+    let scale = 1.0 / (n as f32).sqrt();
+
+    if n == 64 {
+        // The base 64-wide transform already completed every stride; there is no further
+        // butterfly stage to fuse the normalization into, so just scale (and sign-flip for
+        // backward) in place.
+        for i in (0..n).step_by(4) {
+            unsafe {
+                let x = vld1q_f32(block.as_ptr().add(i));
+                let mut v = vmulq_n_f32(x, scale);
+                if !F {
+                    v = vreinterpretq_f32_u32(veorq_u32(
+                        vreinterpretq_u32_f32(v),
+                        vld1q_u32(signs.as_ptr().add(i)),
+                    ));
+                }
+                vst1q_f32(block.as_mut_ptr().add(i), v);
+            }
+        }
+        return;
+    }
+
+    let mut h = 64;
+    while h < n / 2 {
         for i in (0..n).step_by(h * 2) {
-            for j in 0..h {
-                let x = block[i + j];
-                let y = block[i + j + h];
-                block[i + j] = x + y;
-                block[i + j + h] = x - y;
+            for j in (0..h).step_by(4) {
+                let x_off = i + j;
+                let y_off = i + j + h;
+                unsafe {
+                    let x = vld1q_f32(block.as_ptr().add(x_off));
+                    let y = vld1q_f32(block.as_ptr().add(y_off));
+                    vst1q_f32(block.as_mut_ptr().add(x_off), vaddq_f32(x, y));
+                    vst1q_f32(block.as_mut_ptr().add(y_off), vsubq_f32(x, y));
+                }
             }
         }
         h *= 2;
+    }
+
+    for i in (0..n).step_by(h * 2) {
+        for j in (0..h).step_by(4) {
+            let x_off = i + j;
+            let y_off = i + j + h;
+            unsafe {
+                let x = vld1q_f32(block.as_ptr().add(x_off));
+                let y = vld1q_f32(block.as_ptr().add(y_off));
+
+                let mut a = vmulq_n_f32(vaddq_f32(x, y), scale);
+                let mut b = vmulq_n_f32(vsubq_f32(x, y), scale);
+
+                if !F {
+                    a = vreinterpretq_f32_u32(veorq_u32(
+                        vreinterpretq_u32_f32(a),
+                        vld1q_u32(signs.as_ptr().add(x_off)),
+                    ));
+                    b = vreinterpretq_f32_u32(veorq_u32(
+                        vreinterpretq_u32_f32(b),
+                        vld1q_u32(signs.as_ptr().add(y_off)),
+                    ));
+                }
+
+                vst1q_f32(block.as_mut_ptr().add(x_off), a);
+                vst1q_f32(block.as_mut_ptr().add(y_off), b);
+            }
+        }
     }
 }
 

--- a/vectors/src/rotate/aarch64.rs
+++ b/vectors/src/rotate/aarch64.rs
@@ -1,0 +1,163 @@
+use std::arch::aarch64::{
+    float32x4_t, vaddq_f32, veorq_u32, vld1q_f32, vld1q_u32, vreinterpretq_f32_f64,
+    vreinterpretq_f32_u32, vreinterpretq_f64_f32, vreinterpretq_u32_f32, vst1q_f32, vsubq_f32,
+    vuzp1q_f32, vuzp1q_f64, vuzp2q_f32, vuzp2q_f64, vzip1q_f32, vzip1q_f64, vzip2q_f32, vzip2q_f64,
+};
+
+#[inline]
+pub fn neon_walsh_hadamard_transform<const F: bool>(v: &mut [f32], signs: &[u32]) {
+    assert!(
+        v.len().is_power_of_two(),
+        "Hadamard transform requires power of 2 length"
+    );
+    assert_eq!(v.len(), signs.len());
+    if v.len() < 64 {
+        return super::scalar::walsh_hadamard_transform::<F>(v, signs);
+    } else {
+        // Perform the early strides of the block transformation together in 64 dimension chunks
+        // in an effort to improve locality. v.len() is a power of 2 and there are at least 64
+        // entries, so there will be no tail entries.
+        let blocks = v.as_chunks_mut::<64>().0;
+        let sblocks = signs.as_chunks::<64>().0;
+        if F {
+            for (b, s) in blocks.iter_mut().zip(sblocks.iter()) {
+                wht_fixed_block64::<true>(b, s);
+            }
+        } else {
+            for (b, s) in blocks.iter_mut().zip(sblocks.iter()) {
+                wht_fixed_block64::<false>(b, s);
+            }
+        }
+        // Continue butterfly transformation at block size and beyond.
+        wht_block::<64>(v);
+    }
+
+    // Normalize by 1/sqrt(n) to preserve distances and inner products.
+    // For backwards transformation invert the sign flip here too.
+    let scale = 1.0 / (v.len() as f32).sqrt();
+    if F {
+        for x in v.iter_mut() {
+            *x *= scale;
+        }
+    } else {
+        for (&s, x) in signs.iter().zip(v.iter_mut()) {
+            *x *= f32::from_bits(scale.to_bits() ^ s);
+        }
+    }
+}
+
+#[inline]
+fn wht_block<const S: usize>(block: &mut [f32]) {
+    let n = block.len();
+    assert!(
+        n.is_power_of_two(),
+        "Hadamard transform requires power of 2 length"
+    );
+    let mut h = S;
+    while h < n {
+        for i in (0..n).step_by(h * 2) {
+            for j in 0..h {
+                let x = block[i + j];
+                let y = block[i + j + h];
+                block[i + j] = x + y;
+                block[i + j + h] = x - y;
+            }
+        }
+        h *= 2;
+    }
+}
+
+/// Initial base Walsh-Hadamard Transform over a fixed size block.
+///
+/// This includes the sign flips that are needed before the operation begins if `F` is true.
+#[inline]
+fn wht_fixed_block64<const F: bool>(block: &mut [f32; 64], signs: &[u32; 64]) {
+    // Load 4 entries at a time, optionally flipping signs if F is true.
+    fn load4<const F: bool>(b: *const f32, s: *const u32, off: usize) -> float32x4_t {
+        unsafe {
+            let r = vld1q_f32(b.add(off));
+            if F {
+                vreinterpretq_f32_u32(veorq_u32(vreinterpretq_u32_f32(r), vld1q_u32(s.add(off))))
+            } else {
+                r
+            }
+        }
+    }
+    let mut r = [
+        load4::<F>(block.as_ptr(), signs.as_ptr(), 0),
+        load4::<F>(block.as_ptr(), signs.as_ptr(), 4),
+        load4::<F>(block.as_ptr(), signs.as_ptr(), 8),
+        load4::<F>(block.as_ptr(), signs.as_ptr(), 12),
+        load4::<F>(block.as_ptr(), signs.as_ptr(), 16),
+        load4::<F>(block.as_ptr(), signs.as_ptr(), 20),
+        load4::<F>(block.as_ptr(), signs.as_ptr(), 24),
+        load4::<F>(block.as_ptr(), signs.as_ptr(), 28),
+        load4::<F>(block.as_ptr(), signs.as_ptr(), 32),
+        load4::<F>(block.as_ptr(), signs.as_ptr(), 36),
+        load4::<F>(block.as_ptr(), signs.as_ptr(), 40),
+        load4::<F>(block.as_ptr(), signs.as_ptr(), 44),
+        load4::<F>(block.as_ptr(), signs.as_ptr(), 48),
+        load4::<F>(block.as_ptr(), signs.as_ptr(), 52),
+        load4::<F>(block.as_ptr(), signs.as_ptr(), 56),
+        load4::<F>(block.as_ptr(), signs.as_ptr(), 60),
+    ];
+
+    // Perform butterfly rotation steps across 2 registers (8 values) for strides 1 and 2.
+    fn butterfly2(a: float32x4_t, b: float32x4_t) -> (float32x4_t, float32x4_t) {
+        unsafe {
+            // 32 bit unzip to arranage as [0246] [1357], perform butterfly step, then rezip.
+            let x1 = vuzp1q_f32(a, b);
+            let y1 = vuzp2q_f32(a, b);
+            let (x, y) = (vaddq_f32(x1, y1), vsubq_f32(x1, y1));
+            let a1 = vzip1q_f32(x, y);
+            let b1 = vzip2q_f32(x, y);
+
+            // 64 bit unzip to arrange [0145] [2367], perform butterfly step, then rezip.
+            let x2 = vreinterpretq_f32_f64(vuzp1q_f64(
+                vreinterpretq_f64_f32(a1),
+                vreinterpretq_f64_f32(b1),
+            ));
+            let y2 = vreinterpretq_f32_f64(vuzp2q_f64(
+                vreinterpretq_f64_f32(a1),
+                vreinterpretq_f64_f32(b1),
+            ));
+            let (x, y) = (vaddq_f32(x2, y2), vsubq_f32(x2, y2));
+            (
+                vreinterpretq_f32_f64(vzip1q_f64(
+                    vreinterpretq_f64_f32(x),
+                    vreinterpretq_f64_f32(y),
+                )),
+                vreinterpretq_f32_f64(vzip2q_f64(
+                    vreinterpretq_f64_f32(x),
+                    vreinterpretq_f64_f32(y),
+                )),
+            )
+        }
+    }
+
+    (r[0], r[1]) = butterfly2(r[0], r[1]);
+    (r[2], r[3]) = butterfly2(r[2], r[3]);
+    (r[4], r[5]) = butterfly2(r[4], r[5]);
+    (r[6], r[7]) = butterfly2(r[6], r[7]);
+    (r[8], r[9]) = butterfly2(r[8], r[9]);
+    (r[10], r[11]) = butterfly2(r[10], r[11]);
+    (r[12], r[13]) = butterfly2(r[12], r[13]);
+    (r[14], r[15]) = butterfly2(r[14], r[15]);
+
+    let mut h = 1;
+    while h < 16 {
+        for i in (0..16).step_by(h * 2) {
+            for j in 0..h {
+                let x = r[i + j];
+                let y = r[i + j + h];
+                r[i + j] = unsafe { vaddq_f32(x, y) };
+                r[i + j + h] = unsafe { vsubq_f32(x, y) };
+            }
+        }
+        h *= 2;
+    }
+
+    for (i, r) in r.into_iter().enumerate() {
+        unsafe { vst1q_f32(block.as_mut_ptr().add(i * 4), r) };
+    }
+}

--- a/vectors/src/rotate/scalar.rs
+++ b/vectors/src/rotate/scalar.rs
@@ -1,12 +1,4 @@
-/// Walsh-Hadamard Transform vector `v` with `signs` random sign flips.
-///
-/// `signs` are expected to contain 0 or 1 << 31 and will be XORed against floating point values to
-/// flip the sign.
-///
-/// `F` is true if this is a forward transform and false if this is a backward transform.
-/// This determines whether the signs are applied before or after the butterfly transforms.
-///
-/// *Panics* if `v.len()` is not a power of two, or if `v.len() != signs.len()`
+#[inline]
 pub fn walsh_hadamard_transform<const F: bool>(v: &mut [f32], signs: &[u32]) {
     assert!(
         v.len().is_power_of_two(),

--- a/vectors/src/rotate/scalar.rs
+++ b/vectors/src/rotate/scalar.rs
@@ -1,0 +1,101 @@
+/// Walsh-Hadamard Transform vector `v` with `signs` random sign flips.
+///
+/// `signs` are expected to contain 0 or 1 << 31 and will be XORed against floating point values to
+/// flip the sign.
+///
+/// `F` is true if this is a forward transform and false if this is a backward transform.
+/// This determines whether the signs are applied before or after the butterfly transforms.
+///
+/// *Panics* if `v.len()` is not a power of two, or if `v.len() != signs.len()`
+pub fn walsh_hadamard_transform<const F: bool>(v: &mut [f32], signs: &[u32]) {
+    assert!(
+        v.len().is_power_of_two(),
+        "Hadamard transform requires power of 2 length"
+    );
+    assert_eq!(v.len(), signs.len());
+    if v.len() < 64 {
+        if F {
+            // Forward must sign flip first.
+            for (&s, v) in signs.iter().zip(v.iter_mut()) {
+                *v = f32::from_bits(v.to_bits() ^ s);
+            }
+        }
+        wht_block::<1>(v)
+    } else {
+        // Perform the early strides of the block transformation together in 64 dimension chunks
+        // in an effort to improve locality. v.len() is a power of 2 and there are at least 64
+        // entries, so there will be no tail entries.
+        let blocks = v.as_chunks_mut::<64>().0;
+        let sblocks = signs.as_chunks::<64>().0;
+        if F {
+            for (b, s) in blocks.iter_mut().zip(sblocks.iter()) {
+                wht_fixed_block::<true, 64>(b, s);
+            }
+        } else {
+            for (b, s) in blocks.iter_mut().zip(sblocks.iter()) {
+                wht_fixed_block::<false, 64>(b, s);
+            }
+        }
+        // Continue butterfly transformation at block size and beyond.
+        wht_block::<64>(v);
+    }
+
+    // Normalize by 1/sqrt(n) to preserve distances and inner products.
+    // For backwards transformation invert the sign flip here too.
+    let scale = 1.0 / (v.len() as f32).sqrt();
+    if F {
+        for x in v.iter_mut() {
+            *x *= scale;
+        }
+    } else {
+        for (&s, x) in signs.iter().zip(v.iter_mut()) {
+            *x *= f32::from_bits(scale.to_bits() ^ s);
+        }
+    }
+}
+
+#[inline]
+fn wht_block<const S: usize>(block: &mut [f32]) {
+    let n = block.len();
+    assert!(
+        n.is_power_of_two(),
+        "Hadamard transform requires power of 2 length"
+    );
+    let mut h = S;
+    while h < n {
+        for i in (0..n).step_by(h * 2) {
+            for j in 0..h {
+                let x = block[i + j];
+                let y = block[i + j + h];
+                block[i + j] = x + y;
+                block[i + j + h] = x - y;
+            }
+        }
+        h *= 2;
+    }
+}
+
+/// Initial base Walsh-Hadamard Transform over a fixed size block.
+///
+/// This includes the sign flips that are needed before the operation begins if `F` is true.
+#[inline]
+fn wht_fixed_block<const F: bool, const N: usize>(block: &mut [f32; N], signs: &[u32; N]) {
+    if F {
+        for (&s, v) in signs.iter().zip(block.iter_mut()) {
+            *v = f32::from_bits(v.to_bits() ^ s);
+        }
+    }
+
+    let mut h = 1;
+    while h < N {
+        for i in (0..N).step_by(h * 2) {
+            for j in 0..h {
+                let x = block[i + j];
+                let y = block[i + j + h];
+                block[i + j] = x + y;
+                block[i + j + h] = x - y;
+            }
+        }
+        h *= 2;
+    }
+}

--- a/vectors/src/rotate/x86_64.rs
+++ b/vectors/src/rotate/x86_64.rs
@@ -1,7 +1,9 @@
 use std::arch::x86_64::{
-    __m512, __m512i, __mmask16, _mm512_add_ps, _mm512_castps_si512, _mm512_castsi512_ps,
-    _mm512_loadu_ps, _mm512_loadu_si512, _mm512_mask_sub_ps, _mm512_mul_ps, _mm512_permutexvar_ps,
-    _mm512_set1_ps, _mm512_set_epi32, _mm512_storeu_ps, _mm512_sub_ps, _mm512_xor_si512,
+    __m256, __m512, __m512i, __mmask16, _mm256_add_ps, _mm256_loadu_ps, _mm256_mul_ps,
+    _mm256_permute2f128_ps, _mm256_permute_ps, _mm256_set1_ps, _mm256_storeu_ps, _mm256_sub_ps,
+    _mm256_xor_ps, _mm512_add_ps, _mm512_castps_si512, _mm512_castsi512_ps, _mm512_loadu_ps,
+    _mm512_loadu_si512, _mm512_mask_sub_ps, _mm512_mul_ps, _mm512_permutexvar_ps, _mm512_set1_ps,
+    _mm512_set_epi32, _mm512_storeu_ps, _mm512_sub_ps, _mm512_xor_si512,
 };
 
 /// Walsh-Hadamard Transform vector `v` with `signs` random sign flips, using AVX-512F.
@@ -187,6 +189,196 @@ unsafe fn butterfly_lanes(x: __m512, idx: __m512i, mask: __mmask16) -> __m512 {
     let swapped = _mm512_permutexvar_ps(idx, x);
     let sum = _mm512_add_ps(x, swapped);
     _mm512_mask_sub_ps(sum, mask, swapped, x)
+}
+
+/// Walsh-Hadamard Transform vector `v` with `signs` random sign flips, using 256 bit AVX
+/// registers. Intended for hosts without AVX-512.
+///
+/// # Safety
+///
+/// The `avx` CPU feature must be available, e.g. verified with `is_x86_feature_detected!("avx")`
+/// before calling this function.
+#[target_feature(enable = "avx")]
+pub unsafe fn avx_walsh_hadamard_transform<const F: bool>(v: &mut [f32], signs: &[u32]) {
+    assert!(
+        v.len().is_power_of_two(),
+        "Hadamard transform requires power of 2 length"
+    );
+    assert_eq!(v.len(), signs.len());
+    if v.len() < 64 {
+        return super::scalar::walsh_hadamard_transform::<F>(v, signs);
+    }
+
+    // Perform the early strides of the block transformation together in 64 dimension chunks
+    // in an effort to improve locality. v.len() is a power of 2 and there are at least 64
+    // entries, so there will be no tail entries.
+    let blocks = v.as_chunks_mut::<64>().0;
+    let sblocks = signs.as_chunks::<64>().0;
+    if F {
+        for (b, s) in blocks.iter_mut().zip(sblocks.iter()) {
+            unsafe { avx_wht_fixed_block64::<true>(b, s) };
+        }
+    } else {
+        for (b, s) in blocks.iter_mut().zip(sblocks.iter()) {
+            unsafe { avx_wht_fixed_block64::<false>(b, s) };
+        }
+    }
+    // Continue butterfly transformation at block size and beyond.
+    unsafe { avx_wht_block_from64::<F>(v, signs) };
+}
+
+/// Continue the butterfly transformation for strides 64 and beyond, fusing the final stride
+/// with normalization (and the backward sign flip) so the whole block is only touched once
+/// more after `avx_wht_fixed_block64`.
+#[target_feature(enable = "avx")]
+unsafe fn avx_wht_block_from64<const F: bool>(block: &mut [f32], signs: &[u32]) {
+    unsafe {
+        let n = block.len();
+        assert!(
+            n.is_power_of_two(),
+            "Hadamard transform requires power of 2 length"
+        );
+        let scale = 1.0 / (n as f32).sqrt();
+        let scalev = _mm256_set1_ps(scale);
+
+        if n == 64 {
+            // The base 64-wide transform already completed every stride; there is no further
+            // butterfly stage to fuse the normalization into, so just scale (and sign-flip for
+            // backward) in place.
+            for i in (0..n).step_by(8) {
+                let x = _mm256_loadu_ps(block.as_ptr().add(i));
+                let mut v = _mm256_mul_ps(x, scalev);
+                if !F {
+                    v = _mm256_xor_ps(v, _mm256_loadu_ps(signs.as_ptr().add(i) as *const f32));
+                }
+                _mm256_storeu_ps(block.as_mut_ptr().add(i), v);
+            }
+            return;
+        }
+
+        let mut h = 64;
+        while h < n / 2 {
+            for i in (0..n).step_by(h * 2) {
+                for j in (0..h).step_by(8) {
+                    let x_off = i + j;
+                    let y_off = i + j + h;
+                    let x = _mm256_loadu_ps(block.as_ptr().add(x_off));
+                    let y = _mm256_loadu_ps(block.as_ptr().add(y_off));
+                    _mm256_storeu_ps(block.as_mut_ptr().add(x_off), _mm256_add_ps(x, y));
+                    _mm256_storeu_ps(block.as_mut_ptr().add(y_off), _mm256_sub_ps(x, y));
+                }
+            }
+            h *= 2;
+        }
+
+        for i in (0..n).step_by(h * 2) {
+            for j in (0..h).step_by(8) {
+                let x_off = i + j;
+                let y_off = i + j + h;
+                let x = _mm256_loadu_ps(block.as_ptr().add(x_off));
+                let y = _mm256_loadu_ps(block.as_ptr().add(y_off));
+
+                let mut a = _mm256_mul_ps(_mm256_add_ps(x, y), scalev);
+                let mut b = _mm256_mul_ps(_mm256_sub_ps(x, y), scalev);
+
+                if !F {
+                    a = _mm256_xor_ps(a, _mm256_loadu_ps(signs.as_ptr().add(x_off) as *const f32));
+                    b = _mm256_xor_ps(b, _mm256_loadu_ps(signs.as_ptr().add(y_off) as *const f32));
+                }
+
+                _mm256_storeu_ps(block.as_mut_ptr().add(x_off), a);
+                _mm256_storeu_ps(block.as_mut_ptr().add(y_off), b);
+            }
+        }
+    }
+}
+
+/// Initial base Walsh-Hadamard Transform over a fixed size block of 64 dimensions, held in 8
+/// AVX registers.
+///
+/// This includes the sign flips that are needed before the operation begins if `F` is true.
+#[target_feature(enable = "avx")]
+unsafe fn avx_wht_fixed_block64<const F: bool>(block: &mut [f32; 64], signs: &[u32; 64]) {
+    unsafe {
+        let mut r = [
+            avx_load8::<F>(block.as_ptr(), signs.as_ptr(), 0),
+            avx_load8::<F>(block.as_ptr(), signs.as_ptr(), 8),
+            avx_load8::<F>(block.as_ptr(), signs.as_ptr(), 16),
+            avx_load8::<F>(block.as_ptr(), signs.as_ptr(), 24),
+            avx_load8::<F>(block.as_ptr(), signs.as_ptr(), 32),
+            avx_load8::<F>(block.as_ptr(), signs.as_ptr(), 40),
+            avx_load8::<F>(block.as_ptr(), signs.as_ptr(), 48),
+            avx_load8::<F>(block.as_ptr(), signs.as_ptr(), 56),
+        ];
+
+        // Strides 1, 2, and 4 are butterflies within each register's 8 lanes.
+        for x in r.iter_mut() {
+            *x = avx_butterfly8(*x);
+        }
+
+        // Strides 8, 16, and 32 are butterflies across registers.
+        let mut h = 1;
+        while h < 8 {
+            for i in (0..8).step_by(h * 2) {
+                for j in 0..h {
+                    let x = r[i + j];
+                    let y = r[i + j + h];
+                    r[i + j] = _mm256_add_ps(x, y);
+                    r[i + j + h] = _mm256_sub_ps(x, y);
+                }
+            }
+            h *= 2;
+        }
+
+        for (i, x) in r.into_iter().enumerate() {
+            _mm256_storeu_ps(block.as_mut_ptr().add(i * 8), x);
+        }
+    }
+}
+
+/// Load 8 entries at a time, optionally flipping signs if F is true.
+#[target_feature(enable = "avx")]
+unsafe fn avx_load8<const F: bool>(b: *const f32, s: *const u32, off: usize) -> __m256 {
+    unsafe {
+        let r = _mm256_loadu_ps(b.add(off));
+        if F {
+            _mm256_xor_ps(r, _mm256_loadu_ps(s.add(off) as *const f32))
+        } else {
+            r
+        }
+    }
+}
+
+/// Butterfly rotation across all 8 lanes of a register for strides 1, 2, and 4.
+#[target_feature(enable = "avx")]
+unsafe fn avx_butterfly8(x: __m256) -> __m256 {
+    // Stride 1 and 2 swap lanes within each 128 bit half; stride 4 swaps the halves.
+    let x = _mm256_add_ps(_mm256_permute_ps::<0b10_11_00_01>(x), _mm256_xor_ps(x, NEG1));
+    let x = _mm256_add_ps(_mm256_permute_ps::<0b01_00_11_10>(x), _mm256_xor_ps(x, NEG2));
+    _mm256_add_ps(_mm256_permute2f128_ps::<0x01>(x, x), _mm256_xor_ps(x, NEG4))
+}
+
+/// Lane sign masks for the butterfly stages: lane `i` holds `-0.0` when bit `h` of `i` is set,
+/// so `xor`ing negates exactly the lanes that must be subtracted rather than added.
+///
+/// One stage computes `permute_h(x) + xor(x, NEG_h)`: a lane with bit `h` clear (index `i`)
+/// receives `x[i] + x[i ^ h]` and a lane with bit `h` set receives `x[i ^ h] - x[i]`, matching
+/// the scalar `block[i] = x + y; block[i + h] = x - y` butterfly.
+const NEG1: __m256 = neg_mask(1);
+const NEG2: __m256 = neg_mask(2);
+const NEG4: __m256 = neg_mask(4);
+
+const fn neg_mask(h: usize) -> __m256 {
+    let mut m = [0f32; 8];
+    let mut i = 0;
+    while i < 8 {
+        if i & h != 0 {
+            m[i] = -0.0;
+        }
+        i += 1;
+    }
+    // Safety: `__m256` is 8 contiguous `f32` lanes with lane 0 lowest, like `[f32; 8]`.
+    unsafe { std::mem::transmute(m) }
 }
 
 const MASK1: __mmask16 = lane_mask(1);

--- a/vectors/src/rotate/x86_64.rs
+++ b/vectors/src/rotate/x86_64.rs
@@ -1,0 +1,209 @@
+use std::arch::x86_64::{
+    __m512, __m512i, __mmask16, _mm512_add_ps, _mm512_castps_si512, _mm512_castsi512_ps,
+    _mm512_loadu_ps, _mm512_loadu_si512, _mm512_mask_sub_ps, _mm512_mul_ps, _mm512_permutexvar_ps,
+    _mm512_set1_ps, _mm512_set_epi32, _mm512_storeu_ps, _mm512_sub_ps, _mm512_xor_si512,
+};
+
+/// Walsh-Hadamard Transform vector `v` with `signs` random sign flips, using AVX-512F.
+///
+/// # Safety
+///
+/// The `avx512f` CPU feature must be available, e.g. verified with
+/// `is_x86_feature_detected!("avx512f")` before calling this function.
+#[target_feature(enable = "avx512f")]
+pub unsafe fn avx512_walsh_hadamard_transform<const F: bool>(v: &mut [f32], signs: &[u32]) {
+    assert!(
+        v.len().is_power_of_two(),
+        "Hadamard transform requires power of 2 length"
+    );
+    assert_eq!(v.len(), signs.len());
+    if v.len() < 64 {
+        return super::scalar::walsh_hadamard_transform::<F>(v, signs);
+    }
+
+    // Perform the early strides of the block transformation together in 64 dimension chunks
+    // in an effort to improve locality. v.len() is a power of 2 and there are at least 64
+    // entries, so there will be no tail entries.
+    let blocks = v.as_chunks_mut::<64>().0;
+    let sblocks = signs.as_chunks::<64>().0;
+    if F {
+        for (b, s) in blocks.iter_mut().zip(sblocks.iter()) {
+            unsafe { wht_fixed_block64::<true>(b, s) };
+        }
+    } else {
+        for (b, s) in blocks.iter_mut().zip(sblocks.iter()) {
+            unsafe { wht_fixed_block64::<false>(b, s) };
+        }
+    }
+    // Continue butterfly transformation at block size and beyond.
+    unsafe { wht_block_from64::<F>(v, signs) };
+}
+
+/// Continue the butterfly transformation for strides 64 and beyond, fusing the final stride
+/// with normalization (and the backward sign flip) so the whole block is only touched once
+/// more after `wht_fixed_block64`.
+#[target_feature(enable = "avx512f")]
+unsafe fn wht_block_from64<const F: bool>(block: &mut [f32], signs: &[u32]) {
+    unsafe {
+        let n = block.len();
+        assert!(
+            n.is_power_of_two(),
+            "Hadamard transform requires power of 2 length"
+        );
+        let scale = 1.0 / (n as f32).sqrt();
+        let scalev = _mm512_set1_ps(scale);
+
+        if n == 64 {
+            // The base 64-wide transform already completed every stride; there is no further
+            // butterfly stage to fuse the normalization into, so just scale (and sign-flip for
+            // backward) in place.
+            for i in (0..n).step_by(16) {
+                let x = _mm512_loadu_ps(block.as_ptr().add(i));
+                let mut v = _mm512_mul_ps(x, scalev);
+                if !F {
+                    let s = _mm512_loadu_si512(signs.as_ptr().add(i) as *const __m512i);
+                    v = _mm512_castsi512_ps(_mm512_xor_si512(_mm512_castps_si512(v), s));
+                }
+                _mm512_storeu_ps(block.as_mut_ptr().add(i), v);
+            }
+            return;
+        }
+
+        let mut h = 64;
+        while h < n / 2 {
+            for i in (0..n).step_by(h * 2) {
+                for j in (0..h).step_by(16) {
+                    let x_off = i + j;
+                    let y_off = i + j + h;
+                    let x = _mm512_loadu_ps(block.as_ptr().add(x_off));
+                    let y = _mm512_loadu_ps(block.as_ptr().add(y_off));
+                    _mm512_storeu_ps(block.as_mut_ptr().add(x_off), _mm512_add_ps(x, y));
+                    _mm512_storeu_ps(block.as_mut_ptr().add(y_off), _mm512_sub_ps(x, y));
+                }
+            }
+            h *= 2;
+        }
+
+        for i in (0..n).step_by(h * 2) {
+            for j in (0..h).step_by(16) {
+                let x_off = i + j;
+                let y_off = i + j + h;
+                let x = _mm512_loadu_ps(block.as_ptr().add(x_off));
+                let y = _mm512_loadu_ps(block.as_ptr().add(y_off));
+
+                let mut a = _mm512_mul_ps(_mm512_add_ps(x, y), scalev);
+                let mut b = _mm512_mul_ps(_mm512_sub_ps(x, y), scalev);
+
+                if !F {
+                    let sx = _mm512_loadu_si512(signs.as_ptr().add(x_off) as *const __m512i);
+                    let sy = _mm512_loadu_si512(signs.as_ptr().add(y_off) as *const __m512i);
+                    a = _mm512_castsi512_ps(_mm512_xor_si512(_mm512_castps_si512(a), sx));
+                    b = _mm512_castsi512_ps(_mm512_xor_si512(_mm512_castps_si512(b), sy));
+                }
+
+                _mm512_storeu_ps(block.as_mut_ptr().add(x_off), a);
+                _mm512_storeu_ps(block.as_mut_ptr().add(y_off), b);
+            }
+        }
+    }
+}
+
+/// Initial base Walsh-Hadamard Transform over a fixed size block.
+///
+/// This includes the sign flips that are needed before the operation begins if `F` is true.
+#[target_feature(enable = "avx512f")]
+unsafe fn wht_fixed_block64<const F: bool>(block: &mut [f32; 64], signs: &[u32; 64]) {
+    unsafe {
+        // Lane-swap index vectors for the intra-register butterfly stages (h = 1, 2, 4, 8):
+        // idx_h reads lane `i ^ h` of the register.
+        let idx1 = _mm512_set_epi32(14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1);
+        let idx2 = _mm512_set_epi32(13, 12, 15, 14, 9, 8, 11, 10, 5, 4, 7, 6, 1, 0, 3, 2);
+        let idx4 = _mm512_set_epi32(11, 10, 9, 8, 15, 14, 13, 12, 3, 2, 1, 0, 7, 6, 5, 4);
+        let idx8 = _mm512_set_epi32(7, 6, 5, 4, 3, 2, 1, 0, 15, 14, 13, 12, 11, 10, 9, 8);
+
+        let mut r0 = load16::<F>(block.as_ptr(), signs.as_ptr(), 0);
+        let mut r1 = load16::<F>(block.as_ptr(), signs.as_ptr(), 16);
+        let mut r2 = load16::<F>(block.as_ptr(), signs.as_ptr(), 32);
+        let mut r3 = load16::<F>(block.as_ptr(), signs.as_ptr(), 48);
+
+        // Perform butterfly rotation steps within each register for strides 1, 2, 4, and 8.
+        r0 = butterfly16(r0, idx1, idx2, idx4, idx8);
+        r1 = butterfly16(r1, idx1, idx2, idx4, idx8);
+        r2 = butterfly16(r2, idx1, idx2, idx4, idx8);
+        r3 = butterfly16(r3, idx1, idx2, idx4, idx8);
+
+        // Stride 16: butterfly across register pairs (r0, r1) and (r2, r3).
+        let (n0, n1) = (_mm512_add_ps(r0, r1), _mm512_sub_ps(r0, r1));
+        let (n2, n3) = (_mm512_add_ps(r2, r3), _mm512_sub_ps(r2, r3));
+
+        // Stride 32: butterfly across register pairs (n0, n2) and (n1, n3).
+        let (f0, f2) = (_mm512_add_ps(n0, n2), _mm512_sub_ps(n0, n2));
+        let (f1, f3) = (_mm512_add_ps(n1, n3), _mm512_sub_ps(n1, n3));
+
+        _mm512_storeu_ps(block.as_mut_ptr(), f0);
+        _mm512_storeu_ps(block.as_mut_ptr().add(16), f1);
+        _mm512_storeu_ps(block.as_mut_ptr().add(32), f2);
+        _mm512_storeu_ps(block.as_mut_ptr().add(48), f3);
+    }
+}
+
+/// Load 16 entries at a time, optionally flipping signs if F is true.
+#[target_feature(enable = "avx512f")]
+unsafe fn load16<const F: bool>(b: *const f32, s: *const u32, off: usize) -> __m512 {
+    unsafe {
+        let r = _mm512_loadu_ps(b.add(off));
+        if F {
+            let sv = _mm512_loadu_si512(s.add(off) as *const __m512i);
+            _mm512_castsi512_ps(_mm512_xor_si512(_mm512_castps_si512(r), sv))
+        } else {
+            r
+        }
+    }
+}
+
+/// Butterfly rotation across all 16 lanes of a register for strides 1, 2, 4, and 8.
+#[target_feature(enable = "avx512f")]
+unsafe fn butterfly16(
+    x: __m512,
+    idx1: __m512i,
+    idx2: __m512i,
+    idx4: __m512i,
+    idx8: __m512i,
+) -> __m512 {
+    unsafe {
+        let x = butterfly_lanes(x, idx1, MASK1);
+        let x = butterfly_lanes(x, idx2, MASK2);
+        let x = butterfly_lanes(x, idx4, MASK4);
+        butterfly_lanes(x, idx8, MASK8)
+    }
+}
+
+/// One lane-stride butterfly stage: swap each lane `i` with lane `i ^ h` (via `idx`), then
+/// combine so that lanes with bit `h` clear get `x + swapped` and lanes with bit `h` set get
+/// `swapped - x` (`mask` selects the latter, matching the scalar `block[i] = x - y` half of the
+/// butterfly).
+#[target_feature(enable = "avx512f")]
+unsafe fn butterfly_lanes(x: __m512, idx: __m512i, mask: __mmask16) -> __m512 {
+    let swapped = _mm512_permutexvar_ps(idx, x);
+    let sum = _mm512_add_ps(x, swapped);
+    _mm512_mask_sub_ps(sum, mask, swapped, x)
+}
+
+const MASK1: __mmask16 = lane_mask(1);
+const MASK2: __mmask16 = lane_mask(2);
+const MASK4: __mmask16 = lane_mask(4);
+const MASK8: __mmask16 = lane_mask(8);
+
+/// Mask with bit `i` set wherever lane index `i` has bit `h` set, i.e. the "second half" of
+/// each swapped pair for stride `h`.
+const fn lane_mask(h: usize) -> __mmask16 {
+    let mut m: u16 = 0;
+    let mut i = 0;
+    while i < 16 {
+        if i & h != 0 {
+            m |= 1 << i;
+        }
+        i += 1;
+    }
+    m
+}


### PR DESCRIPTION
Vector rotation uses fast Walsh-Hadamard Transforms to produce Gaussian distribution vectors that maintain existing angular and euclidean distance relationships. The result vectors are more predictable statistically.

The current implementation is entirely scalar and quite slow. Speed things up:
* The random shuffle of vector dimensions is not necessary for power-of-two dimensionalities because we get shuffle like behavior with Hadamard transformations.
* Fuse sign flips and scaling where it is possible and substantially more efficient.
* The scalar implementation works in 64 dimensional blocks first to help maintain locality.
* Provide Neon, AVX, and AVX-512 kernels for rotation. The compiler does well for strides 1 and 2, but at 4+ struggles to auto vectorize the code.

Performance is up to 20x better for power-of-two cases with the accelerated kernels. Non-power-of-two cases with 2 ranges are nearly 10x better. The x86 implementation is generally faster because it's performing a bunch of straight line vector arithmetic where greater widths really help. The AVX implementation is nearly as fast as AVX-512, likely because it's working on the same block size and the compiler can unroll a lot of the loops as a result.

Kernels are exported rather than hidden for testing and benchmarking purposes -- we compare the output of all available kernels during testing, and benchmarks run with each available kernel as well.

x86_64 (AMD Ryzen something):
```
rotate/forward/512      time:   [116.93 ns 117.02 ns 117.10 ns]
                        change: [−93.710% −93.704% −93.697%] (p = 0.00 < 0.05)
rotate/backward/512     time:   [110.52 ns 110.57 ns 110.62 ns]
                        change: [−94.096% −94.089% −94.082%] (p = 0.00 < 0.05)
rotate/forward/768      time:   [320.90 ns 321.12 ns 321.33 ns]
                        change: [−88.620% −88.577% −88.550%] (p = 0.00 < 0.05)
rotate/backward/768     time:   [361.55 ns 361.89 ns 362.21 ns]
                        change: [−87.133% −87.087% −87.027%] (p = 0.00 < 0.05)
rotate/forward/1024     time:   [210.39 ns 210.55 ns 210.73 ns]
                        change: [−94.336% −94.329% −94.323%] (p = 0.00 < 0.05)
rotate/backward/1024    time:   [216.10 ns 216.43 ns 216.74 ns]
                        change: [−94.156% −94.148% −94.140%] (p = 0.00 < 0.05)
rotate/forward/1536     time:   [594.36 ns 594.58 ns 594.79 ns]
                        change: [−89.315% −89.305% −89.292%] (p = 0.00 < 0.05)
rotate/backward/1536    time:   [612.01 ns 612.07 ns 612.12 ns]
                        change: [−89.111% −89.104% −89.098%] (p = 0.00 < 0.05)
rotate/forward/2048     time:   [412.59 ns 413.01 ns 413.45 ns]
                        change: [−94.500% −94.494% −94.488%] (p = 0.00 < 0.05)
rotate/backward/2048    time:   [423.43 ns 423.78 ns 424.11 ns]
                        change: [−94.348% −94.341% −94.335%] (p = 0.00 < 0.05)
```

aarch64 (M4):
```
rotate/forward/512      time:   [171.33 ns 171.48 ns 171.63 ns]
                        change: [−88.148% −88.095% −88.050%] (p = 0.00 < 0.05)
rotate/backward/512     time:   [174.30 ns 174.36 ns 174.43 ns]
                        change: [−88.773% −88.686% −88.600%] (p = 0.00 < 0.05)
rotate/forward/768      time:   [437.66 ns 437.73 ns 437.81 ns]
                        change: [−80.100% −79.802% −79.600%] (p = 0.00 < 0.05)
rotate/backward/768     time:   [509.18 ns 509.69 ns 510.16 ns]
                        change: [−76.651% −76.583% −76.523%] (p = 0.00 < 0.05)
rotate/forward/1024     time:   [365.17 ns 365.43 ns 365.73 ns]
                        change: [−87.588% −87.424% −87.286%] (p = 0.00 < 0.05)
rotate/backward/1024    time:   [378.09 ns 378.96 ns 380.37 ns]
                        change: [−86.955% −86.829% −86.670%] (p = 0.00 < 0.05)
rotate/forward/1536     time:   [906.67 ns 906.87 ns 907.09 ns]
                        change: [−78.933% −78.825% −78.720%] (p = 0.00 < 0.05)
rotate/backward/1536    time:   [1.0303 µs 1.0387 µs 1.0528 µs]
                        change: [−76.107% −75.986% −75.842%] (p = 0.00 < 0.05)
rotate/forward/2048     time:   [785.68 ns 788.84 ns 793.82 ns]
                        change: [−86.048% −86.006% −85.963%] (p = 0.00 < 0.05)
rotate/backward/2048    time:   [808.23 ns 809.16 ns 810.05 ns]
                        change: [−86.030% −85.920% −85.836%] (p = 0.00 < 0.05)
```