### PR TITLE
Use f16 vectors for compute-neighbors

### DIFF
--- a/et/src/compute_neighbors/cpu.rs
+++ b/et/src/compute_neighbors/cpu.rs
@@ -17,8 +17,7 @@ pub fn run(args: &ComputeNeighborsArgs) -> io::Result<()> {
     let query_vectors: DerefVectorStore<f16, Mmap> =
         DerefVectorStore::from_file(&args.query_vectors)?;
     let query_limit = args.query_limit.unwrap_or(query_vectors.len());
-    let doc_vectors: DerefVectorStore<f16, Mmap> =
-        DerefVectorStore::from_file(&args.doc_vectors)?;
+    let doc_vectors: DerefVectorStore<f16, Mmap> = DerefVectorStore::from_file(&args.doc_vectors)?;
     let doc_limit = args
         .doc_limit
         .unwrap_or(doc_vectors.len())

--- a/et/src/compute_neighbors/cpu.rs
+++ b/et/src/compute_neighbors/cpu.rs
@@ -1,7 +1,4 @@
-use std::{
-    fs::File,
-    io::{self, BufWriter, Write},
-};
+use std::io;
 
 use easy_tiger::{
     Neighbor,
@@ -13,7 +10,7 @@ use rayon::prelude::*;
 
 use crate::neighbor_util::TopNeighbors;
 
-use super::ComputeNeighborsArgs;
+use super::{ComputeNeighborsArgs, write_neighbors};
 
 pub fn run(args: &ComputeNeighborsArgs) -> io::Result<()> {
     let query_vectors: DerefVectorStore<f32, Mmap> =
@@ -27,7 +24,6 @@ pub fn run(args: &ComputeNeighborsArgs) -> io::Result<()> {
         .min(doc_vectors.len());
 
     let distance_fn = args.similarity.new_distance_function();
-    let k = args.neighbors_len.get();
     let mut results = Vec::with_capacity(query_limit);
     results.resize_with(query_limit, || TopNeighbors::new(args.neighbors_len.get()));
     (0..doc_limit)
@@ -42,12 +38,5 @@ pub fn run(args: &ComputeNeighborsArgs) -> io::Result<()> {
             }
         });
 
-    let mut writer = BufWriter::new(File::create(&args.neighbors)?);
-    for neighbors in results.into_iter().map(|r| r.into_neighbors()) {
-        for n in neighbors.into_iter().take(k) {
-            writer.write_all(&<[u8; 16]>::from(n))?;
-        }
-    }
-
-    Ok(())
+    write_neighbors(args, results)
 }

--- a/et/src/compute_neighbors/cpu.rs
+++ b/et/src/compute_neighbors/cpu.rs
@@ -7,23 +7,34 @@ use easy_tiger::{
 use indicatif::ParallelProgressIterator;
 use memmap2::Mmap;
 use rayon::prelude::*;
+use vectors::f16;
 
 use crate::neighbor_util::TopNeighbors;
 
 use super::{ComputeNeighborsArgs, write_neighbors};
 
 pub fn run(args: &ComputeNeighborsArgs) -> io::Result<()> {
-    let query_vectors: DerefVectorStore<f32, Mmap> =
-        DerefVectorStore::from_file_with_stride(&args.query_vectors, args.dimensions)?;
+    let query_vectors: DerefVectorStore<f16, Mmap> =
+        DerefVectorStore::from_file(&args.query_vectors)?;
     let query_limit = args.query_limit.unwrap_or(query_vectors.len());
-    let doc_vectors: DerefVectorStore<f32, Mmap> =
-        DerefVectorStore::from_file_with_stride(&args.doc_vectors, args.dimensions)?;
+    let doc_vectors: DerefVectorStore<f16, Mmap> =
+        DerefVectorStore::from_file(&args.doc_vectors)?;
     let doc_limit = args
         .doc_limit
         .unwrap_or(doc_vectors.len())
         .min(doc_vectors.len());
+    if query_vectors.elem_stride() != doc_vectors.elem_stride() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "query and doc vectors must have the same dimensionality ({} vs {})",
+                query_vectors.elem_stride(),
+                doc_vectors.elem_stride()
+            ),
+        ));
+    }
 
-    let distance_fn = args.similarity.distance_f32();
+    let distance_fn = args.similarity.distance_f16();
     let mut results = Vec::with_capacity(query_limit);
     results.resize_with(query_limit, || TopNeighbors::new(args.neighbors_len.get()));
     (0..doc_limit)
@@ -33,7 +44,7 @@ pub fn run(args: &ComputeNeighborsArgs) -> io::Result<()> {
             for q in 0..query_limit {
                 results[q].add(Neighbor::new(
                     d as i64,
-                    distance_fn.distance_f32(&query_vectors[q], &doc_vectors[d]),
+                    distance_fn.distance_f16(&query_vectors[q], &doc_vectors[d]),
                 ));
             }
         });

--- a/et/src/compute_neighbors/gpu.rs
+++ b/et/src/compute_neighbors/gpu.rs
@@ -1,9 +1,4 @@
-use std::{
-    fs::File,
-    io::{self, BufWriter, Write},
-    sync::mpsc,
-    time::Duration,
-};
+use std::{io, sync::mpsc, time::Duration};
 
 use bytemuck::{Pod, Zeroable};
 use easy_tiger::{
@@ -15,7 +10,7 @@ use vectors::VectorSimilarity;
 
 use crate::{neighbor_util::TopNeighbors, ui::progress_bar};
 
-use super::ComputeNeighborsArgs;
+use super::{ComputeNeighborsArgs, write_neighbors};
 
 /// WGSL compute shader for pairwise distance computation.
 ///
@@ -429,14 +424,7 @@ pub fn run(adapter: wgpu::Adapter, args: &ComputeNeighborsArgs) -> io::Result<()
     }
 
     // --- Write output ---
-    let mut writer = BufWriter::new(File::create(&args.neighbors)?);
-    for neighbors in results.into_iter().map(|r| r.into_neighbors()) {
-        for n in neighbors.into_iter().take(k) {
-            writer.write_all(&<[u8; 16]>::from(n))?;
-        }
-    }
-
-    Ok(())
+    write_neighbors(args, results)
 }
 
 fn bgl_entry(binding: u32, ty: wgpu::BufferBindingType) -> wgpu::BindGroupLayoutEntry {

--- a/et/src/compute_neighbors/gpu.rs
+++ b/et/src/compute_neighbors/gpu.rs
@@ -6,7 +6,7 @@ use easy_tiger::{
     input::{DerefVectorStore, VectorStore},
 };
 use memmap2::Mmap;
-use vectors::VectorSimilarity;
+use vectors::{VectorSimilarity, f16};
 
 use crate::{neighbor_util::TopNeighbors, ui::progress_bar};
 
@@ -14,14 +14,18 @@ use super::{ComputeNeighborsArgs, write_neighbors};
 
 /// WGSL compute shader for pairwise distance computation.
 ///
-/// Each thread computes the distance between one (query, doc) pair. Three distance functions are
-/// supported, selected at runtime via the `similarity` uniform:
+/// Each thread computes the distance between one (query, doc) pair. Query and doc vectors are
+/// stored as f16 to match the input format, but every accumulation is carried out in f32 for
+/// precision. Three distance functions are supported, selected at runtime via the `similarity`
+/// uniform:
 ///   0 = Euclidean (squared L2)
 ///   1 = Dot product distance – assumes pre-normalized vectors: (-dot + 1) / 2
 ///   2 = Cosine distance – full cosine with per-pair normalization
 ///
 /// Output distances are written row-major as `distances[q * doc_count + d]`.
 const SHADER: &str = r#"
+enable f16;
+
 struct Params {
     query_count: u32,
     doc_count: u32,
@@ -32,8 +36,8 @@ struct Params {
 }
 
 @group(0) @binding(0) var<uniform> params: Params;
-@group(0) @binding(1) var<storage, read> query_vectors: array<f32>;
-@group(0) @binding(2) var<storage, read> doc_vectors: array<f32>;
+@group(0) @binding(1) var<storage, read> query_vectors: array<f16>;
+@group(0) @binding(2) var<storage, read> doc_vectors: array<f16>;
 @group(0) @binding(3) var<storage, read_write> distances: array<f32>;
 
 @compute @workgroup_size(16, 16, 1)
@@ -54,7 +58,7 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
             // Euclidean: squared L2 distance
             var acc: f32 = 0.0;
             for (var i: u32 = 0u; i < params.dimensions; i++) {
-                let diff = query_vectors[q_base + i] - doc_vectors[d_base + i];
+                let diff = f32(query_vectors[q_base + i]) - f32(doc_vectors[d_base + i]);
                 acc = fma(diff, diff, acc);
             }
             result = acc;
@@ -63,7 +67,7 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
             // Dot product distance (vectors assumed to be normalized): (-dot + 1) / 2
             var acc: f32 = 0.0;
             for (var i: u32 = 0u; i < params.dimensions; i++) {
-                acc = fma(query_vectors[q_base + i], doc_vectors[d_base + i], acc);
+                acc = fma(f32(query_vectors[q_base + i]), f32(doc_vectors[d_base + i]), acc);
             }
             result = (-acc + 1.0) / 2.0;
         }
@@ -73,8 +77,8 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
             var norm_q: f32 = 0.0;
             var norm_d: f32 = 0.0;
             for (var i: u32 = 0u; i < params.dimensions; i++) {
-                let qv = query_vectors[q_base + i];
-                let dv = doc_vectors[d_base + i];
+                let qv = f32(query_vectors[q_base + i]);
+                let dv = f32(doc_vectors[d_base + i]);
                 dot_qd = fma(qv, dv, dot_qd);
                 norm_q = fma(qv, qv, norm_q);
                 norm_d = fma(dv, dv, norm_d);
@@ -122,22 +126,37 @@ pub fn try_adapter() -> Option<wgpu::Adapter> {
     .ok()
 }
 
+/// Return true if `adapter` can run WGSL shaders that use the `f16` type, which this module
+/// requires since input vectors are stored as f16.
+pub fn supports_f16(adapter: &wgpu::Adapter) -> bool {
+    adapter.features().contains(wgpu::Features::SHADER_F16)
+}
+
 pub fn run(adapter: wgpu::Adapter, args: &ComputeNeighborsArgs) -> io::Result<()> {
-    let query_vectors: DerefVectorStore<f32, Mmap> =
-        DerefVectorStore::from_file_with_stride(&args.query_vectors, args.dimensions)?;
+    let query_vectors: DerefVectorStore<f16, Mmap> =
+        DerefVectorStore::from_file(&args.query_vectors)?;
     let query_limit = args
         .query_limit
         .unwrap_or(query_vectors.len())
         .min(query_vectors.len());
 
-    let doc_vectors: DerefVectorStore<f32, Mmap> =
-        DerefVectorStore::from_file_with_stride(&args.doc_vectors, args.dimensions)?;
+    let doc_vectors: DerefVectorStore<f16, Mmap> = DerefVectorStore::from_file(&args.doc_vectors)?;
     let doc_limit = args
         .doc_limit
         .unwrap_or(doc_vectors.len())
         .min(doc_vectors.len());
 
-    let dims = args.dimensions.get();
+    if query_vectors.elem_stride() != doc_vectors.elem_stride() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "query and doc vectors must have the same dimensionality ({} vs {})",
+                query_vectors.elem_stride(),
+                doc_vectors.elem_stride()
+            ),
+        ));
+    }
+    let dims = query_vectors.elem_stride();
     let k = args.neighbors_len.get();
 
     let similarity_code: u32 = match args.similarity {
@@ -154,7 +173,7 @@ pub fn run(adapter: wgpu::Adapter, args: &ComputeNeighborsArgs) -> io::Result<()
     let adapter_limits = adapter.limits();
     let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
         label: Some("compute_neighbors"),
-        required_features: wgpu::Features::empty(),
+        required_features: wgpu::Features::SHADER_F16,
         required_limits: wgpu::Limits {
             max_storage_buffer_binding_size: adapter_limits.max_storage_buffer_binding_size,
             max_buffer_size: adapter_limits.max_buffer_size,
@@ -168,20 +187,20 @@ pub fn run(adapter: wgpu::Adapter, args: &ComputeNeighborsArgs) -> io::Result<()
 
     // Compute batch sizes from the limits actually granted by the device. Three buffers are
     // constrained:
-    //   query buffer:    q_batch * dims * 4  <= max_buf_bytes
-    //   doc buffer:      d_batch * dims * 4  <= max_buf_bytes
+    //   query buffer:    q_batch * dims * 2  <= max_buf_bytes
+    //   doc buffer:      d_batch * dims * 2  <= max_buf_bytes
     //   distances buffer: q_batch * d_batch * 4 <= max_buf_bytes
     //
     // To maximise GPU utilisation we size batches symmetrically: q_batch ≈ d_batch ≈
     // sqrt(max_pairs) so the distances buffer fills the allowed budget. Both vector buffers
-    // are also checked against max_vecs = max_buf_bytes / (dims * 4).
+    // are also checked against max_vecs = max_buf_bytes / (dims * 2).
     let device_limits = device.limits();
     let max_buf_bytes = (device_limits.max_buffer_size as usize)
         .min(device_limits.max_storage_buffer_binding_size as usize);
     let (q_batch, d_batch) = if query_limit == 0 || doc_limit == 0 {
         (1, 1) // buffers are created but the processing loop won't execute
     } else {
-        let max_vecs = max_buf_bytes / (dims * std::mem::size_of::<f32>());
+        let max_vecs = max_buf_bytes / (dims * std::mem::size_of::<f16>());
         let max_pairs = max_buf_bytes / std::mem::size_of::<f32>();
         let sq = (max_pairs as f64).sqrt() as usize;
         let q = sq.min(max_vecs).min(query_limit).max(1);
@@ -228,16 +247,19 @@ pub fn run(adapter: wgpu::Adapter, args: &ComputeNeighborsArgs) -> io::Result<()
 
     // --- Buffers ---
 
-    // Query and doc buffers are refilled each batch; both need COPY_DST.
+    // Query and doc buffers are refilled each batch; both need COPY_DST. Sizes are rounded up to
+    // wgpu::COPY_BUFFER_ALIGNMENT (4 bytes) since f16 elements are only 2 bytes wide and
+    // write_buffer/copy_buffer_to_buffer require 4-byte aligned sizes; the batch loop below pads
+    // the write payload to match.
     let query_buffer = device.create_buffer(&wgpu::BufferDescriptor {
         label: Some("query_buffer"),
-        size: (q_batch * dims * std::mem::size_of::<f32>()) as u64,
+        size: round_up_copy_alignment(q_batch * dims * std::mem::size_of::<f16>()) as u64,
         usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
         mapped_at_creation: false,
     });
     let doc_buffer = device.create_buffer(&wgpu::BufferDescriptor {
         label: Some("doc_buffer"),
-        size: (d_batch * dims * std::mem::size_of::<f32>()) as u64,
+        size: round_up_copy_alignment(d_batch * dims * std::mem::size_of::<f16>()) as u64,
         usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
         mapped_at_creation: false,
     });
@@ -301,9 +323,10 @@ pub fn run(adapter: wgpu::Adapter, args: &ComputeNeighborsArgs) -> io::Result<()
         let q_end = (q_start + q_batch).min(query_limit);
         let current_q = q_end - q_start;
 
-        let query_data: Vec<f32> = (q_start..q_end)
+        let mut query_data: Vec<f16> = (q_start..q_end)
             .flat_map(|q| query_vectors[q].iter().copied())
             .collect();
+        pad_to_copy_alignment(&mut query_data);
         queue.write_buffer(&query_buffer, 0, bytemuck::cast_slice(&query_data));
 
         let mut d_start = 0usize;
@@ -311,9 +334,10 @@ pub fn run(adapter: wgpu::Adapter, args: &ComputeNeighborsArgs) -> io::Result<()
             let d_end = (d_start + d_batch).min(doc_limit);
             let current_d = d_end - d_start;
 
-            let doc_data: Vec<f32> = (d_start..d_end)
+            let mut doc_data: Vec<f16> = (d_start..d_end)
                 .flat_map(|d| doc_vectors[d].iter().copied())
                 .collect();
+            pad_to_copy_alignment(&mut doc_data);
             queue.write_buffer(&doc_buffer, 0, bytemuck::cast_slice(&doc_data));
 
             // Split this memory-sized batch into smaller dispatches so no single command buffer
@@ -425,6 +449,21 @@ pub fn run(adapter: wgpu::Adapter, args: &ComputeNeighborsArgs) -> io::Result<()
 
     // --- Write output ---
     write_neighbors(args, results)
+}
+
+/// Round `bytes` up to `wgpu::COPY_BUFFER_ALIGNMENT` (4 bytes), the minimum granularity for
+/// `write_buffer`/`copy_buffer_to_buffer` calls.
+fn round_up_copy_alignment(bytes: usize) -> usize {
+    bytes.div_ceil(wgpu::COPY_BUFFER_ALIGNMENT as usize) * wgpu::COPY_BUFFER_ALIGNMENT as usize
+}
+
+/// Pad `data` with trailing zero elements so its byte length is a multiple of
+/// `wgpu::COPY_BUFFER_ALIGNMENT`. The padding elements sit past the last index any dispatch
+/// reads (bounded by `params.query_count`/`params.doc_count`), so they never affect results.
+fn pad_to_copy_alignment(data: &mut Vec<f16>) {
+    let byte_len = data.len() * std::mem::size_of::<f16>();
+    let padded_elems = round_up_copy_alignment(byte_len) / std::mem::size_of::<f16>();
+    data.resize(padded_elems, f16::default());
 }
 
 fn bgl_entry(binding: u32, ty: wgpu::BufferBindingType) -> wgpu::BindGroupLayoutEntry {

--- a/et/src/compute_neighbors/mod.rs
+++ b/et/src/compute_neighbors/mod.rs
@@ -2,10 +2,17 @@ mod cpu;
 #[cfg(feature = "wgpu")]
 mod gpu;
 
-use std::{io, num::NonZero, path::PathBuf};
+use std::{
+    fs::File,
+    io::{self, BufWriter, Write},
+    num::NonZero,
+    path::PathBuf,
+};
 
 use clap::Args;
 use vectors::VectorSimilarity;
+
+use crate::neighbor_util::TopNeighbors;
 
 #[derive(Args)]
 pub struct ComputeNeighborsArgs {
@@ -31,8 +38,9 @@ pub struct ComputeNeighborsArgs {
 
     /// Path to neighbors file to write.
     ///
-    /// The output file will contain one row for each vector in query_vectors. Within each row
-    /// there will be neighbors_len entries of Neighbor, an (i64, f64) tuple.
+    /// The output file is written in BigANN format: a <count,neighbors_len> header followed by
+    /// one row for each vector in query_vectors, each row containing neighbors_len entries of
+    /// Neighbor, an (i64, f64) tuple.
     #[arg(short, long)]
     neighbors: PathBuf,
     /// Number of neighbors for each query in the neighbors file.
@@ -52,4 +60,19 @@ pub fn compute_neighbors(args: ComputeNeighborsArgs) -> io::Result<()> {
         return gpu::run(adapter, &args);
     }
     cpu::run(&args)
+}
+
+/// Write `results` (one entry per query) to `args.neighbors` in BigANN format: a
+/// `<count,neighbors_len>` header followed by up to `neighbors_len` [`Neighbor`] entries per row.
+fn write_neighbors(args: &ComputeNeighborsArgs, results: Vec<TopNeighbors>) -> io::Result<()> {
+    let k = args.neighbors_len.get();
+    let mut writer = BufWriter::new(File::create(&args.neighbors)?);
+    writer.write_all(&(results.len() as u32).to_le_bytes())?;
+    writer.write_all(&(k as u32).to_le_bytes())?;
+    for neighbors in results.into_iter().map(TopNeighbors::into_neighbors) {
+        for n in neighbors.into_iter().take(k) {
+            writer.write_all(&<[u8; 16]>::from(n))?;
+        }
+    }
+    Ok(())
 }

--- a/et/src/compute_neighbors/mod.rs
+++ b/et/src/compute_neighbors/mod.rs
@@ -16,22 +16,21 @@ use crate::neighbor_util::TopNeighbors;
 
 #[derive(Args)]
 pub struct ComputeNeighborsArgs {
-    /// Path to numpy formatted little-endian float vectors.
+    /// Path to f16 vectors in BigANN format: an 8 byte `<len,dim>` header followed by
+    /// little-endian f16 vector data.
     #[arg(long)]
     query_vectors: PathBuf,
     /// Maximum number of query vectors to process.
     #[arg(long)]
     query_limit: Option<usize>,
-    /// Path to numpy formatted little-endian float vectors.
+    /// Path to f16 vectors in BigANN format: an 8 byte `<len,dim>` header followed by
+    /// little-endian f16 vector data.
     #[arg(long)]
     doc_vectors: PathBuf,
     /// Maximum number of doc vectors to process.
     #[arg(long)]
     doc_limit: Option<usize>,
 
-    /// Number of dimensions for both query and doc vectors.
-    #[arg(short, long)]
-    dimensions: NonZero<usize>,
     /// Similarity function to use.
     #[arg(short, long)]
     similarity: VectorSimilarity,
@@ -57,7 +56,13 @@ pub fn compute_neighbors(args: ComputeNeighborsArgs) -> io::Result<()> {
     if let Some(adapter) = gpu::try_adapter()
         && !args.force_cpu
     {
-        return gpu::run(adapter, &args);
+        if gpu::supports_f16(&adapter) {
+            return gpu::run(adapter, &args);
+        }
+        tracing::warn!(
+            "GPU adapter {} does not support f16 shaders; falling back to CPU",
+            adapter.get_info().name
+        );
     }
     cpu::run(&args)
 }

--- a/et/src/recall.rs
+++ b/et/src/recall.rs
@@ -49,9 +49,6 @@ pub struct RecallArgs {
     /// This should include one row of length neighbors_len for each vector in the query set.
     #[arg(long)]
     neighbors: Option<PathBuf>,
-    /// Number of neighbors for each query in the neighbors file.
-    #[arg(long, default_value_t = NonZero::new(100).unwrap())]
-    neighbors_len: NonZero<usize>,
 }
 
 /// Computes the recall for a query from a golden file.
@@ -60,7 +57,7 @@ pub struct RecallComputer {
     metric: RecallMetric,
     similarity: VectorSimilarity,
     k: usize,
-    neighbors: DerefVectorStore<u8, Mmap>,
+    neighbors: DerefVectorStore<[u8; Self::NEIGHBOR_LEN], Mmap>,
 }
 
 impl RecallComputer {
@@ -68,14 +65,9 @@ impl RecallComputer {
 
     pub fn from_args(args: RecallArgs, similarity: VectorSimilarity) -> io::Result<Option<Self>> {
         if let Some((neighbors, k)) = args.neighbors.zip(args.recall_k) {
-            let elem_stride = Self::NEIGHBOR_LEN * args.neighbors_len.get();
-            let neighbors: DerefVectorStore<u8, Mmap> =
-                DerefVectorStore::<u8, _>::from_file_with_stride(
-                    neighbors,
-                    NonZero::new(elem_stride).unwrap(),
-                )?;
+            let neighbors = DerefVectorStore::<[u8; Self::NEIGHBOR_LEN], _>::from_file(neighbors)?;
 
-            if k.get() <= args.neighbors_len.get() {
+            if k.get() <= neighbors.elem_stride() {
                 Ok(Some(Self {
                     metric: args.recall_metric,
                     similarity,
@@ -140,8 +132,6 @@ impl RecallComputer {
     /// *Panics* if `query_index` is out of bounds in the golden file.
     pub fn compute_recall(&self, query_index: usize, query_results: &[Neighbor]) -> f64 {
         let expected = self.neighbors[query_index]
-            .as_chunks::<{ Self::NEIGHBOR_LEN }>()
-            .0
             .iter()
             .take(self.k)
             .map(|n| Neighbor::from(*n));

--- a/src/input.rs
+++ b/src/input.rs
@@ -89,22 +89,23 @@ where
         let header_parts = header.as_chunks::<4>().0;
         let len = u32::from_le_bytes(header_parts[0]) as usize;
         let dim = u32::from_le_bytes(header_parts[1]) as usize;
-        let stride = dim * std::mem::size_of::<E>();
-        if len * stride != vectors.len() {
+        let elem_width = std::mem::size_of::<E>();
+        let row_bytes = dim * elem_width;
+        if len * row_bytes != vectors.len() {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
-                format!("input vector data must have exactly {len} entries of {stride} length"),
+                format!("input vector data must have exactly {len} entries of {row_bytes} length"),
             ));
         }
 
         // Safety: StableDeref guarantees the pointer is stable even after a move.
         let raw_vectors: &'static [E] = unsafe {
-            std::slice::from_raw_parts(vectors.as_ptr() as *const E, vectors.len() / stride)
+            std::slice::from_raw_parts(vectors.as_ptr() as *const E, vectors.len() / elem_width)
         };
         Ok(Self {
             data,
             raw_vectors,
-            stride,
+            stride: dim,
             len,
         })
     }
@@ -303,5 +304,38 @@ impl<V: VectorStore> Index<usize> for SubsetViewVectorStore<'_, V> {
 
     fn index(&self, index: usize) -> &Self::Output {
         &self.parent[self.subset[index]]
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{DerefVectorStore, VectorStore};
+
+    /// Build a BigANN-formatted byte buffer: an 8 byte `<len,dim>` header followed by
+    /// `len * dim` little-endian `f32` values counting up from 0.0.
+    fn bigann_f32(len: usize, dim: usize) -> Vec<u8> {
+        let mut data = Vec::with_capacity(8 + len * dim * 4);
+        data.extend_from_slice(&(len as u32).to_le_bytes());
+        data.extend_from_slice(&(dim as u32).to_le_bytes());
+        for i in 0..(len * dim) {
+            data.extend_from_slice(&(i as f32).to_le_bytes());
+        }
+        data
+    }
+
+    #[test]
+    fn new_multi_dim_multi_byte_elem() {
+        let len = 5;
+        let dim = 4;
+        let data = bigann_f32(len, dim);
+        let store: DerefVectorStore<f32, Vec<u8>> = DerefVectorStore::new(data).unwrap();
+
+        assert_eq!(store.len(), len);
+        assert_eq!(store.elem_stride(), dim);
+        for i in 0..len {
+            let expected: Vec<f32> = (i * dim..(i + 1) * dim).map(|x| x as f32).collect();
+            assert_eq!(&store[i], expected.as_slice());
+        }
+        assert_eq!(store.iter().count(), len);
     }
 }


### PR DESCRIPTION
Use f16 inputs for query and doc and plumb this through to both cpu and gpu implementations. This may be faster by reducing the bandwidth bound on computing neighbors.

Modify handling of neighbors files to also use bigann format.

Fix a bug in DerefVectorStore bigann input stride computation.