### PR TITLE
Use f16 input to Vamana

### DIFF
--- a/et/src/spann/bulk_load.rs
+++ b/et/src/spann/bulk_load.rs
@@ -2,7 +2,7 @@ use std::{io, num::NonZero, path::PathBuf, sync::Arc, time::Duration};
 
 use clap::Args;
 use easy_tiger::{
-    input::{DerefVectorStore, SubsetViewVectorStore, VectorStore},
+    input::{DerefVectorStore, SubsetViewVectorStore, VecVectorStore, VectorStore},
     kmeans::{HierarchicalKMeansParams, Params, hierarchical_kmeans},
     spann::{
         IndexConfig, TableIndex,
@@ -18,7 +18,7 @@ use easy_tiger::{
     },
 };
 use rand_xoshiro::{Xoshiro128PlusPlus, rand_core::SeedableRng};
-use vectors::{F32VectorCoding, VectorSimilarity};
+use vectors::{F32VectorCoding, VectorSimilarity, f16};
 use wt_mdb::{Connection, connection::DropOptionsBuilder};
 
 use crate::{
@@ -216,12 +216,19 @@ pub fn bulk_load(
         )
     };
     let centroids_len = centroids.len();
+    let centroids_f16 = {
+        let mut store = VecVectorStore::with_capacity(centroids.elem_stride(), centroids.len());
+        for v in centroids.iter() {
+            store.push(&v.iter().map(|x| f16::from_f32(*x)).collect::<Vec<f16>>());
+        }
+        store
+    };
 
     {
         let mut head_loader = BulkLoadBuilder::new(
             connection.clone(),
             Arc::unwrap_or_clone(index.head_config().clone()),
-            centroids,
+            centroids_f16,
             bulk::Options {
                 memory_quantized_vectors: false,
             },

--- a/et/src/vamana/bulk_load.rs
+++ b/et/src/vamana/bulk_load.rs
@@ -9,7 +9,7 @@ use easy_tiger::{
         wt::TableGraphVectorIndex,
     },
 };
-use vectors::{F32VectorCoding, VectorSimilarity};
+use vectors::{F32VectorCoding, VectorSimilarity, f16};
 use wt_mdb::Connection;
 
 use crate::{
@@ -20,12 +20,10 @@ use crate::{
 
 #[derive(Args)]
 pub struct BulkLoadArgs {
-    /// Path to the input vectors to bulk ingest.
+    /// Path to f16 vectors to bulk ingest, in BigANN format: an 8 byte `<len,dim>` header
+    /// followed by little-endian f16 vector data.
     #[arg(short, long)]
-    f32_vectors: PathBuf,
-    /// Number of dimensions in input vectors.
-    #[arg(short, long)]
-    dimensions: NonZero<usize>,
+    vectors: PathBuf,
     /// Similarity function to use for vector scoring.
     #[arg(long)]
     similarity: VectorSimilarity,
@@ -91,17 +89,22 @@ pub fn bulk_load(
     index_name: &str,
     args: BulkLoadArgs,
 ) -> io::Result<()> {
-    let f32_vectors = DerefVectorStore::from_file_with_stride(args.f32_vectors, args.dimensions)?;
+    let vectors: DerefVectorStore<f16, _> = DerefVectorStore::from_file(args.vectors)?;
+    let dimensions = NonZero::new(vectors.elem_stride()).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "input vectors have no dimensions",
+        )
+    })?;
 
-    let num_vectors = f32_vectors.len();
+    let num_vectors = vectors.len();
     let limit = args.limit.unwrap_or(num_vectors);
 
     let centroid = if args.center {
-        let dims = args.dimensions.get();
-        let mut sum = vec![0.0f64; dims];
-        for v in f32_vectors.iter().take(limit) {
+        let mut sum = vec![0.0f64; dimensions.get()];
+        for v in vectors.iter().take(limit) {
             for (s, x) in sum.iter_mut().zip(v.iter()) {
-                *s += *x as f64;
+                *s += x.to_f64();
             }
         }
         let n = limit as f64;
@@ -111,7 +114,7 @@ pub fn bulk_load(
     };
 
     let config = GraphConfig {
-        dimensions: args.dimensions,
+        dimensions,
         similarity: args.similarity,
         nav_format: args.nav_format,
         rerank_format: args.rerank_format,
@@ -138,7 +141,7 @@ pub fn bulk_load(
     let mut builder = BulkLoadBuilder::new(
         connection.clone(),
         index,
-        f32_vectors,
+        vectors,
         Options {
             memory_quantized_vectors: args.memory_quantized_vectors,
         },

--- a/et/src/vamana/search.rs
+++ b/et/src/vamana/search.rs
@@ -16,6 +16,7 @@ use easy_tiger::{
         wt::{TableGraphVectorIndex, TransactionGraphVectorIndex},
     },
 };
+use vectors::f16;
 use wt_mdb::Connection;
 
 use crate::{
@@ -26,7 +27,8 @@ use crate::{
 
 #[derive(Args)]
 pub struct SearchArgs {
-    /// Path to numpy formatted little-endian float vectors.
+    /// Path to f16 query vectors in BigANN format: an 8 byte `<len,dim>` header followed by
+    /// little-endian f16 vector data.
     #[arg(short, long)]
     query_vectors: PathBuf,
     /// Number candidates in the search list.
@@ -67,10 +69,17 @@ pub struct SearchArgs {
 
 pub fn search(connection: Arc<Connection>, index_name: &str, args: SearchArgs) -> io::Result<()> {
     let index = Arc::new(TableGraphVectorIndex::from_db(&connection, index_name)?);
-    let query_vectors = easy_tiger::input::DerefVectorStore::from_file_with_stride(
-        args.query_vectors,
-        index.config().dimensions,
-    )?;
+    let query_vectors: DerefVectorStore<f16, _> = DerefVectorStore::from_file(args.query_vectors)?;
+    if query_vectors.elem_stride() != index.config().dimensions.get() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "query vectors have {} dimensions but index expects {}",
+                query_vectors.elem_stride(),
+                index.config().dimensions.get()
+            ),
+        ));
+    }
     let limit = std::cmp::min(
         query_vectors.len(),
         args.limit.unwrap_or(query_vectors.len()),
@@ -87,7 +96,7 @@ pub fn search(connection: Arc<Connection>, index_name: &str, args: SearchArgs) -
     };
     let recall_computer = RecallComputer::from_args(args.recall)?;
     if let Some(computer) = recall_computer.as_ref() {
-        if computer.neighbors_len() != query_vectors.len() {
+        if computer.neighbors_len() < limit {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!(
@@ -161,7 +170,7 @@ fn search_phase<Q: Send + Sync>(
     iters: usize,
     limit: usize,
     record_limit: i64,
-    query_vectors: &DerefVectorStore<f32, Q>,
+    query_vectors: &DerefVectorStore<f16, Q>,
     index: &Arc<TableGraphVectorIndex>,
     connection: &Arc<Connection>,
     search_params: GraphSearchParams,
@@ -211,6 +220,7 @@ struct SearcherState {
     connection: Arc<Connection>,
     index: Arc<TableGraphVectorIndex>,
     searcher: GraphSearcher,
+    query_buf: Vec<f32>,
 }
 
 impl SearcherState {
@@ -223,13 +233,14 @@ impl SearcherState {
             connection: Arc::clone(connection),
             index: Arc::clone(index),
             searcher: GraphSearcher::new(search_params),
+            query_buf: vec![0.0f32; index.config().dimensions.get()],
         })
     }
 
     fn query(
         &mut self,
         index: usize,
-        query: &[f32],
+        query: &[f16],
         record_limit: i64,
         recall_computer: Option<&RecallComputer>,
     ) -> io::Result<AggregateSearchStats> {
@@ -237,9 +248,12 @@ impl SearcherState {
             Arc::clone(&self.index),
             self.connection.begin_transaction(None)?,
         );
+        for (o, x) in self.query_buf.iter_mut().zip(query.iter()) {
+            *o = x.to_f32();
+        }
         let start = Instant::now();
         let results = self.searcher.search_with_options(
-            query,
+            &self.query_buf,
             GraphSearchOptions::with_filter(|i| i < record_limit),
             &reader,
         )?;

--- a/src/vamana/bulk.rs
+++ b/src/vamana/bulk.rs
@@ -6,7 +6,7 @@
 //! around vector access and graph edge state.
 //!
 //! Caveats:
-//! * Only `numpy` little-endian formatted `f32` vectors are accepted.
+//! * Only `f16` vectors are accepted as input.
 //! * Row keys are assigned densely beginning at zero.
 use core::f64;
 use std::{
@@ -25,7 +25,7 @@ use rayon::prelude::*;
 use rustix::io::Errno;
 use thread_local::ThreadLocal;
 use tracing::warn;
-use vectors::{F32VectorCoding, VectorSimilarity};
+use vectors::{F32VectorCoding, VectorSimilarity, f16};
 use wt_mdb::{Connection, Error, Result, Transaction, connection::CreateOptionsBuilder};
 
 use crate::{
@@ -104,7 +104,7 @@ pub struct BulkLoadBuilder<D> {
 
 impl<D> BulkLoadBuilder<D>
 where
-    D: VectorStore<Elem = f32> + Send + Sync,
+    D: VectorStore<Elem = f16> + Send + Sync,
 {
     /// Create a new bulk graph builder with the passed vector set and configuration.
     /// `limit` limits the number of vectors processed to less than the full set.
@@ -179,6 +179,7 @@ where
         let nav_coder = self.index.nav_table().new_coder();
         let mut nav_vector = vec![0u8; nav_coder.byte_len(dim)];
         let mut sum = vec![0.0; dim];
+        let mut vector_f32 = vec![0.0f32; dim];
         let mut quantized_vectors = if self.options.memory_quantized_vectors {
             Some(MmapMut::map_anon(nav_coder.byte_len(dim) * self.vectors.len()).unwrap())
         } else {
@@ -200,10 +201,13 @@ where
         };
 
         for (i, v) in self.vectors.iter().enumerate().take(self.limit) {
-            for (i, o) in v.iter().zip(sum.iter_mut()) {
+            for (o, x) in vector_f32.iter_mut().zip(v.iter()) {
+                *o = x.to_f32();
+            }
+            for (i, o) in vector_f32.iter().zip(sum.iter_mut()) {
                 *o += *i as f64;
             }
-            nav_coder.encode_to(v, &mut nav_vector);
+            nav_coder.encode_to(&vector_f32, &mut nav_vector);
             if let Some(q) = quantized_vectors.as_mut() {
                 let start = i * nav_vector.len();
                 q[start..(start + nav_vector.len())].copy_from_slice(&nav_vector);
@@ -211,7 +215,7 @@ where
             nav_cursor.append(i as i64, &nav_vector)?;
 
             if let Some((coder, vector, cursor)) = rerank.as_mut() {
-                coder.encode_to(v, vector);
+                coder.encode_to(&vector_f32, vector);
                 cursor.append(i as i64, vector)?;
             }
             progress(1);
@@ -671,7 +675,7 @@ where
 
 struct BulkLoadGraphVectorIndexReader<'a, 'b, D: Send>(&'a BulkLoadBuilder<D>, &'b Transaction);
 
-impl<D: VectorStore<Elem = f32> + Send + Sync> GraphVectorIndex
+impl<D: VectorStore<Elem = f16> + Send + Sync> GraphVectorIndex
     for BulkLoadGraphVectorIndexReader<'_, '_, D>
 {
     type Graph<'b>

--- a/src/vamana/bulk.rs
+++ b/src/vamana/bulk.rs
@@ -201,11 +201,9 @@ where
         };
 
         for (i, v) in self.vectors.iter().enumerate().take(self.limit) {
-            for (o, x) in vector_f32.iter_mut().zip(v.iter()) {
-                *o = x.to_f32();
-            }
-            for (i, o) in vector_f32.iter().zip(sum.iter_mut()) {
-                *o += *i as f64;
+            for (&i, (o, s)) in v.iter().zip(vector_f32.iter_mut().zip(sum.iter_mut())) {
+                *o = i.to_f32();
+                *s += i.to_f64();
             }
             nav_coder.encode_to(&vector_f32, &mut nav_vector);
             if let Some(q) = quantized_vectors.as_mut() {


### PR DESCRIPTION
Bulk load and searches use bigann formatted f16 vectors. This simplifies interfaces and speeds things up by reading half as much data.