### PR TITLE
Switch back to u32 neighbors

### DIFF
--- a/et/src/compute_neighbors/mod.rs
+++ b/et/src/compute_neighbors/mod.rs
@@ -38,8 +38,8 @@ pub struct ComputeNeighborsArgs {
     /// Path to neighbors file to write.
     ///
     /// The output file is written in BigANN format: a <count,neighbors_len> header followed by
-    /// one row for each vector in query_vectors, each row containing neighbors_len entries of
-    /// Neighbor, an (i64, f64) tuple.
+    /// one row for each vector in query_vectors, each row containing neighbors_len vertex ids as
+    /// little-endian u32.
     #[arg(short, long)]
     neighbors: PathBuf,
     /// Number of neighbors for each query in the neighbors file.
@@ -68,7 +68,8 @@ pub fn compute_neighbors(args: ComputeNeighborsArgs) -> io::Result<()> {
 }
 
 /// Write `results` (one entry per query) to `args.neighbors` in BigANN format: a
-/// `<count,neighbors_len>` header followed by up to `neighbors_len` [`Neighbor`] entries per row.
+/// `<count,neighbors_len>` header followed by up to `neighbors_len` little-endian `u32` vertex
+/// ids per row.
 fn write_neighbors(args: &ComputeNeighborsArgs, results: Vec<TopNeighbors>) -> io::Result<()> {
     let k = args.neighbors_len.get();
     let mut writer = BufWriter::new(File::create(&args.neighbors)?);
@@ -76,7 +77,7 @@ fn write_neighbors(args: &ComputeNeighborsArgs, results: Vec<TopNeighbors>) -> i
     writer.write_all(&(k as u32).to_le_bytes())?;
     for neighbors in results.into_iter().map(TopNeighbors::into_neighbors) {
         for n in neighbors.into_iter().take(k) {
-            writer.write_all(&<[u8; 16]>::from(n))?;
+            writer.write_all(&(n.vertex() as u32).to_le_bytes())?;
         }
     }
     Ok(())

--- a/et/src/data.rs
+++ b/et/src/data.rs
@@ -20,7 +20,8 @@ pub struct DataArgs {
 pub enum Command {
     /// Convert f32 vector data to f16 and write in BigANN format.
     ConvertF16(ConvertF16Args),
-    /// Add a BigANN header to a headerless neighbors (recall ground truth) file.
+    /// Convert a headerless (vertex, distance) neighbors (recall ground truth) file into a
+    /// BigANN-formatted file of vertex ids, dropping distances.
     ConvertNeighbors(ConvertNeighborsArgs),
     /// Read a BigANN header and print count, dimensionality, and entry width.
     Check(CheckArgs),

--- a/et/src/data/convert_neighbors.rs
+++ b/et/src/data/convert_neighbors.rs
@@ -1,13 +1,15 @@
 use std::{
     fs::File,
-    io::{self, BufReader, BufWriter, Write},
+    io::{self, BufReader, BufWriter, Read, Write},
     num::NonZero,
     path::PathBuf,
 };
 
 use clap::Args;
+use easy_tiger::Neighbor;
 
-/// Size in bytes of a single serialized `easy_tiger::Neighbor` (vertex: i64, distance: f64).
+/// Size in bytes of a single raw input neighbor entry: `easy_tiger::Neighbor` (vertex: i64,
+/// distance: f64).
 const NEIGHBOR_LEN: usize = 16;
 
 #[derive(Args)]
@@ -19,8 +21,8 @@ pub struct ConvertNeighborsArgs {
     /// Number of neighbor entries per query in the input file.
     #[arg(short = 'n', long, default_value_t = NonZero::new(100).unwrap())]
     neighbors_len: NonZero<usize>,
-    /// Output file to write in BigANN format (<count,dim> header followed by the input data
-    /// unchanged).
+    /// Output file to write in BigANN format: a <count,neighbors_len> header followed by each
+    /// entry's vertex id as a little-endian u32 (distance is dropped).
     #[arg(short, long)]
     output: PathBuf,
 }
@@ -42,7 +44,13 @@ pub fn convert_neighbors(args: ConvertNeighborsArgs) -> io::Result<()> {
     let mut out = BufWriter::new(File::create(&args.output)?);
     out.write_all(&(count as u32).to_le_bytes())?;
     out.write_all(&(args.neighbors_len.get() as u32).to_le_bytes())?;
-    io::copy(&mut input, &mut out)?;
+
+    let mut entry = [0u8; NEIGHBOR_LEN];
+    for _ in 0..(count * args.neighbors_len.get() as u64) {
+        input.read_exact(&mut entry)?;
+        let vertex = Neighbor::from(entry).vertex();
+        out.write_all(&(vertex as u32).to_le_bytes())?;
+    }
 
     Ok(())
 }

--- a/et/src/flat/search.rs
+++ b/et/src/flat/search.rs
@@ -52,7 +52,7 @@ pub fn search(connection: Arc<Connection>, index_name: &str, args: SearchArgs) -
         .unwrap_or(query_vectors.len())
         .min(query_vectors.len());
 
-    let recall_computer = RecallComputer::from_args(args.recall, config.similarity)?;
+    let recall_computer = RecallComputer::from_args(args.recall)?;
     if let Some(computer) = recall_computer.as_ref() {
         if computer.neighbors_len() < limit {
             return Err(io::Error::new(

--- a/et/src/quantization/recall.rs
+++ b/et/src/quantization/recall.rs
@@ -78,9 +78,10 @@ pub fn recall(
         .unwrap_or(query_vectors.len())
         .min(query_vectors.len());
 
-    let recall_computer = RecallComputer::from_args(args.recall)?.ok_or(
-        io::Error::new(io::ErrorKind::InvalidInput, "must provide recall args"),
-    )?;
+    let recall_computer = RecallComputer::from_args(args.recall)?.ok_or(io::Error::new(
+        io::ErrorKind::InvalidInput,
+        "must provide recall args",
+    ))?;
 
     let centers = match args.centers {
         0 => None,

--- a/et/src/quantization/recall.rs
+++ b/et/src/quantization/recall.rs
@@ -78,7 +78,7 @@ pub fn recall(
         .unwrap_or(query_vectors.len())
         .min(query_vectors.len());
 
-    let recall_computer = RecallComputer::from_args(args.recall, args.similarity)?.ok_or(
+    let recall_computer = RecallComputer::from_args(args.recall)?.ok_or(
         io::Error::new(io::ErrorKind::InvalidInput, "must provide recall args"),
     )?;
 

--- a/et/src/recall.rs
+++ b/et/src/recall.rs
@@ -1,9 +1,4 @@
-use std::{
-    collections::{HashMap, HashSet},
-    io,
-    num::NonZero,
-    path::PathBuf,
-};
+use std::{collections::HashSet, io, num::NonZero, path::PathBuf};
 
 use clap::{Args, ValueEnum};
 use easy_tiger::{
@@ -11,7 +6,6 @@ use easy_tiger::{
     input::{DerefVectorStore, VectorStore},
 };
 use memmap2::Mmap;
-use vectors::VectorSimilarity;
 
 /// Supported recall metrics.
 #[derive(Default, Debug, Copy, Clone, ValueEnum)]
@@ -20,12 +14,6 @@ pub enum RecallMetric {
     /// returns a match ratio in [0,1]. This metric does not consider rank or distance values.
     #[default]
     Simple,
-    /// Normalized Discounted Cumulative Gain recall. This metric takes into account ranks and
-    /// scores (~inverted distance) within each result set then normalizes into a [0,1] value.
-    ///
-    /// When computing DCG for the actual result set, distances are replaced with values from the
-    /// expected result set (or 0) to account for quantization error.
-    Ndcg,
     /// Estimates the depth into the actual result set required to recover the expected top-k
     /// results with full-fidelity reranking.
     ///
@@ -45,32 +33,27 @@ pub struct RecallArgs {
     /// Recall metric to compute.
     #[arg(long, value_enum, default_value_t = RecallMetric::Simple)]
     recall_metric: RecallMetric,
-    /// Path buf to formatted [`Neighbor`] vectors.
-    /// This should include one row of length neighbors_len for each vector in the query set.
+    /// Path buf to a golden neighbors file: one row of `neighbors_len` little-endian `u32` vertex
+    /// ids for each vector in the query set.
     #[arg(long)]
     neighbors: Option<PathBuf>,
 }
 
 /// Computes the recall for a query from a golden file.
-// TODO: add an option for NDGC recall computation.
 pub struct RecallComputer {
     metric: RecallMetric,
-    similarity: VectorSimilarity,
     k: usize,
-    neighbors: DerefVectorStore<[u8; Self::NEIGHBOR_LEN], Mmap>,
+    neighbors: DerefVectorStore<u32, Mmap>,
 }
 
 impl RecallComputer {
-    const NEIGHBOR_LEN: usize = 16;
-
-    pub fn from_args(args: RecallArgs, similarity: VectorSimilarity) -> io::Result<Option<Self>> {
+    pub fn from_args(args: RecallArgs) -> io::Result<Option<Self>> {
         if let Some((neighbors, k)) = args.neighbors.zip(args.recall_k) {
-            let neighbors = DerefVectorStore::<[u8; Self::NEIGHBOR_LEN], _>::from_file(neighbors)?;
+            let neighbors = DerefVectorStore::<u32, _>::from_file(neighbors)?;
 
             if k.get() <= neighbors.elem_stride() {
                 Ok(Some(Self {
                     metric: args.recall_metric,
-                    similarity,
                     k: k.get(),
                     neighbors,
                 }))
@@ -92,7 +75,6 @@ impl RecallComputer {
     pub fn label(&self) -> String {
         match self.metric {
             RecallMetric::Simple => format!("Recall@{}", self.k),
-            RecallMetric::Ndcg => format!("NDCG@{}", self.k),
             RecallMetric::Depth => format!("Depth@{}", self.k),
         }
     }
@@ -103,13 +85,13 @@ impl RecallComputer {
 
     /// Format a summary line for the per-query results in `values`.
     ///
-    /// For ratio metrics (Simple/Ndcg) this reports the mean. For [`RecallMetric::Depth`] it also
+    /// For [`RecallMetric::Simple`] this reports the mean. For [`RecallMetric::Depth`] it also
     /// reports the standard deviation and maximum depth across queries.
     pub fn summarize(&self, values: &[f64]) -> String {
         let n = values.len().max(1) as f64;
         let mean = values.iter().sum::<f64>() / n;
         match self.metric {
-            RecallMetric::Simple | RecallMetric::Ndcg => {
+            RecallMetric::Simple => {
                 format!("{}: {:.6}", self.label(), mean)
             }
             RecallMetric::Depth => {
@@ -134,11 +116,10 @@ impl RecallComputer {
         let expected = self.neighbors[query_index]
             .iter()
             .take(self.k)
-            .map(|n| Neighbor::from(*n));
+            .map(|v| *v as i64);
         let actual = query_results.iter().copied();
         match self.metric {
             RecallMetric::Simple => self.simple_recall(expected, actual),
-            RecallMetric::Ndcg => self.ndcg_recall(expected, actual),
             RecallMetric::Depth => Self::required_depth(expected, actual),
         }
     }
@@ -148,10 +129,10 @@ impl RecallComputer {
     /// Returns the 1-based position of the last expected vertex encountered while scanning `actual`
     /// in order. If any expected vertex is missing, returns the length of `actual`.
     fn required_depth(
-        expected: impl Iterator<Item = Neighbor>,
+        expected: impl Iterator<Item = i64>,
         actual: impl Iterator<Item = Neighbor>,
     ) -> f64 {
-        let mut expected = expected.map(|n| n.vertex()).collect::<HashSet<_>>();
+        let mut expected = expected.collect::<HashSet<_>>();
         let mut depth = 0usize;
         for (i, n) in actual.enumerate() {
             depth = i + 1;
@@ -165,45 +146,11 @@ impl RecallComputer {
 
     fn simple_recall(
         &self,
-        expected: impl Iterator<Item = Neighbor>,
+        expected: impl Iterator<Item = i64>,
         actual: impl Iterator<Item = Neighbor>,
     ) -> f64 {
-        let expected = expected.map(|n| n.vertex()).collect::<HashSet<_>>();
+        let expected = expected.collect::<HashSet<_>>();
         let count = actual.filter(|n| expected.contains(&n.vertex())).count();
         count as f64 / self.k as f64
-    }
-
-    fn ndcg_recall(
-        &self,
-        expected: impl Iterator<Item = Neighbor> + Clone,
-        actual: impl Iterator<Item = Neighbor> + Clone,
-    ) -> f64 {
-        let ideal_scores = expected
-            .clone()
-            .map(|n| (n.vertex(), self.distance_to_score(n.distance())))
-            .collect::<HashMap<_, _>>();
-        let idcg = Self::dcg(expected.map(|n| self.distance_to_score(n.distance())));
-        // Replace actual scores with ideal/expected scores, substituting zero when not found.
-        // Quantization error may yield scores that are higher than the actual scores and may result
-        // in a misleading recall figure (> 1.0).
-        let dcg = Self::dcg(actual.map(|n| *ideal_scores.get(&n.vertex()).unwrap_or(&0.0)));
-        dcg / idcg
-    }
-
-    fn dcg(scores: impl Iterator<Item = f64>) -> f64 {
-        scores
-            .enumerate()
-            .map(|(i, s)| s / (i as f64 + 2.0).log2())
-            .sum()
-    }
-
-    fn distance_to_score(&self, distance: f64) -> f64 {
-        match self.similarity {
-            // Map distance to score the same way as Lucene. This normalizes perfect match to 0 but
-            // otherwise creates a pretty strange looking curve.
-            VectorSimilarity::Euclidean => 1.0 / (1.0 + distance.max(0.0)),
-            // Angular distances are already in [0,1] so take the additive inverse
-            VectorSimilarity::Cosine | VectorSimilarity::Dot => (1.0 - distance).clamp(0.0, 1.0),
-        }
     }
 }

--- a/et/src/spann/search.rs
+++ b/et/src/spann/search.rs
@@ -109,8 +109,7 @@ pub fn search(connection: Arc<Connection>, index_name: &str, args: SearchArgs) -
             .posting_rerank_budget
             .unwrap_or(args.posting_candidates.get()),
     };
-    let recall_computer =
-        RecallComputer::from_args(args.recall, index.head_config().config().similarity)?;
+    let recall_computer = RecallComputer::from_args(args.recall)?;
     if let Some(computer) = recall_computer.as_ref() {
         if computer.neighbors_len() < limit {
             return Err(io::Error::new(

--- a/et/src/vamana/search.rs
+++ b/et/src/vamana/search.rs
@@ -85,7 +85,7 @@ pub fn search(connection: Arc<Connection>, index_name: &str, args: SearchArgs) -
         num_rerank: args.rerank_budget.unwrap_or_else(|| args.candidates.get()),
         patience,
     };
-    let recall_computer = RecallComputer::from_args(args.recall, index.config().similarity)?;
+    let recall_computer = RecallComputer::from_args(args.recall)?;
     if let Some(computer) = recall_computer.as_ref() {
         if computer.neighbors_len() != query_vectors.len() {
             return Err(io::Error::new(


### PR DESCRIPTION
The existing neighbors format uses wide identifiers and includes distances for NDCG. I never use NDCG and need to save some space so remove NDCG and write new outputs as u32 sequences.