### PR TITLE
Extend f16 support to work more like f32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ cmake = "0.1.51"
 criterion = "0.8.1"
 crossbeam-skiplist = "0.1.3"
 crossbeam-utils = "0.8.21"
-half = "2.7.1"
+half = { version = "2.7.1", features = ["bytemuck"] }
 histogram = "0.11.3"
 indicatif = "0.17.8"
 leb128 = "0.2.5"

--- a/et/src/compute_neighbors/cpu.rs
+++ b/et/src/compute_neighbors/cpu.rs
@@ -26,7 +26,7 @@ pub fn run(args: &ComputeNeighborsArgs) -> io::Result<()> {
         .unwrap_or(doc_vectors.len())
         .min(doc_vectors.len());
 
-    let distance_fn = args.similarity.new_distance_function();
+    let distance_fn = args.similarity.distance_f32();
     let k = args.neighbors_len.get();
     let mut results = Vec::with_capacity(query_limit);
     results.resize_with(query_limit, || TopNeighbors::new(args.neighbors_len.get()));

--- a/et/src/quantization/recall.rs
+++ b/et/src/quantization/recall.rs
@@ -204,7 +204,7 @@ fn select_center_for_doc(
         if centers.len() == 1 {
             0
         } else {
-            let dist = similarity.new_distance_function();
+            let dist = similarity.distance_f32();
             centers
                 .iter()
                 .enumerate()

--- a/src/kmeans.rs
+++ b/src/kmeans.rs
@@ -7,7 +7,7 @@ use rand::seq::index;
 use rand::{distr::weighted::WeightedIndex, prelude::*};
 use rayon::prelude::*;
 use tracing::warn;
-use vectors::{EuclideanDistance, F32VectorDistance};
+use vectors::{F32VectorDistance, float32::EuclideanDistance};
 
 use crate::input::{SubsetViewVectorStore, VecVectorStore, VectorStore};
 
@@ -155,7 +155,7 @@ mod bp {
 
     use rand::{distr::weighted::WeightedIndex, prelude::*};
     use rayon::prelude::*;
-    use vectors::{EuclideanDistance, F32VectorDistance};
+    use vectors::{F32VectorDistance, float32::EuclideanDistance};
 
     use crate::input::{VecVectorStore, VectorStore};
 

--- a/src/vamana/search.rs
+++ b/src/vamana/search.rs
@@ -784,7 +784,7 @@ mod test {
         let dim_values = [-0.25, -0.125, 0.125, 0.25];
         TestGraphVectorIndex::new(
             NonZero::new(max_edges).unwrap(),
-            VectorSimilarity::Dot.new_distance_function(),
+            VectorSimilarity::Dot.distance_f32(),
             (0..256).map(|v| {
                 Vec::from([
                     dim_values[v & 0x3],
@@ -803,7 +803,7 @@ mod test {
         let dim_values = [-0.25, -0.125, 0.125, 0.25];
         TestGraphVectorIndex::new_with_centroid(
             NonZero::new(max_edges).unwrap(),
-            VectorSimilarity::Dot.new_distance_function(),
+            VectorSimilarity::Dot.distance_f32(),
             (0..256).map(|v| {
                 Vec::from([
                     dim_values[v & 0x3],

--- a/vectors/src/float16.rs
+++ b/vectors/src/float16.rs
@@ -67,7 +67,7 @@ impl VectorCoder {
 impl F32VectorCoder for VectorCoder {
     fn encode_to(&self, vector: &[f32], out: &mut [u8]) {
         let scale = if self.0.l2_normalize() {
-            Some(1.0 / super::l2_norm(vector))
+            Some(1.0 / crate::float32::l2_norm(vector))
         } else {
             None
         };

--- a/vectors/src/float16.rs
+++ b/vectors/src/float16.rs
@@ -1,5 +1,6 @@
 #[cfg(target_arch = "aarch64")]
 mod aarch64;
+mod scalar;
 #[cfg(target_arch = "x86_64")]
 mod x86_64;
 
@@ -52,27 +53,9 @@ impl VectorCoder {
         Self(similarity, Kernel::default())
     }
 
-    fn convert_and_encode_scalar(
-        &self,
-        vector: impl ExactSizeIterator<Item = f32> + Clone,
-        out: &mut [u8],
-    ) {
-        let encode_it = vector.zip(out.chunks_mut(2));
-        for (d, o) in encode_it {
-            o.copy_from_slice(&f16::from_f32(d).to_le_bytes());
-        }
-    }
-
     fn convert_and_encode(&self, vector: &[f32], scale: Option<f32>, out: &mut [u8]) {
         match self.1 {
-            Kernel::Scalar => {
-                let vector_it = vector.iter().copied();
-                if let Some(scale) = scale {
-                    self.convert_and_encode_scalar(vector_it.map(|d| d * scale), out)
-                } else {
-                    self.convert_and_encode_scalar(vector_it, out)
-                }
-            }
+            Kernel::Scalar => scalar::serialize_f16(vector, scale, out),
             #[cfg(target_arch = "aarch64")]
             Kernel::Neon => unsafe { aarch64::serialize_f16(vector, scale, out) },
             #[cfg(target_arch = "x86_64")]
@@ -97,11 +80,7 @@ impl F32VectorCoder for VectorCoder {
 
     fn decode_to(&self, encoded: &[u8], out: &mut [f32]) {
         match self.1 {
-            Kernel::Scalar => {
-                for (d, o) in unaligned_f16_iter(encoded).zip(out.iter_mut()) {
-                    *o = d.to_f32();
-                }
-            }
+            Kernel::Scalar => scalar::deserialize_f16(encoded, out),
             #[cfg(target_arch = "aarch64")]
             Kernel::Neon => unsafe { aarch64::deserialize_f16(encoded, out) },
             #[cfg(target_arch = "x86_64")]
@@ -114,22 +93,13 @@ impl F32VectorCoder for VectorCoder {
     }
 }
 
-fn unaligned_f16_iter(raw: &[u8]) -> impl ExactSizeIterator<Item = f16> + '_ {
-    let (chunks, rem) = raw.as_chunks::<{ std::mem::size_of::<f16>() }>();
-    debug_assert!(rem.is_empty());
-    chunks.iter().map(|c| f16::from_le_bytes(*c))
-}
-
 #[derive(Debug, Copy, Clone, Default)]
 pub struct DotProductDistance(Kernel);
 
 impl DotProductDistance {
     fn dot(&self, a: &[u8], b: &[u8]) -> f32 {
         match self.0 {
-            Kernel::Scalar => unaligned_f16_iter(a)
-                .zip(unaligned_f16_iter(b))
-                .map(|(a, b)| a.to_f32() * b.to_f32())
-                .sum::<f32>(),
+            Kernel::Scalar => scalar::dot_f16_f16(a, b),
             #[cfg(target_arch = "aarch64")]
             Kernel::Neon => unsafe { aarch64::dot_f16_f16(a, b) },
             #[cfg(target_arch = "x86_64")]
@@ -155,12 +125,7 @@ impl<'a> DotProductQueryDistance<'a> {
 
     fn dot(&self, v: &[u8]) -> f32 {
         match self.1 {
-            Kernel::Scalar => self
-                .0
-                .iter()
-                .zip(unaligned_f16_iter(v).map(f16::to_f32))
-                .map(|(&s, o)| s * o)
-                .sum::<f32>(),
+            Kernel::Scalar => scalar::dot_f32_f16(&self.0, v),
             #[cfg(target_arch = "aarch64")]
             Kernel::Neon => unsafe { aarch64::dot_f32_f16(&self.0, v) },
             #[cfg(target_arch = "x86_64")]
@@ -182,13 +147,7 @@ pub struct EuclideanDistance(Kernel);
 impl EuclideanDistance {
     fn l2(&self, a: &[u8], b: &[u8]) -> f32 {
         match self.0 {
-            Kernel::Scalar => unaligned_f16_iter(a)
-                .zip(unaligned_f16_iter(b))
-                .map(|(a, b)| {
-                    let diff = a.to_f32() - b.to_f32();
-                    diff * diff
-                })
-                .sum::<f32>(),
+            Kernel::Scalar => scalar::l2_f16_f16(a, b),
             #[cfg(target_arch = "aarch64")]
             Kernel::Neon => unsafe { aarch64::l2_f16_f16(a, b) },
             #[cfg(target_arch = "x86_64")]
@@ -213,15 +172,7 @@ impl<'a> EuclideanQueryDistance<'a> {
 
     fn l2(&self, v: &[u8]) -> f32 {
         match self.1 {
-            Kernel::Scalar => self
-                .0
-                .iter()
-                .zip(unaligned_f16_iter(v).map(f16::to_f32))
-                .map(|(s, o)| {
-                    let diff = *s - o;
-                    diff * diff
-                })
-                .sum::<f32>(),
+            Kernel::Scalar => scalar::l2_f32_f16(&self.0, v),
             #[cfg(target_arch = "aarch64")]
             Kernel::Neon => unsafe { aarch64::l2_f32_f16(&self.0, v) },
             #[cfg(target_arch = "x86_64")]

--- a/vectors/src/float16.rs
+++ b/vectors/src/float16.rs
@@ -4,11 +4,13 @@ mod scalar;
 #[cfg(target_arch = "x86_64")]
 mod x86_64;
 
-use std::borrow::Cow;
+use std::{borrow::Cow, sync::OnceLock};
 
 use half::f16;
 
-use crate::{F32VectorCoder, QueryVectorDistance, VectorDistance, VectorSimilarity};
+use crate::{
+    F16VectorDistance, F32VectorCoder, QueryVectorDistance, VectorDistance, VectorSimilarity,
+};
 
 #[derive(Debug, Copy, Clone)]
 enum Kernel {
@@ -93,10 +95,17 @@ impl F32VectorCoder for VectorCoder {
     }
 }
 
+static DOT_DIST: OnceLock<DotProductDistance> = OnceLock::new();
+
 #[derive(Debug, Copy, Clone, Default)]
 pub struct DotProductDistance(Kernel);
 
 impl DotProductDistance {
+    /// Returns a static instance of dot product distance.
+    pub fn get() -> &'static DotProductDistance {
+        DOT_DIST.get_or_init(DotProductDistance::default)
+    }
+
     fn dot(&self, a: &[u8], b: &[u8]) -> f32 {
         match self.0 {
             Kernel::Scalar => scalar::dot_f16_f16(a, b),
@@ -111,6 +120,13 @@ impl DotProductDistance {
 impl VectorDistance for DotProductDistance {
     fn distance(&self, query: &[u8], doc: &[u8]) -> f64 {
         let dot = self.dot(query, doc) as f64;
+        (-dot + 1.0) / 2.0
+    }
+}
+
+impl F16VectorDistance for DotProductDistance {
+    fn distance_f16(&self, a: &[f16], b: &[f16]) -> f64 {
+        let dot = self.dot(bytemuck::cast_slice(a), bytemuck::cast_slice(b)) as f64;
         (-dot + 1.0) / 2.0
     }
 }
@@ -141,10 +157,85 @@ impl QueryVectorDistance for DotProductQueryDistance<'_> {
     }
 }
 
+static COS_DIST: OnceLock<CosineDistance> = OnceLock::new();
+
+#[derive(Debug, Copy, Clone, Default)]
+pub struct CosineDistance(Kernel);
+
+impl CosineDistance {
+    /// Returns a static instance of dot product distance.
+    pub fn get() -> &'static CosineDistance {
+        COS_DIST.get_or_init(CosineDistance::default)
+    }
+
+    fn dot(&self, a: &[u8], b: &[u8]) -> f32 {
+        match self.0 {
+            Kernel::Scalar => scalar::dot_f16_f16(a, b),
+            #[cfg(target_arch = "aarch64")]
+            Kernel::Neon => unsafe { aarch64::dot_f16_f16(a, b) },
+            #[cfg(target_arch = "x86_64")]
+            Kernel::AvxF16c => unsafe { x86_64::dot_f16_f16(a, b) },
+        }
+    }
+}
+
+impl VectorDistance for CosineDistance {
+    fn distance(&self, query: &[u8], doc: &[u8]) -> f64 {
+        let qd = self.dot(query, doc) as f64;
+        let qq = self.dot(query, query) as f64;
+        let dd = self.dot(doc, doc) as f64;
+        let cos = qd / (qq * dd).sqrt();
+        (-cos + 1.0) / 2.0
+    }
+}
+
+impl F16VectorDistance for CosineDistance {
+    fn distance_f16(&self, a: &[f16], b: &[f16]) -> f64 {
+        self.distance(bytemuck::cast_slice(a), bytemuck::cast_slice(b))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CosineQueryDistance<'a>(Cow<'a, [f32]>, Kernel);
+
+impl<'a> CosineQueryDistance<'a> {
+    pub fn new(query: Cow<'a, [f32]>) -> Self {
+        Self(crate::float32::l2_normalize(query), Kernel::default())
+    }
+}
+
+impl QueryVectorDistance for CosineQueryDistance<'_> {
+    fn distance(&self, vector: &[u8]) -> f64 {
+        let ab = match self.1 {
+            Kernel::Scalar => scalar::dot_f32_f16(&self.0, vector),
+            #[cfg(target_arch = "aarch64")]
+            Kernel::Neon => unsafe { aarch64::dot_f32_f16(&self.0, vector) },
+            #[cfg(target_arch = "x86_64")]
+            Kernel::AvxF16c => unsafe { x86_64::dot_f32_f16(&self.0, vector) },
+        } as f64;
+        let bb = match self.1 {
+            Kernel::Scalar => scalar::dot_f16_f16(vector, vector),
+            #[cfg(target_arch = "aarch64")]
+            Kernel::Neon => unsafe { aarch64::dot_f16_f16(vector, vector) },
+            #[cfg(target_arch = "x86_64")]
+            Kernel::AvxF16c => unsafe { x86_64::dot_f16_f16(vector, vector) },
+        } as f64;
+        let cos = ab / bb.sqrt();
+        (-cos + 1.0) / 2.0
+    }
+}
+
+static L2_DIST: OnceLock<EuclideanDistance> = OnceLock::new();
+
 #[derive(Debug, Copy, Clone, Default)]
 pub struct EuclideanDistance(Kernel);
 
 impl EuclideanDistance {
+    /// Returns a static instance of euclidean distance.
+    pub fn get() -> &'static EuclideanDistance {
+        L2_DIST.get_or_init(EuclideanDistance::default)
+    }
+
     fn l2(&self, a: &[u8], b: &[u8]) -> f32 {
         match self.0 {
             Kernel::Scalar => scalar::l2_f16_f16(a, b),
@@ -159,6 +250,12 @@ impl EuclideanDistance {
 impl VectorDistance for EuclideanDistance {
     fn distance(&self, query: &[u8], doc: &[u8]) -> f64 {
         self.l2(query, doc) as f64
+    }
+}
+
+impl F16VectorDistance for EuclideanDistance {
+    fn distance_f16(&self, a: &[f16], b: &[f16]) -> f64 {
+        self.l2(bytemuck::cast_slice(a), bytemuck::cast_slice(b)) as f64
     }
 }
 

--- a/vectors/src/float16/scalar.rs
+++ b/vectors/src/float16/scalar.rs
@@ -1,0 +1,65 @@
+use half::f16;
+
+/// Serialize `v` to half precision floats in `out`, optionally scaling each value by `scale`.
+pub fn serialize_f16(v: &[f32], scale: Option<f32>, out: &mut [u8]) {
+    assert_eq!(out.len(), v.len() * 2);
+    for (&d, o) in v.iter().zip(out.chunks_mut(2)) {
+        let d = match scale {
+            Some(scale) => d * scale,
+            None => d,
+        };
+        o.copy_from_slice(&f16::from_f32(d).to_le_bytes());
+    }
+}
+
+/// Deserialize half precision floats in `v` to `out`.
+pub fn deserialize_f16(v: &[u8], out: &mut [f32]) {
+    for (d, o) in unaligned_f16_iter(v).zip(out.iter_mut()) {
+        *o = d.to_f32();
+    }
+}
+
+/// Dot product of two half precision vectors.
+pub fn dot_f16_f16(a: &[u8], b: &[u8]) -> f32 {
+    unaligned_f16_iter(a)
+        .zip(unaligned_f16_iter(b))
+        .map(|(a, b)| a.to_f32() * b.to_f32())
+        .sum()
+}
+
+/// Dot product of a single precision vector and a half precision vector.
+pub fn dot_f32_f16(a: &[f32], b: &[u8]) -> f32 {
+    a.iter()
+        .zip(unaligned_f16_iter(b).map(f16::to_f32))
+        .map(|(&s, o)| s * o)
+        .sum()
+}
+
+/// Squared euclidean (l2) distance between two half precision vectors.
+pub fn l2_f16_f16(a: &[u8], b: &[u8]) -> f32 {
+    unaligned_f16_iter(a)
+        .zip(unaligned_f16_iter(b))
+        .map(|(a, b)| {
+            let diff = a.to_f32() - b.to_f32();
+            diff * diff
+        })
+        .sum()
+}
+
+/// Squared euclidean (l2) distance between a single precision vector and a half precision
+/// vector.
+pub fn l2_f32_f16(a: &[f32], b: &[u8]) -> f32 {
+    a.iter()
+        .zip(unaligned_f16_iter(b).map(f16::to_f32))
+        .map(|(s, o)| {
+            let diff = *s - o;
+            diff * diff
+        })
+        .sum()
+}
+
+pub fn unaligned_f16_iter(raw: &[u8]) -> impl ExactSizeIterator<Item = f16> + '_ {
+    let (chunks, rem) = raw.as_chunks::<{ std::mem::size_of::<f16>() }>();
+    debug_assert!(rem.is_empty());
+    chunks.iter().map(|c| f16::from_le_bytes(*c))
+}

--- a/vectors/src/float32.rs
+++ b/vectors/src/float32.rs
@@ -223,14 +223,10 @@ impl VectorDistance for CosineDistance {
 
 impl F32VectorDistance for CosineDistance {
     fn distance_f32(&self, a: &[f32], b: &[f32]) -> f64 {
-        // We can't assume the vectors have been processed/normalized here so we have to perform
-        // full cosine similarity.
-        let (ab, a2, b2) = a
-            .iter()
-            .zip(b.iter())
-            .map(|(a, b)| (*a * b, *a * *a, *b * *b))
-            .fold((0.0, 0.0, 0.0), |s, x| (s.0 + x.0, s.1 + x.1, s.2 + x.2));
-        let cos = ab / (a2.sqrt() * b2.sqrt());
+        let ab = self.0.distance_f32(a, b);
+        let aa = self.0.distance_f32(a, a);
+        let bb = self.0.distance_f32(b, b);
+        let cos = ab / (aa * bb).sqrt();
         (-cos as f64 + 1.0) / 2.0
     }
 }

--- a/vectors/src/float32.rs
+++ b/vectors/src/float32.rs
@@ -5,272 +5,78 @@
 //! For Cosine similarity the vector will be normalized during encoding. When scoring float vectors
 //! we will assume the vectors are unnormalized.
 
+#[cfg(target_arch = "aarch64")]
+mod aarch64;
+mod scalar;
+#[cfg(target_arch = "x86_64")]
+mod x86_64;
+
 use std::{borrow::Cow, sync::OnceLock};
 
 use crate::{
     F32VectorCoder, F32VectorDistance, QueryVectorDistance as QueryVectorDistanceT, VectorDistance,
-    VectorSimilarity, float32::distance::InstructionSet,
+    VectorSimilarity,
 };
 
-mod distance {
-    #![allow(unsafe_op_in_unsafe_fn)]
+#[derive(Debug, Clone, Copy)]
+enum Kernel {
+    #[allow(unused)]
+    Scalar,
+    #[cfg(target_arch = "aarch64")]
+    Neon,
+    #[cfg(target_arch = "x86_64")]
+    Avx512f,
+}
 
-    #[derive(Debug, Clone, Copy)]
-    pub enum InstructionSet {
-        #[allow(unused)]
-        Scalar,
-        #[cfg(target_arch = "aarch64")]
-        Neon,
-        #[cfg(target_arch = "x86_64")]
-        Avx512f,
-    }
-
-    impl Default for InstructionSet {
-        #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
-        fn default() -> Self {
-            InstructionSet::Scalar
-        }
-
-        #[cfg(target_arch = "aarch64")]
-        fn default() -> Self {
-            InstructionSet::Neon
-        }
-
-        #[cfg(target_arch = "x86_64")]
-        fn default() -> Self {
-            if std::arch::is_x86_feature_detected!("avx512f") {
-                InstructionSet::Avx512f
-            } else {
-                InstructionSet::Scalar
-            }
-        }
-    }
-
-    #[inline]
-    pub fn dot(a: &[u8], b: &[u8], inst: Option<InstructionSet>) -> f64 {
-        assert_eq!(a.len(), b.len());
-        assert_eq!(a.len() % 4, 0);
-        match inst.unwrap_or_default() {
-            InstructionSet::Scalar => dot_scalar(a, b),
-            #[cfg(target_arch = "aarch64")]
-            InstructionSet::Neon => unsafe { dot_neon(a, b) },
-            #[cfg(target_arch = "x86_64")]
-            InstructionSet::Avx512f => unsafe { dot_avx512f(a, b) },
-        }
-    }
-
-    #[inline]
-    fn dot_scalar(a: &[u8], b: &[u8]) -> f64 {
-        f32_le_iter(a)
-            .zip(f32_le_iter(b))
-            .map(|(a, b)| a * b)
-            .sum::<f32>()
-            .into()
+impl Default for Kernel {
+    #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
+    fn default() -> Self {
+        Kernel::Scalar
     }
 
     #[cfg(target_arch = "aarch64")]
-    #[inline]
-    unsafe fn dot_neon(a: &[u8], b: &[u8]) -> f64 {
-        use std::arch::aarch64::{vaddq_f32, vaddvq_f32, vdupq_n_f32, vfmaq_f32};
-        let len64 = a.len() & !63;
-        let mut dot0 = vdupq_n_f32(0.0);
-        let mut dot1 = vdupq_n_f32(0.0);
-        let mut dot2 = vdupq_n_f32(0.0);
-        let mut dot3 = vdupq_n_f32(0.0);
-        for i in (0..len64).step_by(64) {
-            dot0 = vfmaq_f32(
-                dot0,
-                load_f32x4_le(a.as_ptr().add(i)),
-                load_f32x4_le(b.as_ptr().add(i)),
-            );
-            dot1 = vfmaq_f32(
-                dot1,
-                load_f32x4_le(a.as_ptr().add(i + 16)),
-                load_f32x4_le(b.as_ptr().add(i + 16)),
-            );
-            dot2 = vfmaq_f32(
-                dot2,
-                load_f32x4_le(a.as_ptr().add(i + 32)),
-                load_f32x4_le(b.as_ptr().add(i + 32)),
-            );
-            dot3 = vfmaq_f32(
-                dot3,
-                load_f32x4_le(a.as_ptr().add(i + 48)),
-                load_f32x4_le(b.as_ptr().add(i + 48)),
-            );
-        }
-
-        dot0 = vaddq_f32(vaddq_f32(dot0, dot1), vaddq_f32(dot2, dot3));
-        let len16 = a.len() & !15;
-        for i in (len64..len16).step_by(16) {
-            dot0 = vfmaq_f32(
-                dot0,
-                load_f32x4_le(a.as_ptr().add(i)),
-                load_f32x4_le(b.as_ptr().add(i)),
-            );
-        }
-
-        let mut dot = vaddvq_f32(dot0);
-        for i in (len16..a.len()).step_by(4) {
-            dot += std::ptr::read_unaligned(a.as_ptr().add(i) as *const f32)
-                * std::ptr::read_unaligned(b.as_ptr().add(i) as *const f32);
-        }
-        dot.into()
+    fn default() -> Self {
+        Kernel::Neon
     }
 
     #[cfg(target_arch = "x86_64")]
-    #[inline]
-    #[target_feature(enable = "avx512f")]
-    unsafe fn dot_avx512f(q: &[u8], d: &[u8]) -> f64 {
-        use std::arch::x86_64::{
-            _mm_cvtss_f32, _mm_hadd_ps, _mm512_add_ps, _mm512_castps512_ps128, _mm512_fmadd_ps,
-            _mm512_maskz_loadu_ps, _mm512_set1_ps, _mm512_shuffle_f32x4,
-        };
-        let mut dot = _mm512_set1_ps(0.0);
-        for i in (0..q.len()).step_by(64) {
-            let rem = (q.len() - i).min(64) / 4;
-            let mask = u16::MAX >> (16 - rem);
-            let qv = _mm512_maskz_loadu_ps(mask, q.as_ptr().add(i) as *const f32);
-            let dv = _mm512_maskz_loadu_ps(mask, d.as_ptr().add(i) as *const f32);
-            dot = _mm512_fmadd_ps(qv, dv, dot);
-        }
-
-        let x = _mm512_add_ps(dot, _mm512_shuffle_f32x4(dot, dot, 0b00001110));
-        let r = _mm512_castps512_ps128(_mm512_add_ps(x, _mm512_shuffle_f32x4(x, x, 0b00000001)));
-        let r = _mm_hadd_ps(r, r);
-        _mm_cvtss_f32(_mm_hadd_ps(r, r)).into()
-    }
-
-    pub fn l2sq(a: &[u8], b: &[u8], inst: Option<InstructionSet>) -> f64 {
-        assert_eq!(a.len(), b.len());
-        assert_eq!(a.len() % 4, 0);
-        match inst.unwrap_or_default() {
-            InstructionSet::Scalar => l2sq_scalar(a, b),
-            #[cfg(target_arch = "aarch64")]
-            InstructionSet::Neon => unsafe { l2sq_neon(a, b) },
-            #[cfg(target_arch = "x86_64")]
-            InstructionSet::Avx512f => unsafe { l2sq_avx512(a, b) },
-        }
-    }
-
-    #[inline]
-    fn l2sq_scalar(a: &[u8], b: &[u8]) -> f64 {
-        f32_le_iter(a)
-            .zip(f32_le_iter(b))
-            .map(|(a, b)| {
-                let delta = a - b;
-                delta * delta
-            })
-            .sum::<f32>()
-            .into()
-    }
-
-    #[cfg(target_arch = "aarch64")]
-    #[inline]
-    unsafe fn l2sq_neon(q: &[u8], d: &[u8]) -> f64 {
-        use std::arch::aarch64::{vaddq_f32, vaddvq_f32, vdupq_n_f32, vfmaq_f32, vsubq_f32};
-
-        let len64 = q.len() & !63;
-        let mut sum0 = vdupq_n_f32(0.0);
-        let mut sum1 = vdupq_n_f32(0.0);
-        let mut sum2 = vdupq_n_f32(0.0);
-        let mut sum3 = vdupq_n_f32(0.0);
-        for i in (0..len64).step_by(64) {
-            let mut diff = vsubq_f32(
-                load_f32x4_le(q.as_ptr().add(i)),
-                load_f32x4_le(d.as_ptr().add(i)),
-            );
-            sum0 = vfmaq_f32(sum0, diff, diff);
-
-            diff = vsubq_f32(
-                load_f32x4_le(q.as_ptr().add(i + 16)),
-                load_f32x4_le(d.as_ptr().add(i + 16)),
-            );
-            sum1 = vfmaq_f32(sum1, diff, diff);
-
-            diff = vsubq_f32(
-                load_f32x4_le(q.as_ptr().add(i + 32)),
-                load_f32x4_le(d.as_ptr().add(i + 32)),
-            );
-            sum2 = vfmaq_f32(sum2, diff, diff);
-
-            diff = vsubq_f32(
-                load_f32x4_le(q.as_ptr().add(i + 48)),
-                load_f32x4_le(d.as_ptr().add(i + 48)),
-            );
-            sum3 = vfmaq_f32(sum3, diff, diff);
-        }
-
-        sum0 = vaddq_f32(vaddq_f32(sum0, sum1), vaddq_f32(sum2, sum3));
-        let len16 = q.len() & !15;
-        for i in (len64..len16).step_by(16) {
-            let diff = vsubq_f32(
-                load_f32x4_le(q.as_ptr().add(i)),
-                load_f32x4_le(d.as_ptr().add(i)),
-            );
-            sum0 = vfmaq_f32(sum0, diff, diff);
-        }
-
-        let mut sum = vaddvq_f32(sum0);
-        for i in (len16..q.len()).step_by(4) {
-            let diff = std::ptr::read_unaligned(q.as_ptr().add(i) as *const f32)
-                - std::ptr::read_unaligned(d.as_ptr().add(i) as *const f32);
-            sum = diff.mul_add(diff, sum);
-        }
-
-        sum.into()
-    }
-
-    #[cfg(target_arch = "x86_64")]
-    #[inline]
-    #[target_feature(enable = "avx512f")]
-    unsafe fn l2sq_avx512(q: &[u8], d: &[u8]) -> f64 {
-        use std::arch::x86_64::{
-            _mm_cvtss_f32, _mm_hadd_ps, _mm512_add_ps, _mm512_castps512_ps128, _mm512_fmadd_ps,
-            _mm512_maskz_loadu_ps, _mm512_set1_ps, _mm512_shuffle_f32x4, _mm512_sub_ps,
-        };
-        let mut sum = _mm512_set1_ps(0.0);
-        for i in (0..q.len()).step_by(64) {
-            let rem = (q.len() - i).min(64) / 4;
-            let mask = u16::MAX >> (16 - rem);
-            let qv = _mm512_maskz_loadu_ps(mask, q.as_ptr().add(i) as *const f32);
-            let dv = _mm512_maskz_loadu_ps(mask, d.as_ptr().add(i) as *const f32);
-            let diff = _mm512_sub_ps(qv, dv);
-            sum = _mm512_fmadd_ps(diff, diff, sum);
-        }
-
-        let x = _mm512_add_ps(sum, _mm512_shuffle_f32x4(sum, sum, 0b00_00_11_10));
-        let r = _mm512_castps512_ps128(_mm512_add_ps(x, _mm512_shuffle_f32x4(x, x, 0b00_00_00_01)));
-        let r = _mm_hadd_ps(r, r);
-        _mm_cvtss_f32(_mm_hadd_ps(r, r)).into()
-    }
-
-    pub fn f32_le_iter<'b>(b: &'b [u8]) -> impl ExactSizeIterator<Item = f32> + 'b {
-        let (chunks, rem) = b.as_chunks::<{ std::mem::size_of::<f32>() }>();
-        debug_assert!(rem.is_empty());
-        chunks.iter().map(|c| {
-            f32::from_bits(u32::from_le(unsafe {
-                // SAFETY: byte array chunk is guaranteed to be the same size as u32/f32.
-                std::ptr::read_unaligned(c.as_ptr() as *const u32)
-            }))
-        })
-    }
-
-    #[inline(always)]
-    #[cfg(target_arch = "aarch64")]
-    unsafe fn load_f32x4_le(p: *const u8) -> core::arch::aarch64::float32x4_t {
-        use core::arch::aarch64;
-        if cfg!(target_endian = "big") {
-            aarch64::vreinterpretq_f32_u8(aarch64::vrev32q_u8(aarch64::vld1q_u8(p)))
+    fn default() -> Self {
+        if std::arch::is_x86_feature_detected!("avx512f") {
+            Kernel::Avx512f
         } else {
-            aarch64::vld1q_f32(p as *const f32)
+            Kernel::Scalar
         }
     }
-} // mod distance
+}
+
+#[inline]
+fn dot(a: &[u8], b: &[u8], inst: Option<Kernel>) -> f64 {
+    assert_eq!(a.len(), b.len());
+    assert_eq!(a.len() % 4, 0);
+    match inst.unwrap_or_default() {
+        Kernel::Scalar => scalar::dot(a, b),
+        #[cfg(target_arch = "aarch64")]
+        Kernel::Neon => unsafe { aarch64::dot(a, b) },
+        #[cfg(target_arch = "x86_64")]
+        Kernel::Avx512f => unsafe { x86_64::dot(a, b) },
+    }
+}
+
+fn l2sq(a: &[u8], b: &[u8], inst: Option<Kernel>) -> f64 {
+    assert_eq!(a.len(), b.len());
+    assert_eq!(a.len() % 4, 0);
+    match inst.unwrap_or_default() {
+        Kernel::Scalar => scalar::l2sq(a, b),
+        #[cfg(target_arch = "aarch64")]
+        Kernel::Neon => unsafe { aarch64::l2sq(a, b) },
+        #[cfg(target_arch = "x86_64")]
+        Kernel::Avx512f => unsafe { x86_64::l2sq(a, b) },
+    }
+}
 
 /// Compute the l2 norm of `vector`.
 pub fn l2_norm(vector: impl AsRef<[f32]>) -> f32 {
-    distance::dot(
+    dot(
         bytemuck::cast_slice(vector.as_ref()),
         bytemuck::cast_slice(vector.as_ref()),
         None,
@@ -325,7 +131,7 @@ impl F32VectorCoder for VectorCoder {
     }
 
     fn decode_to(&self, encoded: &[u8], out: &mut [f32]) {
-        for (d, o) in distance::f32_le_iter(encoded).zip(out.iter_mut()) {
+        for (d, o) in scalar::f32_le_iter(encoded).zip(out.iter_mut()) {
             *o = d
         }
     }
@@ -339,7 +145,7 @@ static L2_DIST: OnceLock<EuclideanDistance> = OnceLock::new();
 
 /// Compute squared l2 (Euclidean) distance.
 #[derive(Debug, Copy, Clone, Default)]
-pub struct EuclideanDistance(InstructionSet);
+pub struct EuclideanDistance(Kernel);
 
 impl EuclideanDistance {
     /// Returns a static instance of euclidean distance.
@@ -350,13 +156,13 @@ impl EuclideanDistance {
 
 impl VectorDistance for EuclideanDistance {
     fn distance(&self, query: &[u8], doc: &[u8]) -> f64 {
-        distance::l2sq(query, doc, Some(self.0))
+        l2sq(query, doc, Some(self.0))
     }
 }
 
 impl F32VectorDistance for EuclideanDistance {
     fn distance_f32(&self, a: &[f32], b: &[f32]) -> f64 {
-        distance::l2sq(
+        l2sq(
             bytemuck::cast_slice(a),
             bytemuck::cast_slice(b),
             Some(self.0),
@@ -368,7 +174,7 @@ static DOT_DIST: OnceLock<DotProductDistance> = OnceLock::new();
 
 /// Computes a score based on the dot product.
 #[derive(Debug, Copy, Clone, Default)]
-pub struct DotProductDistance(InstructionSet);
+pub struct DotProductDistance(Kernel);
 
 impl DotProductDistance {
     /// Returns a static instance of dot product distance.
@@ -380,14 +186,14 @@ impl DotProductDistance {
 impl VectorDistance for DotProductDistance {
     fn distance(&self, query: &[u8], doc: &[u8]) -> f64 {
         // Assuming values are normalized, this will produce a distance in [0,1]
-        (-distance::dot(query, doc, Some(self.0)) + 1.0) / 2.0
+        (-dot(query, doc, Some(self.0)) + 1.0) / 2.0
     }
 }
 
 impl F32VectorDistance for DotProductDistance {
     fn distance_f32(&self, a: &[f32], b: &[f32]) -> f64 {
         // Assuming values are normalized, this will produce a distance in [0,1]
-        (-distance::dot(
+        (-dot(
             bytemuck::cast_slice(a),
             bytemuck::cast_slice(b),
             Some(self.0),

--- a/vectors/src/float32.rs
+++ b/vectors/src/float32.rs
@@ -223,9 +223,21 @@ impl VectorDistance for CosineDistance {
 
 impl F32VectorDistance for CosineDistance {
     fn distance_f32(&self, a: &[f32], b: &[f32]) -> f64 {
-        let ab = self.0.distance_f32(a, b);
-        let aa = self.0.distance_f32(a, a);
-        let bb = self.0.distance_f32(b, b);
+        let ab = dot(
+            bytemuck::cast_slice(a),
+            bytemuck::cast_slice(b),
+            Some(self.0.0),
+        );
+        let aa = dot(
+            bytemuck::cast_slice(a),
+            bytemuck::cast_slice(a),
+            Some(self.0.0),
+        );
+        let bb = dot(
+            bytemuck::cast_slice(b),
+            bytemuck::cast_slice(b),
+            Some(self.0.0),
+        );
         let cos = ab / (aa * bb).sqrt();
         (-cos as f64 + 1.0) / 2.0
     }

--- a/vectors/src/float32/aarch64.rs
+++ b/vectors/src/float32/aarch64.rs
@@ -1,0 +1,115 @@
+#![allow(unsafe_op_in_unsafe_fn)]
+
+#[inline]
+pub unsafe fn dot(a: &[u8], b: &[u8]) -> f64 {
+    use std::arch::aarch64::{vaddq_f32, vaddvq_f32, vdupq_n_f32, vfmaq_f32};
+    let len64 = a.len() & !63;
+    let mut dot0 = vdupq_n_f32(0.0);
+    let mut dot1 = vdupq_n_f32(0.0);
+    let mut dot2 = vdupq_n_f32(0.0);
+    let mut dot3 = vdupq_n_f32(0.0);
+    for i in (0..len64).step_by(64) {
+        dot0 = vfmaq_f32(
+            dot0,
+            load_f32x4_le(a.as_ptr().add(i)),
+            load_f32x4_le(b.as_ptr().add(i)),
+        );
+        dot1 = vfmaq_f32(
+            dot1,
+            load_f32x4_le(a.as_ptr().add(i + 16)),
+            load_f32x4_le(b.as_ptr().add(i + 16)),
+        );
+        dot2 = vfmaq_f32(
+            dot2,
+            load_f32x4_le(a.as_ptr().add(i + 32)),
+            load_f32x4_le(b.as_ptr().add(i + 32)),
+        );
+        dot3 = vfmaq_f32(
+            dot3,
+            load_f32x4_le(a.as_ptr().add(i + 48)),
+            load_f32x4_le(b.as_ptr().add(i + 48)),
+        );
+    }
+
+    dot0 = vaddq_f32(vaddq_f32(dot0, dot1), vaddq_f32(dot2, dot3));
+    let len16 = a.len() & !15;
+    for i in (len64..len16).step_by(16) {
+        dot0 = vfmaq_f32(
+            dot0,
+            load_f32x4_le(a.as_ptr().add(i)),
+            load_f32x4_le(b.as_ptr().add(i)),
+        );
+    }
+
+    let mut dot = vaddvq_f32(dot0);
+    for i in (len16..a.len()).step_by(4) {
+        dot += std::ptr::read_unaligned(a.as_ptr().add(i) as *const f32)
+            * std::ptr::read_unaligned(b.as_ptr().add(i) as *const f32);
+    }
+    dot.into()
+}
+
+#[inline]
+pub unsafe fn l2sq(q: &[u8], d: &[u8]) -> f64 {
+    use std::arch::aarch64::{vaddq_f32, vaddvq_f32, vdupq_n_f32, vfmaq_f32, vsubq_f32};
+
+    let len64 = q.len() & !63;
+    let mut sum0 = vdupq_n_f32(0.0);
+    let mut sum1 = vdupq_n_f32(0.0);
+    let mut sum2 = vdupq_n_f32(0.0);
+    let mut sum3 = vdupq_n_f32(0.0);
+    for i in (0..len64).step_by(64) {
+        let mut diff = vsubq_f32(
+            load_f32x4_le(q.as_ptr().add(i)),
+            load_f32x4_le(d.as_ptr().add(i)),
+        );
+        sum0 = vfmaq_f32(sum0, diff, diff);
+
+        diff = vsubq_f32(
+            load_f32x4_le(q.as_ptr().add(i + 16)),
+            load_f32x4_le(d.as_ptr().add(i + 16)),
+        );
+        sum1 = vfmaq_f32(sum1, diff, diff);
+
+        diff = vsubq_f32(
+            load_f32x4_le(q.as_ptr().add(i + 32)),
+            load_f32x4_le(d.as_ptr().add(i + 32)),
+        );
+        sum2 = vfmaq_f32(sum2, diff, diff);
+
+        diff = vsubq_f32(
+            load_f32x4_le(q.as_ptr().add(i + 48)),
+            load_f32x4_le(d.as_ptr().add(i + 48)),
+        );
+        sum3 = vfmaq_f32(sum3, diff, diff);
+    }
+
+    sum0 = vaddq_f32(vaddq_f32(sum0, sum1), vaddq_f32(sum2, sum3));
+    let len16 = q.len() & !15;
+    for i in (len64..len16).step_by(16) {
+        let diff = vsubq_f32(
+            load_f32x4_le(q.as_ptr().add(i)),
+            load_f32x4_le(d.as_ptr().add(i)),
+        );
+        sum0 = vfmaq_f32(sum0, diff, diff);
+    }
+
+    let mut sum = vaddvq_f32(sum0);
+    for i in (len16..q.len()).step_by(4) {
+        let diff = std::ptr::read_unaligned(q.as_ptr().add(i) as *const f32)
+            - std::ptr::read_unaligned(d.as_ptr().add(i) as *const f32);
+        sum = diff.mul_add(diff, sum);
+    }
+
+    sum.into()
+}
+
+#[inline(always)]
+unsafe fn load_f32x4_le(p: *const u8) -> core::arch::aarch64::float32x4_t {
+    use core::arch::aarch64;
+    if cfg!(target_endian = "big") {
+        aarch64::vreinterpretq_f32_u8(aarch64::vrev32q_u8(aarch64::vld1q_u8(p)))
+    } else {
+        aarch64::vld1q_f32(p as *const f32)
+    }
+}

--- a/vectors/src/float32/scalar.rs
+++ b/vectors/src/float32/scalar.rs
@@ -1,0 +1,31 @@
+#[inline]
+pub fn dot(a: &[u8], b: &[u8]) -> f64 {
+    f32_le_iter(a)
+        .zip(f32_le_iter(b))
+        .map(|(a, b)| a * b)
+        .sum::<f32>()
+        .into()
+}
+
+#[inline]
+pub fn l2sq(a: &[u8], b: &[u8]) -> f64 {
+    f32_le_iter(a)
+        .zip(f32_le_iter(b))
+        .map(|(a, b)| {
+            let delta = a - b;
+            delta * delta
+        })
+        .sum::<f32>()
+        .into()
+}
+
+pub fn f32_le_iter<'b>(b: &'b [u8]) -> impl ExactSizeIterator<Item = f32> + 'b {
+    let (chunks, rem) = b.as_chunks::<{ std::mem::size_of::<f32>() }>();
+    debug_assert!(rem.is_empty());
+    chunks.iter().map(|c| {
+        f32::from_bits(u32::from_le(unsafe {
+            // SAFETY: byte array chunk is guaranteed to be the same size as u32/f32.
+            std::ptr::read_unaligned(c.as_ptr() as *const u32)
+        }))
+    })
+}

--- a/vectors/src/float32/x86_64.rs
+++ b/vectors/src/float32/x86_64.rs
@@ -1,0 +1,46 @@
+#![allow(unsafe_op_in_unsafe_fn)]
+
+#[inline]
+#[target_feature(enable = "avx512f")]
+pub unsafe fn dot(q: &[u8], d: &[u8]) -> f64 {
+    use std::arch::x86_64::{
+        _mm_cvtss_f32, _mm_hadd_ps, _mm512_add_ps, _mm512_castps512_ps128, _mm512_fmadd_ps,
+        _mm512_maskz_loadu_ps, _mm512_set1_ps, _mm512_shuffle_f32x4,
+    };
+    let mut dot = _mm512_set1_ps(0.0);
+    for i in (0..q.len()).step_by(64) {
+        let rem = (q.len() - i).min(64) / 4;
+        let mask = u16::MAX >> (16 - rem);
+        let qv = _mm512_maskz_loadu_ps(mask, q.as_ptr().add(i) as *const f32);
+        let dv = _mm512_maskz_loadu_ps(mask, d.as_ptr().add(i) as *const f32);
+        dot = _mm512_fmadd_ps(qv, dv, dot);
+    }
+
+    let x = _mm512_add_ps(dot, _mm512_shuffle_f32x4(dot, dot, 0b00001110));
+    let r = _mm512_castps512_ps128(_mm512_add_ps(x, _mm512_shuffle_f32x4(x, x, 0b00000001)));
+    let r = _mm_hadd_ps(r, r);
+    _mm_cvtss_f32(_mm_hadd_ps(r, r)).into()
+}
+
+#[inline]
+#[target_feature(enable = "avx512f")]
+pub unsafe fn l2sq(q: &[u8], d: &[u8]) -> f64 {
+    use std::arch::x86_64::{
+        _mm_cvtss_f32, _mm_hadd_ps, _mm512_add_ps, _mm512_castps512_ps128, _mm512_fmadd_ps,
+        _mm512_maskz_loadu_ps, _mm512_set1_ps, _mm512_shuffle_f32x4, _mm512_sub_ps,
+    };
+    let mut sum = _mm512_set1_ps(0.0);
+    for i in (0..q.len()).step_by(64) {
+        let rem = (q.len() - i).min(64) / 4;
+        let mask = u16::MAX >> (16 - rem);
+        let qv = _mm512_maskz_loadu_ps(mask, q.as_ptr().add(i) as *const f32);
+        let dv = _mm512_maskz_loadu_ps(mask, d.as_ptr().add(i) as *const f32);
+        let diff = _mm512_sub_ps(qv, dv);
+        sum = _mm512_fmadd_ps(diff, diff, sum);
+    }
+
+    let x = _mm512_add_ps(sum, _mm512_shuffle_f32x4(sum, sum, 0b00_00_11_10));
+    let r = _mm512_castps512_ps128(_mm512_add_ps(x, _mm512_shuffle_f32x4(x, x, 0b00_00_00_01)));
+    let r = _mm_hadd_ps(r, r);
+    _mm_cvtss_f32(_mm_hadd_ps(r, r)).into()
+}

--- a/vectors/src/lib.rs
+++ b/vectors/src/lib.rs
@@ -4,7 +4,7 @@ use std::{borrow::Cow, fmt::Debug, io, str::FromStr};
 
 mod binary;
 mod float16;
-mod float32;
+pub mod float32;
 mod lvq;
 mod quiver;
 pub mod rotate;
@@ -39,7 +39,7 @@ pub enum VectorSimilarity {
 
 impl VectorSimilarity {
     /// Return an [`F32VectorDistance`] for this similarity function.
-    pub fn new_distance_function(self) -> Box<dyn F32VectorDistance> {
+    pub fn distance_f32(self) -> Box<dyn F32VectorDistance> {
         match self {
             Self::Euclidean => Box::new(float32::EuclideanDistance::default()),
             Self::Dot => Box::new(float32::DotProductDistance::default()),
@@ -601,7 +601,7 @@ mod test {
         let a = TestVector::new(a, similarity, coder.as_ref());
         let b = TestVector::new(b, similarity, coder.as_ref());
 
-        let f32_dist_fn = similarity.new_distance_function();
+        let f32_dist_fn = similarity.distance_f32();
         let rf32_dist = f32_dist_fn.distance_f32(&a.rvec, &b.rvec);
         let ru8_dist =
             f32_dist_fn.distance(bytemuck::cast_slice(&a.rvec), bytemuck::cast_slice(&b.rvec));
@@ -624,7 +624,7 @@ mod test {
         let a = TestVector::new(a, similarity, coder.as_ref());
         let b = TestVector::new(b, similarity, coder.as_ref());
 
-        let f32_dist_fn = similarity.new_distance_function();
+        let f32_dist_fn = similarity.distance_f32();
         let f32_dist = f32_dist_fn.distance_f32(&a.rvec, &b.rvec);
 
         let query_dist_fn = format.query_distance_asymmetric(similarity, &a.rvec, None);

--- a/vectors/src/lib.rs
+++ b/vectors/src/lib.rs
@@ -3,7 +3,7 @@
 use std::{borrow::Cow, fmt::Debug, io, str::FromStr};
 
 mod binary;
-mod float16;
+pub mod float16;
 pub mod float32;
 mod lvq;
 mod quiver;
@@ -39,11 +39,20 @@ pub enum VectorSimilarity {
 
 impl VectorSimilarity {
     /// Return an [`F32VectorDistance`] for this similarity function.
-    pub fn distance_f32(self) -> Box<dyn F32VectorDistance> {
+    pub fn distance_f32(&self) -> Box<dyn F32VectorDistance> {
         match self {
             Self::Euclidean => Box::new(float32::EuclideanDistance::default()),
             Self::Dot => Box::new(float32::DotProductDistance::default()),
             Self::Cosine => Box::new(float32::CosineDistance::default()),
+        }
+    }
+
+    /// Return an [`F16VectorDistance`] for this similarity function.
+    pub fn distance_f16(&self) -> Box<dyn F16VectorDistance> {
+        match self {
+            Self::Euclidean => Box::new(float16::EuclideanDistance::default()),
+            Self::Dot => Box::new(float16::DotProductDistance::default()),
+            Self::Cosine => Box::new(float16::CosineDistance::default()),
         }
     }
 
@@ -547,7 +556,8 @@ impl<'a, D: VectorDistance> QueryVectorDistance for QuantizedQueryVectorDistance
 #[cfg(test)]
 mod test {
     use crate::{
-        F32VectorCoder, F32VectorCoding, VectorSimilarity, l2_normalize,
+        F32VectorCoder, F32VectorCoding, VectorSimilarity,
+        float32::l2_normalize,
         lvq::{TurboPrimaryCoder, TurboResidualCoder},
     };
 

--- a/vectors/src/lib.rs
+++ b/vectors/src/lib.rs
@@ -11,7 +11,7 @@ pub mod rotate;
 
 use serde::{Deserialize, Serialize};
 
-pub use float32::{CosineDistance, DotProductDistance, EuclideanDistance, l2_norm, l2_normalize};
+pub use half::f16;
 
 /// Functions used for to compute the distance between two vectors.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -119,15 +119,19 @@ pub trait VectorDistance: Send + Sync {
 }
 
 /// Distance function for `f32` vectors.
-///
-/// This trait is object-safe; it may be instantiated at runtime based on
-/// data that appears in a file or other backing store.
 pub trait F32VectorDistance: VectorDistance {
-    /// Score vectors `a` and `b` against one another. Returns a score
-    /// where larger values are better matches.
+    /// Compute the distance between `a` and `b`; smaller values are better.
     ///
     /// Input vectors must be the same length or this function may panic.
     fn distance_f32(&self, a: &[f32], b: &[f32]) -> f64;
+}
+
+/// Distance function for `f16` vectors.
+pub trait F16VectorDistance: VectorDistance {
+    /// Compute the distance between `a` and `b`; smaller values are better.
+    ///
+    /// Input vectors must be the same length or this function may panic.
+    fn distance_f16(&self, a: &[f16], b: &[f16]) -> f64;
 }
 
 /// Supported coding schemes for input f32 vectors.
@@ -269,7 +273,7 @@ impl F32VectorCoding {
                 float32::new_query_vector_distance(similarity, query.into())
             }
             (F32VectorCoding::F16, VectorSimilarity::Cosine) => Box::new(
-                float16::DotProductQueryDistance::new(l2_normalize(query.into())),
+                float16::DotProductQueryDistance::new(float32::l2_normalize(query.into())),
             ),
             (F32VectorCoding::F16, VectorSimilarity::Dot) => {
                 Box::new(float16::DotProductQueryDistance::new(query.into()))

--- a/vectors/src/lvq.rs
+++ b/vectors/src/lvq.rs
@@ -25,7 +25,9 @@ use std::{
 use half::f16;
 use thread_local::ThreadLocal;
 
-use crate::{F32VectorCoder, QueryVectorDistance, VectorDistance, VectorSimilarity, l2_norm};
+use crate::{
+    F32VectorCoder, QueryVectorDistance, VectorDistance, VectorSimilarity, float32::l2_norm,
+};
 
 const SUPPORTED_PRIMARY_BITS: [usize; 4] = [1, 2, 4, 8];
 

--- a/vectors/src/lvq/test.rs
+++ b/vectors/src/lvq/test.rs
@@ -3,7 +3,7 @@ use approx::{AbsDiffEq, abs_diff_eq, assert_abs_diff_eq};
 use crate::lvq::{
     PrimaryVectorHeader, ResidualVectorHeader, TurboPrimaryCoder, TurboResidualCoder, VectorStats,
 };
-use crate::{F32VectorCoder, F32VectorCoding, VectorSimilarity, l2_normalize};
+use crate::{F32VectorCoder, F32VectorCoding, VectorSimilarity, float32::l2_normalize};
 
 impl AbsDiffEq for PrimaryVectorHeader {
     type Epsilon = f32;

--- a/vectors/src/lvq/test.rs
+++ b/vectors/src/lvq/test.rs
@@ -772,7 +772,7 @@ fn check_lvq_distance(
         (a.to_vec(), b.to_vec())
     };
 
-    let f32_dist = sim.new_distance_function().distance_f32(&a, &b);
+    let f32_dist = sim.distance_f32().distance_f32(&a, &b);
 
     let coder = format.coder(sim, center.map(|c| c.to_vec()));
     let enc_a = coder.encode(&a);

--- a/vectors/src/quiver/test.rs
+++ b/vectors/src/quiver/test.rs
@@ -4,7 +4,7 @@ use approx::assert_abs_diff_eq;
 use rand::{Rng, SeedableRng, TryRngCore, rngs::OsRng};
 use rand_xoshiro::Xoshiro256PlusPlus;
 
-use crate::l2_normalize;
+use crate::float32::l2_normalize;
 
 use super::{
     Header, new_asymmetric_distance, new_coder, new_scalar_asymmetric_distance, new_scalar_coder,


### PR DESCRIPTION
* F16VectorDistance trait with support for directly computing distances from &[f16]
* Singleton instances of F16 distance functions.
* Remove some f32 re-exports since it may no longer the default you'd want to use.
* f32 cleanups